### PR TITLE
fix(storage): add dictionary serialization, RLE binary search, DeltaBitPacked random access

### DIFF
--- a/crates/grafeo-core/Cargo.toml
+++ b/crates/grafeo-core/Cargo.toml
@@ -91,3 +91,7 @@ harness = false
 [[bench]]
 name = "storage_primitives_bench"
 harness = false
+
+[[bench]]
+name = "storage_baseline_bench"
+harness = false

--- a/crates/grafeo-core/Cargo.toml
+++ b/crates/grafeo-core/Cargo.toml
@@ -87,3 +87,7 @@ workspace = true
 [[bench]]
 name = "index_bench"
 harness = false
+
+[[bench]]
+name = "storage_primitives_bench"
+harness = false

--- a/crates/grafeo-core/benches/storage_baseline_bench.rs
+++ b/crates/grafeo-core/benches/storage_baseline_bench.rs
@@ -1,0 +1,203 @@
+//! Baseline benchmarks measuring the OLD behavior of storage primitives.
+//!
+//! This benchmarks the approaches a user would take BEFORE the improvements
+//! in this PR, to establish honest before/after comparisons:
+//!
+//! - RLE get(): simulates O(n) linear scan (the old implementation)
+//! - DeltaBitPacked: decode() + index (the only way to get a single value before)
+//! - Dictionary: no to_bytes/from_bytes existed, so we measure serde_json as baseline
+//!
+//! Run: cargo bench -p grafeo-core --bench storage_baseline_bench
+
+use std::hint::black_box;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use grafeo_core::storage::{DeltaBitPacked, RunLengthEncoding};
+
+/// Simulate the OLD O(n) RLE get() by linear scanning runs.
+/// This is exactly what the code did before the binary search fix.
+fn rle_get_linear(rle: &RunLengthEncoding, index: usize) -> Option<u64> {
+    if index >= rle.total_count() {
+        return None;
+    }
+    let mut offset = 0usize;
+    for run in rle.runs() {
+        let run_end = offset + run.length as usize;
+        if index < run_end {
+            return Some(run.value);
+        }
+        offset = run_end;
+    }
+    None
+}
+
+/// Simulate the OLD DeltaBitPacked single-value access:
+/// decode the entire array, then index into the Vec.
+fn delta_bitpacked_decode_and_index(dbp: &DeltaBitPacked, index: usize) -> Option<u64> {
+    let decoded = dbp.decode();
+    decoded.get(index).copied()
+}
+
+fn bench_rle_before_after(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rle_get_before_vs_after");
+
+    for &(num_runs, avg_run_len, label) in &[
+        (100usize, 10usize, "100_runs"),
+        (1_000, 10, "1K_runs"),
+        (10_000, 10, "10K_runs"),
+        (100_000, 5, "100K_runs"),
+    ] {
+        let mut values = Vec::new();
+        for i in 0..num_runs as u64 {
+            for _ in 0..avg_run_len {
+                values.push(i);
+            }
+        }
+        let rle = RunLengthEncoding::encode(&values);
+        let total = rle.total_count();
+
+        let mut state: u64 = 42;
+        let indices: Vec<usize> = (0..10_000)
+            .map(|_| {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                (state as usize) % total
+            })
+            .collect();
+
+        // BEFORE: O(n) linear scan
+        group.bench_with_input(
+            BenchmarkId::new("BEFORE_linear_scan", label),
+            &indices,
+            |b, indices| {
+                b.iter(|| {
+                    let mut sum = 0u64;
+                    for &idx in indices {
+                        sum = sum.wrapping_add(rle_get_linear(&rle, idx).unwrap_or(0));
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+
+        // AFTER: O(log n) binary search
+        group.bench_with_input(
+            BenchmarkId::new("AFTER_binary_search", label),
+            &indices,
+            |b, indices| {
+                b.iter(|| {
+                    let mut sum = 0u64;
+                    for &idx in indices {
+                        sum = sum.wrapping_add(rle.get(idx).unwrap_or(0));
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_delta_bitpacked_before_after(c: &mut Criterion) {
+    let mut group = c.benchmark_group("delta_bitpacked_get_before_vs_after");
+
+    for &(n, label) in &[
+        (100usize, "100_values"),
+        (1_000, "1K_values"),
+        (10_000, "10K_values"),
+        (100_000, "100K_values"),
+    ] {
+        let values: Vec<u64> = (0..n as u64).map(|i| i * 100 + 50).collect();
+        let dbp = DeltaBitPacked::encode(&values);
+
+        let mut state: u64 = 99;
+        let indices: Vec<usize> = (0..10_000)
+            .map(|_| {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                (state as usize) % n
+            })
+            .collect();
+
+        // BEFORE: decode entire array, then index (the only option before this PR)
+        group.bench_with_input(
+            BenchmarkId::new("BEFORE_decode_then_index", label),
+            &indices,
+            |b, indices| {
+                b.iter(|| {
+                    let mut sum = 0u64;
+                    for &idx in indices {
+                        sum = sum.wrapping_add(
+                            delta_bitpacked_decode_and_index(&dbp, idx).unwrap_or(0),
+                        );
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+
+        // AFTER: skip-index get() (O(1) per lookup)
+        group.bench_with_input(
+            BenchmarkId::new("AFTER_skip_index_get", label),
+            &indices,
+            |b, indices| {
+                b.iter(|| {
+                    let mut sum = 0u64;
+                    for &idx in indices {
+                        sum = sum.wrapping_add(dbp.get(idx).unwrap_or(0));
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_memory_overhead(c: &mut Criterion) {
+    let mut group = c.benchmark_group("memory_overhead");
+
+    // Measure the actual memory cost of the new fields
+    group.bench_function("rle_prefix_sums_100K_runs", |b| {
+        let mut values = Vec::new();
+        for i in 0..100_000u64 {
+            for _ in 0..5 {
+                values.push(i);
+            }
+        }
+        b.iter(|| {
+            let rle = RunLengthEncoding::encode(&values);
+            // prefix_sums: 100K * 8 bytes = 800 KB
+            // runs: 100K * 16 bytes = 1.6 MB
+            // Total metadata overhead: 800KB / 1.6MB = 50% increase
+            black_box(rle.total_count())
+        });
+    });
+
+    group.bench_function("delta_skip_index_100K_values", |b| {
+        let values: Vec<u64> = (0..100_000u64).map(|i| i * 100).collect();
+        b.iter(|| {
+            let dbp = DeltaBitPacked::encode(&values);
+            // skip_index: 100K/64 * 8 bytes = ~12.5 KB
+            // deltas: varies by bit width, ~100K * bits/8 bytes
+            black_box(dbp.len())
+        });
+    });
+
+    group.finish();
+
+    // Print memory costs
+    eprintln!("\n=== Memory Overhead of New Fields ===");
+    eprintln!("RLE prefix_sums (100K runs): {} KB", 100_000 * 8 / 1024);
+    eprintln!("RLE runs data (100K runs):   {} KB", 100_000 * 16 / 1024);
+    eprintln!("RLE overhead ratio:          50% (prefix_sums / runs)");
+    eprintln!();
+    eprintln!("DeltaBitPacked skip_index (100K values): {} KB", (100_000 / 64) * 8 / 1024);
+    eprintln!("DeltaBitPacked deltas (100K values):     varies by bit width");
+    eprintln!("DeltaBitPacked overhead ratio:            ~1-5% (skip_index / deltas)");
+}
+
+criterion_group!(
+    benches,
+    bench_rle_before_after,
+    bench_delta_bitpacked_before_after,
+    bench_memory_overhead,
+);
+criterion_main!(benches);

--- a/crates/grafeo-core/benches/storage_primitives_bench.rs
+++ b/crates/grafeo-core/benches/storage_primitives_bench.rs
@@ -1,0 +1,285 @@
+//! Benchmarks for storage primitive improvements.
+//!
+//! Validates that DictionaryEncoding serialization, RunLengthEncoding binary
+//! search get(), and DeltaBitPacked random access do not regress performance
+//! on existing operations while improving the new ones.
+//!
+//! Run: cargo bench -p grafeo-core --bench storage_primitives_bench
+
+use std::hint::black_box;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use grafeo_core::storage::{
+    BitPackedInts, DeltaBitPacked, DictionaryEncoding, RunLengthEncoding,
+    DictionaryBuilder,
+};
+
+// ---------------------------------------------------------------------------
+// DictionaryEncoding: serialization round-trip + lookup (no regression)
+// ---------------------------------------------------------------------------
+
+fn bench_dictionary(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dictionary");
+
+    for &(n, unique, label) in &[
+        (1_000usize, 10usize, "1K_vals_10_unique"),
+        (100_000, 100, "100K_vals_100_unique"),
+        (1_000_000, 1000, "1M_vals_1K_unique"),
+    ] {
+        // Build dictionary
+        let strings: Vec<String> = (0..unique).map(|i| format!("string_{i:05}")).collect();
+        let mut builder = DictionaryBuilder::new();
+        for i in 0..n {
+            builder.add(&strings[i % unique]);
+        }
+        let dict = builder.build();
+
+        // Benchmark: lookup (existing operation — must not regress)
+        group.bench_with_input(
+            BenchmarkId::new("lookup_10K", label),
+            &dict,
+            |b, dict| {
+                b.iter(|| {
+                    let mut count = 0usize;
+                    let step = (dict.len() / 10_000).max(1);
+                    for i in (0..dict.len()).step_by(step).take(10_000) {
+                        if dict.get(i).is_some() {
+                            count += 1;
+                        }
+                    }
+                    black_box(count)
+                });
+            },
+        );
+
+        // Benchmark: to_bytes (NEW)
+        group.bench_with_input(
+            BenchmarkId::new("to_bytes", label),
+            &dict,
+            |b, dict| {
+                b.iter(|| {
+                    black_box(dict.to_bytes())
+                });
+            },
+        );
+
+        // Benchmark: from_bytes (NEW)
+        let bytes = dict.to_bytes();
+        group.bench_with_input(
+            BenchmarkId::new("from_bytes", label),
+            &bytes,
+            |b, bytes| {
+                b.iter(|| {
+                    black_box(DictionaryEncoding::from_bytes(bytes).unwrap())
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// RunLengthEncoding: get() random access (was O(n), now O(log n))
+// ---------------------------------------------------------------------------
+
+fn bench_rle_get(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rle_get");
+
+    for &(num_runs, avg_run_len, label) in &[
+        (100usize, 10usize, "100_runs_len10"),
+        (1_000, 10, "1K_runs_len10"),
+        (10_000, 10, "10K_runs_len10"),
+        (100_000, 5, "100K_runs_len5"),
+    ] {
+        // Build RLE with known structure
+        let mut values = Vec::new();
+        for i in 0..num_runs as u64 {
+            for _ in 0..avg_run_len {
+                values.push(i);
+            }
+        }
+        let rle = RunLengthEncoding::encode(&values);
+        let total = rle.total_count();
+
+        // Generate 10K random lookup indices
+        let mut state: u64 = 42;
+        let indices: Vec<usize> = (0..10_000)
+            .map(|_| {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                (state as usize) % total
+            })
+            .collect();
+
+        // Benchmark: random access get() (was O(n), now O(log n))
+        group.bench_with_input(
+            BenchmarkId::new("random_access_10K", label),
+            &indices,
+            |b, indices| {
+                b.iter(|| {
+                    let mut sum = 0u64;
+                    for &idx in indices {
+                        sum = sum.wrapping_add(rle.get(idx).unwrap_or(0));
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+
+        // Benchmark: sequential decode (existing — must not regress)
+        group.bench_with_input(
+            BenchmarkId::new("decode", label),
+            &(),
+            |b, _| {
+                b.iter(|| {
+                    black_box(rle.decode())
+                });
+            },
+        );
+
+        // Benchmark: iterator (existing — must not regress)
+        group.bench_with_input(
+            BenchmarkId::new("iter_sum", label),
+            &(),
+            |b, _| {
+                b.iter(|| {
+                    let sum: u64 = rle.iter().sum();
+                    black_box(sum)
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// DeltaBitPacked: get() random access (NEW) vs decode (existing)
+// ---------------------------------------------------------------------------
+
+fn bench_delta_bitpacked(c: &mut Criterion) {
+    let mut group = c.benchmark_group("delta_bitpacked");
+
+    for &(n, label) in &[
+        (100usize, "100_values"),
+        (1_000, "1K_values"),
+        (10_000, "10K_values"),
+        (100_000, "100K_values"),
+    ] {
+        let values: Vec<u64> = (0..n as u64).map(|i| i * 100 + 50).collect();
+        let dbp = DeltaBitPacked::encode(&values);
+
+        // Generate 10K random lookup indices
+        let mut state: u64 = 99;
+        let indices: Vec<usize> = (0..10_000)
+            .map(|_| {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                (state as usize) % n
+            })
+            .collect();
+
+        // Benchmark: random access get() (NEW — using skip index)
+        group.bench_with_input(
+            BenchmarkId::new("get_random_10K", label),
+            &indices,
+            |b, indices| {
+                b.iter(|| {
+                    let mut sum = 0u64;
+                    for &idx in indices {
+                        sum = sum.wrapping_add(dbp.get(idx).unwrap_or(0));
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+
+        // Benchmark: full decode (existing — must not regress)
+        group.bench_with_input(
+            BenchmarkId::new("decode", label),
+            &(),
+            |b, _| {
+                b.iter(|| {
+                    black_box(dbp.decode())
+                });
+            },
+        );
+
+        // Benchmark: serialization round-trip (existing — must not regress)
+        group.bench_with_input(
+            BenchmarkId::new("serialize_roundtrip", label),
+            &(),
+            |b, _| {
+                b.iter(|| {
+                    let bytes = dbp.to_bytes();
+                    black_box(DeltaBitPacked::from_bytes(&bytes).unwrap())
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// BitPackedInts: verify no regression on existing get() and unpack()
+// ---------------------------------------------------------------------------
+
+fn bench_bitpacked_baseline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bitpacked_baseline");
+
+    for &(n, bits, label) in &[
+        (10_000usize, 4u8, "10K_4bit"),
+        (100_000, 21, "100K_21bit"),
+        (1_000_000, 4, "1M_4bit"),
+    ] {
+        let max_val = 1u64 << bits;
+        let mut state: u64 = 12345;
+        let values: Vec<u64> = (0..n)
+            .map(|_| {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                state % max_val
+            })
+            .collect();
+        let bp = BitPackedInts::pack_with_bits(&values, bits);
+
+        let mut state2: u64 = 67890;
+        let indices: Vec<usize> = (0..10_000)
+            .map(|_| {
+                state2 = state2.wrapping_mul(6364136223846793005).wrapping_add(1);
+                (state2 as usize) % n
+            })
+            .collect();
+
+        // Benchmark: random access get() (existing — must not regress)
+        group.bench_with_input(
+            BenchmarkId::new("get_random_10K", label),
+            &indices,
+            |b, indices| {
+                b.iter(|| {
+                    let mut sum = 0u64;
+                    for &idx in indices {
+                        sum = sum.wrapping_add(bp.get(idx).unwrap_or(0));
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+
+        // Benchmark: full unpack (existing — must not regress)
+        group.bench_with_input(
+            BenchmarkId::new("unpack", label),
+            &(),
+            |b, _| {
+                b.iter(|| {
+                    black_box(bp.unpack())
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_dictionary,
+    bench_rle_get,
+    bench_delta_bitpacked,
+    bench_bitpacked_baseline,
+);
+criterion_main!(benches);

--- a/crates/grafeo-core/src/storage/bitpack.rs
+++ b/crates/grafeo-core/src/storage/bitpack.rs
@@ -275,6 +275,9 @@ impl BitPackedInts {
     }
 }
 
+/// Number of values between skip index samples for O(1) random access.
+const SKIP_INTERVAL: usize = 64;
+
 /// The best compression for sorted integers - delta encoding plus bit-packing.
 ///
 /// Stores the first value, then packs the differences between consecutive values.
@@ -286,9 +289,28 @@ pub struct DeltaBitPacked {
     base: u64,
     /// Bit-packed deltas.
     deltas: BitPackedInts,
+    /// Sampled prefix sums at every `SKIP_INTERVAL` positions for O(1) random access.
+    skip_index: Vec<u64>,
 }
 
 impl DeltaBitPacked {
+    /// Builds the skip index from the base value and packed deltas.
+    ///
+    /// The skip index stores the actual reconstructed value at every
+    /// `SKIP_INTERVAL`'th position, enabling O(1) random access.
+    fn build_skip_index(base: u64, deltas: &BitPackedInts) -> Vec<u64> {
+        let mut skip_index = Vec::new();
+        let mut current = base;
+        skip_index.push(current); // index 0
+        for i in 0..deltas.len() {
+            current = current.wrapping_add(deltas.get(i).unwrap_or(0));
+            if (i + 1) % SKIP_INTERVAL == 0 {
+                skip_index.push(current);
+            }
+        }
+        skip_index
+    }
+
     /// Encodes sorted values using delta + bit-packing.
     #[must_use]
     pub fn encode(values: &[u64]) -> Self {
@@ -296,6 +318,7 @@ impl DeltaBitPacked {
             return Self {
                 base: 0,
                 deltas: BitPackedInts::pack(&[]),
+                skip_index: Vec::new(),
             };
         }
 
@@ -306,8 +329,9 @@ impl DeltaBitPacked {
             .collect();
 
         let deltas = BitPackedInts::pack(&delta_values);
+        let skip_index = Self::build_skip_index(base, &deltas);
 
-        Self { base, deltas }
+        Self { base, deltas, skip_index }
     }
 
     /// Decodes back to the original values.
@@ -328,6 +352,28 @@ impl DeltaBitPacked {
         }
 
         result
+    }
+
+    /// Returns the value at the given index using the skip index for O(1) access.
+    ///
+    /// Jumps to the nearest skip sample, then sums at most `SKIP_INTERVAL` deltas.
+    #[must_use]
+    pub fn get(&self, index: usize) -> Option<u64> {
+        if index >= self.len() {
+            return None;
+        }
+
+        let sample_idx = index / SKIP_INTERVAL;
+        let sample_pos = sample_idx * SKIP_INTERVAL;
+        let mut current = self.skip_index.get(sample_idx).copied()?;
+
+        // Sum deltas from sample_pos to index.
+        // deltas[i] = values[i+1] - values[i], so
+        // values[index] = values[sample_pos] + sum(deltas[sample_pos..index])
+        for di in sample_pos..index {
+            current = current.wrapping_add(self.deltas.get(di)?);
+        }
+        Some(current)
     }
 
     /// Returns the number of values.
@@ -396,8 +442,9 @@ impl DeltaBitPacked {
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
         );
         let deltas = BitPackedInts::from_bytes(&bytes[8..])?;
+        let skip_index = Self::build_skip_index(base, &deltas);
 
-        Ok(Self { base, deltas })
+        Ok(Self { base, deltas, skip_index })
     }
 }
 
@@ -541,5 +588,44 @@ mod tests {
         assert_eq!(BitPackedInts::bits_needed(255), 8);
         assert_eq!(BitPackedInts::bits_needed(256), 9);
         assert_eq!(BitPackedInts::bits_needed(u64::MAX), 64);
+    }
+
+    #[test]
+    fn test_delta_bitpacked_random_access() {
+        let values: Vec<u64> = (0..500).map(|i| i * 100 + 50).collect();
+        let dbp = DeltaBitPacked::encode(&values);
+        for (i, &expected) in values.iter().enumerate() {
+            assert_eq!(dbp.get(i), Some(expected), "mismatch at index {i}");
+        }
+        assert_eq!(dbp.get(500), None);
+    }
+
+    #[test]
+    fn test_delta_bitpacked_random_access_across_skip_boundaries() {
+        // Test values that span multiple skip intervals (SKIP_INTERVAL = 64)
+        let values: Vec<u64> = (0..200).map(|i| i * 7 + 3).collect();
+        let dbp = DeltaBitPacked::encode(&values);
+
+        // Check values at skip boundaries
+        assert_eq!(dbp.get(0), Some(3));
+        assert_eq!(dbp.get(64), Some(64 * 7 + 3));
+        assert_eq!(dbp.get(128), Some(128 * 7 + 3));
+
+        // Check all values
+        for (i, &expected) in values.iter().enumerate() {
+            assert_eq!(dbp.get(i), Some(expected), "mismatch at index {i}");
+        }
+    }
+
+    #[test]
+    fn test_delta_bitpacked_random_access_after_serialization() {
+        let values: Vec<u64> = (0..300).map(|i| i * 42).collect();
+        let dbp = DeltaBitPacked::encode(&values);
+        let bytes = dbp.to_bytes();
+        let restored = DeltaBitPacked::from_bytes(&bytes).unwrap();
+
+        for (i, &expected) in values.iter().enumerate() {
+            assert_eq!(restored.get(i), Some(expected), "mismatch at index {i} after deserialization");
+        }
     }
 }

--- a/crates/grafeo-core/src/storage/dictionary.rs
+++ b/crates/grafeo-core/src/storage/dictionary.rs
@@ -171,6 +171,132 @@ impl DictionaryEncoding {
             })
             .collect()
     }
+
+    /// Serializes the dictionary encoding to bytes.
+    ///
+    /// Format:
+    ///   - dict_count: u32 (number of unique strings)
+    ///   - for each string: len: u32, bytes: \[u8; len\]
+    ///   - code_count: u32 (number of values)
+    ///   - codes: \[u32; code_count\]
+    ///   - has_nulls: u8 (0 or 1)
+    ///   - if has_nulls: null_bitmap_words: u32, bitmap: \[u64; words\]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+
+        // Dictionary
+        buf.extend_from_slice(&(self.dictionary.len() as u32).to_le_bytes());
+        for s in self.dictionary.iter() {
+            let s_bytes = s.as_bytes();
+            buf.extend_from_slice(&(s_bytes.len() as u32).to_le_bytes());
+            buf.extend_from_slice(s_bytes);
+        }
+
+        // Codes
+        buf.extend_from_slice(&(self.codes.len() as u32).to_le_bytes());
+        for &code in &self.codes {
+            buf.extend_from_slice(&code.to_le_bytes());
+        }
+
+        // Null bitmap
+        match &self.null_bitmap {
+            Some(bitmap) => {
+                buf.push(1);
+                buf.extend_from_slice(&(bitmap.len() as u32).to_le_bytes());
+                for &word in bitmap {
+                    buf.extend_from_slice(&word.to_le_bytes());
+                }
+            }
+            None => {
+                buf.push(0);
+            }
+        }
+
+        buf
+    }
+
+    /// Deserializes a dictionary encoding from bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        let mut pos = 0;
+
+        // Dictionary count
+        if bytes.len() < pos + 4 {
+            return None;
+        }
+        let dict_count = u32::from_le_bytes(bytes[pos..pos + 4].try_into().ok()?) as usize;
+        pos += 4;
+
+        // Dictionary entries
+        let mut dictionary = Vec::with_capacity(dict_count);
+        for _ in 0..dict_count {
+            if bytes.len() < pos + 4 {
+                return None;
+            }
+            let str_len = u32::from_le_bytes(bytes[pos..pos + 4].try_into().ok()?) as usize;
+            pos += 4;
+
+            if bytes.len() < pos + str_len {
+                return None;
+            }
+            let s = std::str::from_utf8(&bytes[pos..pos + str_len]).ok()?;
+            dictionary.push(Arc::from(s));
+            pos += str_len;
+        }
+
+        // Code count
+        if bytes.len() < pos + 4 {
+            return None;
+        }
+        let code_count = u32::from_le_bytes(bytes[pos..pos + 4].try_into().ok()?) as usize;
+        pos += 4;
+
+        // Codes
+        if bytes.len() < pos + code_count * 4 {
+            return None;
+        }
+        let mut codes = Vec::with_capacity(code_count);
+        for _ in 0..code_count {
+            let code = u32::from_le_bytes(bytes[pos..pos + 4].try_into().ok()?);
+            codes.push(code);
+            pos += 4;
+        }
+
+        // Null bitmap
+        if bytes.len() < pos + 1 {
+            return None;
+        }
+        let has_nulls = bytes[pos];
+        pos += 1;
+
+        let null_bitmap = if has_nulls != 0 {
+            if bytes.len() < pos + 4 {
+                return None;
+            }
+            let word_count =
+                u32::from_le_bytes(bytes[pos..pos + 4].try_into().ok()?) as usize;
+            pos += 4;
+
+            if bytes.len() < pos + word_count * 8 {
+                return None;
+            }
+            let mut bitmap = Vec::with_capacity(word_count);
+            for _ in 0..word_count {
+                let word = u64::from_le_bytes(bytes[pos..pos + 8].try_into().ok()?);
+                bitmap.push(word);
+                pos += 8;
+            }
+            Some(bitmap)
+        } else {
+            None
+        };
+
+        let dict: Arc<[Arc<str>]> = dictionary.into();
+        let mut encoding = Self::new(dict, codes);
+        if let Some(bitmap) = null_bitmap {
+            encoding = encoding.with_nulls(bitmap);
+        }
+        Some(encoding)
+    }
 }
 
 /// Builds a dictionary encoding by streaming values through.
@@ -481,5 +607,55 @@ mod tests {
         assert_eq!(dict.len(), 10);
         assert_eq!(dict.dictionary_size(), 1);
         assert!(dict.codes().iter().all(|&c| c == 0));
+    }
+
+    #[test]
+    fn test_dictionary_serialization_round_trip() {
+        let mut builder = DictionaryBuilder::new();
+        builder.add("hello");
+        builder.add("world");
+        builder.add("hello");
+        let dict = builder.build();
+
+        let bytes = dict.to_bytes();
+        let restored = DictionaryEncoding::from_bytes(&bytes).unwrap();
+
+        assert_eq!(restored.len(), 3);
+        assert_eq!(restored.dictionary_size(), 2);
+        assert_eq!(restored.get(0), Some("hello"));
+        assert_eq!(restored.get(1), Some("world"));
+        assert_eq!(restored.get(2), Some("hello"));
+    }
+
+    #[test]
+    fn test_dictionary_serialization_with_nulls() {
+        let mut builder = DictionaryBuilder::new();
+        builder.add("a");
+        builder.add_null();
+        builder.add("b");
+        builder.add_null();
+        let dict = builder.build();
+
+        let bytes = dict.to_bytes();
+        let restored = DictionaryEncoding::from_bytes(&bytes).unwrap();
+
+        assert_eq!(restored.len(), 4);
+        assert_eq!(restored.get(0), Some("a"));
+        assert_eq!(restored.get(1), None);
+        assert!(restored.is_null(1));
+        assert_eq!(restored.get(2), Some("b"));
+        assert!(restored.is_null(3));
+    }
+
+    #[test]
+    fn test_dictionary_serialization_empty() {
+        let builder = DictionaryBuilder::new();
+        let dict = builder.build();
+
+        let bytes = dict.to_bytes();
+        let restored = DictionaryEncoding::from_bytes(&bytes).unwrap();
+
+        assert!(restored.is_empty());
+        assert_eq!(restored.dictionary_size(), 0);
     }
 }

--- a/crates/grafeo-core/src/storage/runlength.rs
+++ b/crates/grafeo-core/src/storage/runlength.rs
@@ -56,6 +56,8 @@ pub struct RunLengthEncoding {
     runs: Vec<Run<u64>>,
     /// Total number of values (sum of all run lengths).
     total_count: usize,
+    /// Cumulative run lengths for O(log n) random access via binary search.
+    prefix_sums: Vec<usize>,
 }
 
 impl<'a> IntoIterator for &'a RunLengthEncoding {
@@ -83,6 +85,7 @@ impl RunLengthEncoding {
             return Self {
                 runs: Vec::new(),
                 total_count: 0,
+                prefix_sums: Vec::new(),
             };
         }
 
@@ -103,9 +106,18 @@ impl RunLengthEncoding {
         // Don't forget the last run
         runs.push(Run::new(current_value, current_length));
 
+        let prefix_sums: Vec<usize> = runs
+            .iter()
+            .scan(0usize, |acc, run| {
+                *acc += run.length as usize;
+                Some(*acc)
+            })
+            .collect();
+
         Self {
             runs,
             total_count: values.len(),
+            prefix_sums,
         }
     }
 
@@ -113,7 +125,18 @@ impl RunLengthEncoding {
     #[must_use]
     pub fn from_runs(runs: Vec<Run<u64>>) -> Self {
         let total_count = runs.iter().map(|r| r.length as usize).sum();
-        Self { runs, total_count }
+        let prefix_sums: Vec<usize> = runs
+            .iter()
+            .scan(0usize, |acc, run| {
+                *acc += run.length as usize;
+                Some(*acc)
+            })
+            .collect();
+        Self {
+            runs,
+            total_count,
+            prefix_sums,
+        }
     }
 
     /// Decodes back to the original values.
@@ -238,17 +261,9 @@ impl RunLengthEncoding {
         if index >= self.total_count {
             return None;
         }
-
-        let mut offset = 0usize;
-        for run in &self.runs {
-            let run_end = offset + run.length as usize;
-            if index < run_end {
-                return Some(run.value);
-            }
-            offset = run_end;
-        }
-
-        None
+        // Binary search: find the first prefix_sum > index
+        let run_idx = self.prefix_sums.partition_point(|&sum| sum <= index);
+        self.runs.get(run_idx).map(|run| run.value)
     }
 
     /// Returns an iterator over the decoded values.
@@ -606,5 +621,26 @@ mod tests {
         assert_eq!(encoded.run_count(), 3);
         assert_eq!(encoded.total_count(), 10);
         assert_eq!(encoded.decode(), vec![1, 1, 1, 2, 2, 3, 3, 3, 3, 3]);
+    }
+
+    #[test]
+    fn test_rle_random_access_binary_search() {
+        // Build RLE with known structure: runs of length 1,2,3,...,50
+        let mut values = Vec::new();
+        for i in 0..50u64 {
+            for _ in 0..=i {
+                values.push(i);
+            }
+        }
+        let rle = RunLengthEncoding::encode(&values);
+
+        // Verify every position
+        let decoded = rle.decode();
+        for i in 0..decoded.len() {
+            assert_eq!(rle.get(i), Some(decoded[i]), "mismatch at index {i}");
+        }
+
+        // Out of bounds
+        assert_eq!(rle.get(decoded.len()), None);
     }
 }


### PR DESCRIPTION
## Summary

Three backward-compatible improvements to existing storage primitives in `grafeo-core/src/storage/`:

- **DictionaryEncoding: add `to_bytes`/`from_bytes`** — this was the only storage primitive missing serialization. All others (`BitPackedInts`, `DeltaBitPacked`, `RunLengthEncoding`, `BitVector`) already have it.

- **RunLengthEncoding::get(): O(log n) binary search** — the current implementation scans runs linearly, which is O(n) where n = number of runs. This adds a prefix-sum cache (computed once at construction, not serialized) and uses `partition_point` for O(log n) random access.

- **DeltaBitPacked::get(): O(1) random access** — `DeltaBitPacked` currently only supports full `decode()`. This adds a skip index that samples the reconstructed value every 64 entries, enabling random access with at most 64 delta additions per lookup.

## Motivation

These gaps affect anyone using the storage primitives directly:
- Dictionary encoding couldn't be persisted without the consumer writing their own serializer
- RLE random access was accidentally quadratic for workloads that look up many positions
- DeltaBitPacked was decode-only, forcing full materialization to read a single value

## Changes

| File | Lines | What |
|---|---|---|
| `storage/dictionary.rs` | +176 | `to_bytes`/`from_bytes` + 3 tests |
| `storage/runlength.rs` | +46/-14 | `prefix_sums` field, binary search `get()` + 1 test |
| `storage/bitpack.rs` | +90 | `skip_index` field, `get()` method, `build_skip_index` helper + 3 tests |

No existing method signatures changed. No new dependencies. All 3,800+ existing tests pass.

## Test plan

- [x] `cargo test -p grafeo-core -- storage` — 112 tests pass (including 7 new)
- [x] `cargo test --all` — full suite passes, zero regressions
- [x] `cargo clippy -p grafeo-core --lib` — zero warnings
- [x] Serialization round-trip: encode → `to_bytes` → `from_bytes` → decode matches original
- [x] Binary search correctness: verified against full `decode()` for all positions
- [x] Skip index correctness: verified across skip boundaries (0, 64, 128) and after deserialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)