### PR TITLE
perf(compact): avoid per-row Value allocation in property scans

### DIFF
--- a/crates/grafeo-core/Cargo.toml
+++ b/crates/grafeo-core/Cargo.toml
@@ -88,3 +88,8 @@ workspace = true
 [[bench]]
 name = "index_bench"
 harness = false
+
+[[bench]]
+name = "compressed_eval_bench"
+harness = false
+required-features = ["compact-store"]

--- a/crates/grafeo-core/benches/compressed_eval_bench.rs
+++ b/crates/grafeo-core/benches/compressed_eval_bench.rs
@@ -1,0 +1,194 @@
+//! Benchmark: property scan performance in CompactStore.
+//!
+//! Measures the cost of `find_nodes_by_property` and `find_nodes_in_range`
+//! using the current decode path vs typed codec-native evaluation.
+//!
+//! Run: `cargo bench -p grafeo-core --bench compressed_eval_bench --features compact-store`
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use grafeo_common::types::Value;
+use grafeo_core::graph::compact::builder::CompactStoreBuilder;
+use grafeo_core::graph::compact::column::ColumnCodec;
+use grafeo_core::graph::compact::CompactStore;
+use grafeo_core::graph::traits::GraphStore;
+use grafeo_core::storage::bitpack::BitPackedInts;
+use grafeo_core::storage::dictionary::DictionaryBuilder;
+
+/// Build a test graph at the given scale.
+/// - `n` Item nodes with "score" (4-bit) and "name" (dict, 5 values)
+/// - `n * 5` Activity nodes with "rating" (4-bit)
+fn build_store(n: usize) -> CompactStore {
+    let scores: Vec<u64> = (0..n).map(|i| (i % 10) as u64).collect();
+    let names: Vec<&str> = (0..n)
+        .map(|i| match i % 5 {
+            0 => "alpha",
+            1 => "beta",
+            2 => "gamma",
+            3 => "delta",
+            _ => "epsilon",
+        })
+        .collect();
+    let activity_count = n * 5;
+    let ratings: Vec<u64> = (0..activity_count).map(|i| ((i % 5) + 1) as u64).collect();
+
+    CompactStoreBuilder::new()
+        .node_table("Item", |t| {
+            t.column_bitpacked("score", &scores, 4)
+                .column_dict("name", &names)
+        })
+        .node_table("Activity", |t| t.column_bitpacked("rating", &ratings, 4))
+        .build()
+        .expect("Failed to build test store")
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: find_nodes_by_property (equality) on dictionary column
+// ---------------------------------------------------------------------------
+
+fn bench_find_by_dict_property(c: &mut Criterion) {
+    let mut group = c.benchmark_group("find_nodes_by_property_dict");
+
+    for &n in &[1_000usize, 10_000, 100_000] {
+        let store = build_store(n);
+
+        // find_nodes_by_property uses ColumnCodec::find_eq internally.
+        group.bench_function(format!("name_eq_gamma/{n}"), |b| {
+            b.iter(|| {
+                let results = store.find_nodes_by_property("name", &Value::String("gamma".into()));
+                black_box(results.len())
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: find_nodes_by_property (equality) on bitpacked column
+// ---------------------------------------------------------------------------
+
+fn bench_find_by_int_property(c: &mut Criterion) {
+    let mut group = c.benchmark_group("find_nodes_by_property_int");
+
+    for &n in &[1_000usize, 10_000, 100_000] {
+        let store = build_store(n);
+
+        group.bench_function(format!("score_eq_5/{n}"), |b| {
+            b.iter(|| {
+                let results = store.find_nodes_by_property("score", &Value::Int64(5));
+                black_box(results.len())
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: find_nodes_in_range on bitpacked column
+// ---------------------------------------------------------------------------
+
+fn bench_find_in_range(c: &mut Criterion) {
+    let mut group = c.benchmark_group("find_nodes_in_range");
+
+    for &n in &[1_000usize, 10_000, 100_000] {
+        let store = build_store(n);
+
+        // score > 7 (20% selectivity)
+        group.bench_function(format!("score_gt_7/{n}"), |b| {
+            b.iter(|| {
+                let results = store.find_nodes_in_range(
+                    "score",
+                    Some(&Value::Int64(7)),
+                    None,
+                    false,
+                    false,
+                );
+                black_box(results.len())
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: raw codec-level comparison (isolate the decode cost)
+//
+// Compares three paths at 100K rows:
+//   1. ColumnCodec::get() → Value → compare (current path for other consumers)
+//   2. Typed accessor (bp.get() / dict.get()) → native type → compare
+//   3. Bulk find_eq / find_in_range (new methods)
+// ---------------------------------------------------------------------------
+
+fn bench_codec_paths(c: &mut Criterion) {
+    let mut group = c.benchmark_group("codec_paths");
+
+    let n = 100_000usize;
+
+    // --- BitPacked column ---
+    let values: Vec<u64> = (0..n).map(|i| (i % 10) as u64).collect();
+    let bp = BitPackedInts::pack_with_bits(&values, 4);
+    let col = ColumnCodec::BitPacked(bp.clone());
+
+    group.bench_function("bitpacked/via_value/100K", |b| {
+        b.iter(|| {
+            let mut count = 0u32;
+            for i in 0..n {
+                if let Some(Value::Int64(v)) = col.get(i) {
+                    if v == 5 {
+                        count += 1;
+                    }
+                }
+            }
+            black_box(count)
+        });
+    });
+
+    group.bench_function("bitpacked/find_eq/100K", |b| {
+        b.iter(|| black_box(col.find_eq(&Value::Int64(5)).len()))
+    });
+
+    // --- Dictionary column ---
+    let labels = ["alpha", "beta", "gamma", "delta", "epsilon"];
+    let string_values: Vec<&str> = (0..n).map(|i| labels[i % 5]).collect();
+    let mut builder = DictionaryBuilder::new();
+    for &s in &string_values {
+        builder.add(s);
+    }
+    let dict = builder.build();
+    let dict_col = ColumnCodec::Dict(dict);
+
+    group.bench_function("dict/via_value/100K", |b| {
+        b.iter(|| {
+            let mut count = 0u32;
+            for i in 0..n {
+                if let Some(Value::String(ref s)) = dict_col.get(i) {
+                    if s.as_str() == "gamma" {
+                        count += 1;
+                    }
+                }
+            }
+            black_box(count)
+        });
+    });
+
+    group.bench_function("dict/find_eq/100K", |b| {
+        let target = Value::String("gamma".into());
+        b.iter(|| black_box(dict_col.find_eq(&target).len()))
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_find_by_dict_property,
+    bench_find_by_int_property,
+    bench_find_in_range,
+    bench_codec_paths,
+);
+criterion_main!(benches);

--- a/crates/grafeo-core/benches/compressed_eval_bench.rs
+++ b/crates/grafeo-core/benches/compressed_eval_bench.rs
@@ -10,9 +10,9 @@ use std::hint::black_box;
 use criterion::{Criterion, criterion_group, criterion_main};
 
 use grafeo_common::types::Value;
+use grafeo_core::graph::compact::CompactStore;
 use grafeo_core::graph::compact::builder::CompactStoreBuilder;
 use grafeo_core::graph::compact::column::ColumnCodec;
-use grafeo_core::graph::compact::CompactStore;
 use grafeo_core::graph::traits::GraphStore;
 use grafeo_core::storage::bitpack::BitPackedInts;
 use grafeo_core::storage::dictionary::DictionaryBuilder;
@@ -100,13 +100,8 @@ fn bench_find_in_range(c: &mut Criterion) {
         // score > 7 (20% selectivity)
         group.bench_function(format!("score_gt_7/{n}"), |b| {
             b.iter(|| {
-                let results = store.find_nodes_in_range(
-                    "score",
-                    Some(&Value::Int64(7)),
-                    None,
-                    false,
-                    false,
-                );
+                let results =
+                    store.find_nodes_in_range("score", Some(&Value::Int64(7)), None, false, false);
                 black_box(results.len())
             });
         });

--- a/crates/grafeo-core/src/graph/compact/column.rs
+++ b/crates/grafeo-core/src/graph/compact/column.rs
@@ -152,7 +152,11 @@ impl ColumnCodec {
                     };
                 }
                 let values_per_word = 64 / bits;
-                let mask = if bits >= 64 { u64::MAX } else { (1u64 << bits) - 1 };
+                let mask = if bits >= 64 {
+                    u64::MAX
+                } else {
+                    (1u64 << bits) - 1
+                };
                 if target_u64 > mask {
                     return Vec::new(); // Value exceeds column's bit width
                 }
@@ -179,11 +183,9 @@ impl ColumnCodec {
                     Vec::new() // Target not in dictionary — no matches
                 }
             }
-            (Self::Bitmap(bv), &Value::Bool(target_bool)) => {
-                (0..bv.len())
-                    .filter(|&i| bv.get(i) == Some(target_bool))
-                    .collect()
-            }
+            (Self::Bitmap(bv), &Value::Bool(target_bool)) => (0..bv.len())
+                .filter(|&i| bv.get(i) == Some(target_bool))
+                .collect(),
             // Type mismatch or Int8Vector — fall back to Value comparison.
             _ => (0..self.len())
                 .filter(|&i| self.get(i).as_ref() == Some(target))
@@ -226,10 +228,18 @@ impl ColumnCodec {
                     (_, Some(hi)) if hi == 0 && !max_inclusive => false,
                     _ => true,
                 };
-                return if zero_matches { (0..len).collect() } else { Vec::new() };
+                return if zero_matches {
+                    (0..len).collect()
+                } else {
+                    Vec::new()
+                };
             }
             let values_per_word = 64 / bits;
-            let mask = if bits >= 64 { u64::MAX } else { (1u64 << bits) - 1 };
+            let mask = if bits >= 64 {
+                u64::MAX
+            } else {
+                (1u64 << bits) - 1
+            };
             let data = bp.data();
             let mut results = Vec::new();
             for i in 0..len {

--- a/crates/grafeo-core/src/graph/compact/column.rs
+++ b/crates/grafeo-core/src/graph/compact/column.rs
@@ -126,6 +126,155 @@ impl ColumnCodec {
         self.len() == 0
     }
 
+    /// Returns the offsets of all rows whose value equals `target`.
+    ///
+    /// Operates in the codec's native domain to avoid per-row `Value` allocation:
+    /// - [`BitPacked`](Self::BitPacked): compares raw `u64` values
+    /// - [`Dict`](Self::Dict): resolves the target string to a dictionary code
+    ///   once, then scans integer codes
+    /// - [`Bitmap`](Self::Bitmap): checks bits directly
+    ///
+    /// Falls back to [`get`](Self::get)-based comparison for type mismatches.
+    pub fn find_eq(&self, target: &Value) -> Vec<usize> {
+        match (self, target) {
+            (Self::BitPacked(bp), &Value::Int64(v)) => {
+                if v < 0 {
+                    return Vec::new(); // BitPacked stores unsigned values
+                }
+                let target_u64 = v as u64;
+                let len = bp.len();
+                let bits = bp.bits_per_value() as usize;
+                if bits == 0 {
+                    return if target_u64 == 0 {
+                        (0..len).collect()
+                    } else {
+                        Vec::new()
+                    };
+                }
+                let values_per_word = 64 / bits;
+                let mask = if bits >= 64 { u64::MAX } else { (1u64 << bits) - 1 };
+                if target_u64 > mask {
+                    return Vec::new(); // Value exceeds column's bit width
+                }
+                let data = bp.data();
+                let mut results = Vec::new();
+                for i in 0..len {
+                    let word_idx = i / values_per_word;
+                    let bit_offset = (i % values_per_word) * bits;
+                    if (data[word_idx] >> bit_offset) & mask == target_u64 {
+                        results.push(i);
+                    }
+                }
+                results
+            }
+            (Self::Dict(dict), Value::String(s)) => {
+                if let Some(code) = dict.encode(s.as_str()) {
+                    dict.codes()
+                        .iter()
+                        .enumerate()
+                        .filter(|&(_, &c)| c == code)
+                        .map(|(i, _)| i)
+                        .collect()
+                } else {
+                    Vec::new() // Target not in dictionary — no matches
+                }
+            }
+            (Self::Bitmap(bv), &Value::Bool(target_bool)) => {
+                (0..bv.len())
+                    .filter(|&i| bv.get(i) == Some(target_bool))
+                    .collect()
+            }
+            // Type mismatch or Int8Vector — fall back to Value comparison.
+            _ => (0..self.len())
+                .filter(|&i| self.get(i).as_ref() == Some(target))
+                .collect(),
+        }
+    }
+
+    /// Returns the offsets of all rows whose value falls within `[min, max]`.
+    ///
+    /// Like [`find_eq`](Self::find_eq), operates in the codec's native domain
+    /// to avoid per-row `Value` allocation for integer columns.
+    pub fn find_in_range(
+        &self,
+        min: Option<&Value>,
+        max: Option<&Value>,
+        min_inclusive: bool,
+        max_inclusive: bool,
+    ) -> Vec<usize> {
+        // For BitPacked columns with integer bounds, compare raw u64 values.
+        if let Self::BitPacked(bp) = self {
+            let min_u64 = match min {
+                Some(&Value::Int64(v)) if v >= 0 => Some(v as u64),
+                Some(&Value::Int64(_)) => Some(0), // negative min → effectively 0 for unsigned
+                None => None,
+                _ => return self.find_in_range_fallback(min, max, min_inclusive, max_inclusive),
+            };
+            let max_u64 = match max {
+                Some(&Value::Int64(v)) if v >= 0 => Some(v as u64),
+                Some(&Value::Int64(v)) if v < 0 => return Vec::new(), // negative max → no unsigned matches
+                None => None,
+                _ => return self.find_in_range_fallback(min, max, min_inclusive, max_inclusive),
+            };
+
+            let len = bp.len();
+            let bits = bp.bits_per_value() as usize;
+            if bits == 0 {
+                let zero_matches = match (min_u64, max_u64) {
+                    (Some(lo), _) if lo > 0 => false,
+                    (Some(0), _) if !min_inclusive => false,
+                    (_, Some(hi)) if hi == 0 && !max_inclusive => false,
+                    _ => true,
+                };
+                return if zero_matches { (0..len).collect() } else { Vec::new() };
+            }
+            let values_per_word = 64 / bits;
+            let mask = if bits >= 64 { u64::MAX } else { (1u64 << bits) - 1 };
+            let data = bp.data();
+            let mut results = Vec::new();
+            for i in 0..len {
+                let word_idx = i / values_per_word;
+                let bit_offset = (i % values_per_word) * bits;
+                let v = (data[word_idx] >> bit_offset) & mask;
+                let above_min = match min_u64 {
+                    Some(lo) if min_inclusive => v >= lo,
+                    Some(lo) => v > lo,
+                    None => true,
+                };
+                let below_max = match max_u64 {
+                    Some(hi) if max_inclusive => v <= hi,
+                    Some(hi) => v < hi,
+                    None => true,
+                };
+                if above_min && below_max {
+                    results.push(i);
+                }
+            }
+            return results;
+        }
+
+        self.find_in_range_fallback(min, max, min_inclusive, max_inclusive)
+    }
+
+    /// Fallback range scan via per-row `Value` decode.
+    fn find_in_range_fallback(
+        &self,
+        min: Option<&Value>,
+        max: Option<&Value>,
+        min_inclusive: bool,
+        max_inclusive: bool,
+    ) -> Vec<usize> {
+        (0..self.len())
+            .filter(|&i| {
+                if let Some(v) = self.get(i) {
+                    super::CompactStore::value_in_range(&v, min, max, min_inclusive, max_inclusive)
+                } else {
+                    false
+                }
+            })
+            .collect()
+    }
+
     /// Returns an estimate of heap memory used by this column in bytes.
     #[must_use]
     pub fn heap_bytes(&self) -> usize {

--- a/crates/grafeo-core/src/graph/compact/graph_store_impl.rs
+++ b/crates/grafeo-core/src/graph/compact/graph_store_impl.rs
@@ -232,12 +232,8 @@ impl GraphStore for CompactStore {
             }
             if let Some(col) = nt.column(&key) {
                 let table_id = nt.table_id();
-                for offset in 0..col.len() {
-                    if let Some(v) = col.get(offset)
-                        && &v == value
-                    {
-                        results.push(encode_node_id(table_id, offset as u64));
-                    }
+                for offset in col.find_eq(value) {
+                    results.push(encode_node_id(table_id, offset as u64));
                 }
             }
         }
@@ -307,12 +303,8 @@ impl GraphStore for CompactStore {
             }
             if let Some(col) = nt.column(&key) {
                 let table_id = nt.table_id();
-                for offset in 0..col.len() {
-                    if let Some(v) = col.get(offset)
-                        && Self::value_in_range(&v, min, max, min_inclusive, max_inclusive)
-                    {
-                        results.push(encode_node_id(table_id, offset as u64));
-                    }
+                for offset in col.find_in_range(min, max, min_inclusive, max_inclusive) {
+                    results.push(encode_node_id(table_id, offset as u64));
                 }
             }
         }

--- a/crates/grafeo-core/src/graph/compact/mod.rs
+++ b/crates/grafeo-core/src/graph/compact/mod.rs
@@ -214,7 +214,7 @@ impl CompactStore {
     }
 
     /// Checks if a value falls within a range.
-    fn value_in_range(
+    pub(super) fn value_in_range(
         val: &Value,
         min: Option<&Value>,
         max: Option<&Value>,


### PR DESCRIPTION
## Summary

- Add `ColumnCodec::find_eq()` and `ColumnCodec::find_in_range()` that return matching row offsets by operating in each codec's native domain, avoiding per-row `Value` allocation
- Update `find_nodes_by_property` and `find_nodes_in_range` to use these methods
- Add benchmark: `cargo bench -p grafeo-core --bench compressed_eval_bench --features compact-store`

## Measured impact (criterion, 100K rows)

| Column type | Before (`ColumnCodec::get()` per row) | After (typed scan) | Speedup |
|---|---|---|---|
| Dictionary (string equality) | 1,554 µs | 64 µs | **24x** |
| BitPacked (integer equality) | 251 µs | 67 µs | **3.7x** |

The dictionary improvement comes from resolving the target string to a dictionary code once via `dict.encode()`, then scanning `u32` codes. The string table is never touched for non-matches. The previous path called `ArcStr::from()` per row.

## What changed

- `column.rs`: `find_eq()` and `find_in_range()` methods on `ColumnCodec` (149 lines)
- `graph_store_impl.rs`: `find_nodes_by_property` and `find_nodes_in_range` call new methods (net -3 lines)
- `mod.rs`: `value_in_range` visibility changed to `pub(super)` for range fallback
- Benchmark added

Zero new dependencies. All 120 compact store tests pass.

Fixes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)