### PR TITLE
fix: CompactStore supports multiple label pairs per edge type

### DIFF
--- a/crates/grafeo-core/src/graph/compact/builder.rs
+++ b/crates/grafeo-core/src/graph/compact/builder.rs
@@ -330,14 +330,17 @@ impl CompactStoreBuilder {
             }
         }
 
-        // Step 2b: Validate no duplicate edge types.
+        // Step 2b: Validate no duplicate (edge_type, src_label, dst_label) triples.
+        // The same edge type can span multiple label pairs (e.g., CALLS between
+        // Method→Method and Class→Method) — this is normal in LPGs.
         {
-            let mut seen_types = FxHashSet::default();
+            let mut seen_triples = FxHashSet::default();
             for rtb in &self.rel_table_builders {
-                if !seen_types.insert(&rtb.edge_type) {
-                    return Err(CompactStoreError::DuplicateEdgeType(
-                        rtb.edge_type.to_string(),
-                    ));
+                if !seen_triples.insert((&rtb.edge_type, &rtb.src_label, &rtb.dst_label)) {
+                    return Err(CompactStoreError::DuplicateEdgeType(format!(
+                        "{}({} -> {})",
+                        rtb.edge_type, rtb.src_label, rtb.dst_label
+                    )));
                 }
             }
         }
@@ -382,7 +385,7 @@ impl CompactStoreBuilder {
 
         // Step 5: Build each RelTable.
         let mut rel_tables_by_id: Vec<RelTable> = Vec::with_capacity(self.rel_table_builders.len());
-        let mut edge_type_to_rel_id: FxHashMap<ArcStr, u16> = FxHashMap::default();
+        let mut edge_type_to_rel_id: FxHashMap<ArcStr, Vec<u16>> = FxHashMap::default();
         let mut rel_table_id_to_type: Vec<ArcStr> = Vec::new();
 
         for (idx, rtb) in self.rel_table_builders.into_iter().enumerate() {
@@ -463,7 +466,10 @@ impl CompactStoreBuilder {
                 rtb.properties.into_iter().collect();
 
             let table = RelTable::new(schema, fwd, bwd, properties, src_table_id, dst_table_id);
-            edge_type_to_rel_id.insert(rtb.edge_type.clone(), rel_table_id);
+            edge_type_to_rel_id
+                .entry(rtb.edge_type.clone())
+                .or_default()
+                .push(rel_table_id);
             rel_tables_by_id.push(table);
         }
 
@@ -479,11 +485,19 @@ impl CompactStoreBuilder {
             stats.update_label(label.as_str(), LabelStatistics::new(count));
         }
 
-        for (idx, rt) in rel_tables_by_id.iter().enumerate() {
-            let count = rt.num_edges() as u64;
-            total_edges += count;
-            let edge_type = &rel_table_id_to_type[idx];
-            stats.update_edge_type(edge_type.as_str(), EdgeTypeStatistics::new(count, 0.0, 0.0));
+        // Aggregate edge counts per edge type before inserting into stats,
+        // since the same edge type can span multiple rel tables.
+        {
+            let mut edge_type_counts: FxHashMap<&str, u64> = FxHashMap::default();
+            for (idx, rt) in rel_tables_by_id.iter().enumerate() {
+                let count = rt.num_edges() as u64;
+                total_edges += count;
+                let edge_type = rel_table_id_to_type[idx].as_str();
+                *edge_type_counts.entry(edge_type).or_default() += count;
+            }
+            for (edge_type, count) in &edge_type_counts {
+                stats.update_edge_type(edge_type, EdgeTypeStatistics::new(*count, 0.0, 0.0));
+            }
         }
 
         stats.total_nodes = total_nodes;
@@ -1407,6 +1421,92 @@ mod tests {
         assert_eq!(
             infer_type_from_values(&[Value::Int64(5), Value::Null, Value::Int64(10)]),
             InferredType::BitPacked
+        );
+    }
+
+    /// Same edge type spanning multiple label pairs — normal in LPGs.
+    /// Regression test for <https://github.com/GrafeoDB/grafeo/issues/221>.
+    #[test]
+    fn test_from_graph_store_multi_label_edge_type() {
+        use crate::graph::lpg::LpgStore;
+
+        let store = LpgStore::new().unwrap();
+
+        // Three node types
+        let m1 = store.create_node(&["Method"]);
+        store.set_node_property(m1, "name", Value::from("foo"));
+        let m2 = store.create_node(&["Method"]);
+        store.set_node_property(m2, "name", Value::from("bar"));
+        let c1 = store.create_node(&["Class"]);
+        store.set_node_property(c1, "name", Value::from("MyClass"));
+        let i1 = store.create_node(&["Interface"]);
+        store.set_node_property(i1, "name", Value::from("MyInterface"));
+
+        // CALLS edges between different label pairs
+        store.create_edge(m1, m2, "CALLS"); // Method -> Method
+        store.create_edge(c1, m1, "CALLS"); // Class -> Method
+        // USES_TYPE edges between different label pairs
+        store.create_edge(m1, c1, "USES_TYPE"); // Method -> Class
+        store.create_edge(m1, i1, "USES_TYPE"); // Method -> Interface
+
+        // This should not panic — same edge type across multiple label pairs is valid.
+        let compact = from_graph_store(&store).unwrap();
+
+        // Verify all nodes survived
+        assert_eq!(compact.nodes_by_label("Method").len(), 2);
+        assert_eq!(compact.nodes_by_label("Class").len(), 1);
+        assert_eq!(compact.nodes_by_label("Interface").len(), 1);
+
+        // Verify edges survived — check via rel_tables_for_type
+        let calls_tables = compact.rel_tables_for_type("CALLS");
+        let uses_tables = compact.rel_tables_for_type("USES_TYPE");
+
+        // CALLS spans 2 label pairs: Method→Method, Class→Method
+        assert_eq!(
+            calls_tables.len(),
+            2,
+            "CALLS should have 2 rel tables (different label pairs)"
+        );
+        // USES_TYPE spans 2 label pairs: Method→Class, Method→Interface
+        assert_eq!(
+            uses_tables.len(),
+            2,
+            "USES_TYPE should have 2 rel tables (different label pairs)"
+        );
+
+        // Total edges across all CALLS tables
+        let total_calls: usize = calls_tables.iter().map(|rt| rt.num_edges()).sum();
+        assert_eq!(total_calls, 2, "Should have 2 CALLS edges total");
+        // Total edges across all USES_TYPE tables
+        let total_uses: usize = uses_tables.iter().map(|rt| rt.num_edges()).sum();
+        assert_eq!(total_uses, 2, "Should have 2 USES_TYPE edges total");
+
+        // Verify all_edge_types returns deduplicated type names
+        use crate::graph::traits::GraphStore;
+        let mut edge_types = compact.all_edge_types();
+        edge_types.sort();
+        assert_eq!(
+            edge_types,
+            vec!["CALLS", "USES_TYPE"],
+            "all_edge_types should return each type once, not per rel table"
+        );
+
+        // Verify estimate_avg_degree deduplicates shared source labels.
+        // USES_TYPE has Method→Class and Method→Interface — Method appears as source in both
+        // rel tables but should only be counted once in the denominator.
+        // 2 edges / 2 source nodes (Method) = 1.0 (not 2 edges / 4 = 0.5 if double-counted)
+        let avg_out = compact.estimate_avg_degree("USES_TYPE", true);
+        assert!(avg_out > 0.0, "USES_TYPE outgoing degree should be > 0");
+        assert!(
+            (avg_out - 1.0).abs() < f64::EPSILON,
+            "USES_TYPE avg outgoing degree should be 1.0 (2 edges / 2 Method nodes), got {avg_out}"
+        );
+
+        // Verify unknown edge type returns 0
+        let unknown = compact.estimate_avg_degree("NONEXISTENT", true);
+        assert!(
+            (unknown - 0.0).abs() < f64::EPSILON,
+            "Unknown edge type should return 0.0 avg degree"
         );
     }
 }

--- a/crates/grafeo-core/src/graph/compact/graph_store_impl.rs
+++ b/crates/grafeo-core/src/graph/compact/graph_store_impl.rs
@@ -357,26 +357,34 @@ impl GraphStore for CompactStore {
     }
 
     fn estimate_avg_degree(&self, edge_type: &str, outgoing: bool) -> f64 {
-        if let Some(rt) = self
-            .edge_type_to_rel_id
-            .get(edge_type)
-            .and_then(|&rid| self.rel_tables_by_id.get(rid as usize))
-        {
-            let num_edges = rt.num_edges();
-            if num_edges == 0 {
-                return 0.0;
-            }
-            let num_nodes = if outgoing {
-                self.resolve_node_table(rt.src_table_id())
-                    .map_or(1, |nt| nt.len().max(1))
-            } else {
-                self.resolve_node_table(rt.dst_table_id())
-                    .map_or(1, |nt| nt.len().max(1))
+        let Some(rids) = self.edge_type_to_rel_id.get(edge_type) else {
+            return 0.0;
+        };
+        let mut total_edges = 0usize;
+        // Deduplicate node tables to avoid double-counting when multiple
+        // rel tables share the same source/destination label.
+        let mut seen_table_ids = FxHashSet::default();
+        let mut total_nodes = 0usize;
+        for &rid in rids {
+            let Some(rt) = self.rel_tables_by_id.get(rid as usize) else {
+                continue;
             };
-            num_edges as f64 / num_nodes as f64
-        } else {
-            0.0
+            total_edges += rt.num_edges();
+            let table_id = if outgoing {
+                rt.src_table_id()
+            } else {
+                rt.dst_table_id()
+            };
+            if seen_table_ids.insert(table_id) {
+                total_nodes += self
+                    .resolve_node_table(table_id)
+                    .map_or(1, |nt| nt.len().max(1));
+            }
         }
+        if total_nodes == 0 {
+            return 0.0;
+        }
+        total_edges as f64 / total_nodes as f64
     }
 
     fn current_epoch(&self) -> EpochId {
@@ -391,8 +399,8 @@ impl GraphStore for CompactStore {
     }
 
     fn all_edge_types(&self) -> Vec<String> {
-        self.rel_table_id_to_type
-            .iter()
+        self.edge_type_to_rel_id
+            .keys()
             .map(|s| s.to_string())
             .collect()
     }

--- a/crates/grafeo-core/src/graph/compact/mod.rs
+++ b/crates/grafeo-core/src/graph/compact/mod.rs
@@ -50,8 +50,9 @@ pub struct CompactStore {
     label_to_table_id: FxHashMap<ArcStr, u16>,
     /// Relationship tables indexed by rel_table_id for O(1) lookup from EdgeId.
     rel_tables_by_id: Vec<RelTable>,
-    /// rel_table_id lookup from edge type string.
-    edge_type_to_rel_id: FxHashMap<ArcStr, u16>,
+    /// rel_table_id(s) lookup from edge type string. One edge type can span
+    /// multiple (src_label, dst_label) pairs, each with its own rel table.
+    edge_type_to_rel_id: FxHashMap<ArcStr, Vec<u16>>,
     /// Lookup: table ID -> label.
     table_id_to_label: Vec<ArcStr>,
     /// Lookup: rel table ID -> edge type.
@@ -86,7 +87,7 @@ impl CompactStore {
         node_tables_by_id: Vec<NodeTable>,
         label_to_table_id: FxHashMap<ArcStr, u16>,
         rel_tables_by_id: Vec<RelTable>,
-        edge_type_to_rel_id: FxHashMap<ArcStr, u16>,
+        edge_type_to_rel_id: FxHashMap<ArcStr, Vec<u16>>,
         table_id_to_label: Vec<ArcStr>,
         rel_table_id_to_type: Vec<ArcStr>,
         statistics: Statistics,
@@ -140,11 +141,18 @@ impl CompactStore {
         self.node_tables_by_id.get(tid as usize)
     }
 
-    /// Returns a reference to the relationship table for the given edge type.
+    /// Returns references to all relationship tables for the given edge type.
+    /// An edge type can have multiple rel tables if it spans different label pairs.
     #[must_use]
-    pub fn rel_table(&self, edge_type: &str) -> Option<&RelTable> {
-        let &rid = self.edge_type_to_rel_id.get(edge_type)?;
-        self.rel_tables_by_id.get(rid as usize)
+    pub fn rel_tables_for_type(&self, edge_type: &str) -> Vec<&RelTable> {
+        self.edge_type_to_rel_id
+            .get(edge_type)
+            .map(|rids| {
+                rids.iter()
+                    .filter_map(|&rid| self.rel_tables_by_id.get(rid as usize))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     /// Returns the label for a given table ID, if valid.

--- a/crates/grafeo-core/src/graph/compact/tests.rs
+++ b/crates/grafeo-core/src/graph/compact/tests.rs
@@ -178,7 +178,7 @@ fn test_builder_duplicate_edge_type_error() {
 
     assert!(matches!(
         result,
-        Err(CompactStoreError::DuplicateEdgeType(ref s)) if s == "LIVES_IN"
+        Err(CompactStoreError::DuplicateEdgeType(ref s)) if s.contains("LIVES_IN")
     ));
 }
 
@@ -1114,7 +1114,7 @@ fn test_node_property_might_match_multi_table_conservative() {
 #[test]
 fn test_rel_table_source_node_id_out_of_bounds() {
     let store = build_test_store();
-    let rt = store.rel_table("LIVES_IN").unwrap();
+    let rt = store.rel_tables_for_type("LIVES_IN")[0];
     // CSR position far beyond edge count should return None.
     assert!(rt.source_node_id(9999).is_none());
 }
@@ -1122,17 +1122,17 @@ fn test_rel_table_source_node_id_out_of_bounds() {
 #[test]
 fn test_rel_table_dest_node_id_out_of_bounds() {
     let store = build_test_store();
-    let rt = store.rel_table("LIVES_IN").unwrap();
+    let rt = store.rel_tables_for_type("LIVES_IN")[0];
     assert!(rt.dest_node_id(9999).is_none());
 }
 
 #[test]
 fn test_rel_table_memory_bytes_nonzero() {
     let store = build_test_store();
-    let rt = store.rel_table("LIVES_IN").unwrap();
+    let rt = store.rel_tables_for_type("LIVES_IN")[0];
     assert!(rt.memory_bytes() > 0);
     // With backward CSR, memory should be higher.
-    let knows = store.rel_table("KNOWS").unwrap();
+    let knows = store.rel_tables_for_type("KNOWS")[0];
     assert!(knows.memory_bytes() > 0);
 }
 
@@ -1145,7 +1145,7 @@ fn test_rel_table_no_backward_dest_node_id() {
         .build()
         .unwrap();
 
-    let rt = store.rel_table("LINK").unwrap();
+    let rt = store.rel_tables_for_type("LINK")[0];
     // source_node_id should work (forward CSR).
     assert!(rt.source_node_id(0).is_some());
     // dest_node_id should also work (uses forward CSR only).


### PR DESCRIPTION
## Summary

Fixes #221 — `compact()` fails with "duplicate edge type" when the graph has the same edge type spanning multiple node label pairs (e.g., `CALLS` between `Method→Method` and `Class→Method`).

This is a normal pattern in Labeled Property Graphs. Our use case is a code dependency graph with 8 edge types across multiple node label combinations.

## Root cause

`from_graph_store()` groups edges by `(edge_type, src_label, dst_label)` and creates one `rel_table` per group, but `build()` validated uniqueness by edge type name alone.

## Changes

- **Validate `(edge_type, src_label, dst_label)` triples** instead of just edge type name
- **`edge_type_to_rel_id`**: `HashMap<ArcStr, u16>` → `HashMap<ArcStr, Vec<u16>>` to support one-to-many mapping
- **`rel_table()`** → **`rel_tables_for_type()`** returning `Vec<&RelTable>` (reflects that one edge type can have multiple backing tables)
- **`estimate_avg_degree()`**: aggregates across all rel tables for a given edge type
- **Existing test updated**: `test_builder_duplicate_edge_type_error` now matches on `contains("LIVES_IN")` since the error message includes the label pair

## Test

New test `test_from_graph_store_multi_label_edge_type`:
- Creates nodes with 3 labels (Method, Class, Interface)
- Creates `CALLS` edges across 2 label pairs (Method→Method, Class→Method)
- Creates `USES_TYPE` edges across 2 label pairs (Method→Class, Method→Interface)
- Verifies `compact()` succeeds and all edges survive

All 1,386 existing tests pass (`cargo test -p grafeo-core --features compact-store`).

## Test plan

- [x] New test for multi-label-pair edge types
- [x] Existing `test_builder_duplicate_edge_type_error` still catches true duplicates (same triple)
- [x] Full `grafeo-core` test suite passes (1,386 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow a single edge type to span multiple node label pairs in CompactStore. This fixes false "duplicate edge type" errors and makes stats and degree estimates correct.

- **Bug Fixes**
  - Validate uniqueness by (edge_type, src_label, dst_label), not edge type name.
  - Map edge types to multiple rel tables; add rel_tables_for_type() returning all tables for a type.
  - Update estimate_avg_degree() to aggregate across rel tables, dedupe node tables, and return 0 for unknown types.
  - Aggregate per-type edge counts in Statistics; all_edge_types() now returns unique types.
  - Add regression test for multi-label edge types; keep true duplicate-triple detection and update existing test (error shows label pair).

- **Migration**
  - Replace rel_table("TYPE") with rel_tables_for_type("TYPE") and handle zero/multiple tables (e.g., pick [0] or iterate).

<sup>Written for commit bee1dac9ad9260f71f78fa648372799468dc3b35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

