### PR TITLE
fix: add `cli` optional extra to grafeo Python package

### DIFF
--- a/crates/bindings/python/pyproject.toml
+++ b/crates/bindings/python/pyproject.toml
@@ -40,6 +40,9 @@ Repository = "https://github.com/GrafeoDB/grafeo"
 Issues = "https://github.com/GrafeoDB/grafeo/issues"
 
 [project.optional-dependencies]
+cli = [
+    "grafeo-cli>=0.5.34",
+]
 dev = [
     "pytest>=9",
     "pytest-asyncio>=1.3",


### PR DESCRIPTION
## Summary

- `uv add grafeo[cli]` (and `pip install grafeo[cli]`) silently ignores the `[cli]` extra because it's not defined in `[project.optional-dependencies]`
- Adds a `cli` extra that pulls in `grafeo-cli`, the launcher package with the bundled binary

## Details

The `grafeo-cli` package on PyPI already ships platform-specific wheels with the pre-built binary, and `uv tool install grafeo-cli` works correctly - which is great. The missing (minor) piece was the `cli` extra on the main `grafeo` package to make the `grafeo[cli]` install path work as documented.

## Test plan

- `uv add grafeo[cli]` should install both `grafeo` and `grafeo-cli`
- `grafeo --version` should work after install

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `cli` optional extra to `grafeo` so `uv add grafeo[cli]` and `pip install grafeo[cli]` also install `grafeo-cli` with the bundled binary. This fixes the previously ignored `[cli]` extra.

- **Bug Fixes**
  - Define `cli` in `[project.optional-dependencies]` as `grafeo-cli>=0.5.34`.

<sup>Written for commit 8625e79bfe7f40dad32e87104915ab11a58f20e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

