### PR TITLE
Release/0.5.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Grafeo, for future reference (and enjoyment).
 
+## [0.5.37] - Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+
 ## [0.5.36] - 2026-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,24 @@ All notable changes to Grafeo, for future reference (and enjoyment).
 
 ### Added
 
+- **SPARQL query execution overhaul**: major compliance pass closing 18 spec gaps. Composite indexes (SP, PO, OS) for O(1) two-bound and three-bound lookups. Batch insert with single-lock-per-index acquisition. Named graph CRUD (`CREATE GRAPH`, `DROP GRAPH`, `COPY`, `MOVE`, `ADD`, `CLEAR`). SPARQL UPDATE (`INSERT DATA`, `DELETE DATA`, `DELETE/INSERT WHERE`). `CONSTRUCT`, `BIND`, `OPTIONAL`, `MINUS`, `UNION`, `FILTER`, `EXISTS`/`NOT EXISTS` as semi/anti joins. 109 new W3C execution tests.
+- **Ring Index planner integration** (`ring-index`): wavelet-tree-based compact triple index wired into the SPARQL query planner. Leapfrog join operator (`RdfLeapfrogOperator`) provides worst-case optimal multi-way joins when all inputs are simple triple scans. Falls back to cascading hash joins when companion columns (LANG/DATATYPE) are needed.
+- **Ring Index persistence**: `save()`/`load()` via bincode serialization, `save_to_bytes()`/`load_from_bytes()` for container integration, `save_to_file()`/`load_from_file()` for standalone use. Comprehensive post-load validation (dictionary consistency, wavelet tree bounds, permutation lengths). `RdfRingSection` persists to `.grafeo` container during checkpoint, eliminating rebuild on restart.
+- **Dictionary encoding infrastructure**: `TermDictionary` maps RDF terms to compact u32 IDs for efficient join processing. `DictResolveOperator` converts IDs back to strings at result boundaries. Built lazily, invalidated on mutations.
+- **COUNT(\*) fast paths**: `COUNT(*)` over fully-unbound triple scans returns `store.len()` in O(1). Predicate-bound `COUNT(*)` uses per-predicate statistics. Graph-scoped `COUNT(*)` uses named graph length. Ring Index `count()` handles any partially-bound pattern in O(log sigma).
+- **RDF query optimizer**: `RdfStatistics` collector with per-predicate cardinality estimates. Cached statistics (invalidated on mutation). Cost-based join reordering for multi-way joins. Cardinality estimation for triple scan patterns.
+- **`EXPLAIN` / `EXPLAIN ANALYZE` for SPARQL**: `EXPLAIN SELECT ...` returns the physical plan tree without executing. `EXPLAIN ANALYZE SELECT ...` executes with profiling, showing actual row counts and timing per operator. Integrated into Python bindings.
+- **SPARQL WCOJ auto-detection**: `MultiWayJoin` operator detects star patterns sharing variables and routes them to Leapfrog join when the Ring Index is available, falling back to pairwise hash joins otherwise.
+
 ### Changed
 
+- **RDF store indexes upgraded to `foldhash`**: replaced `ahash` hasher with `foldhash::fast::RandomState` for all HashMap-based indexes (subject, predicate, object, SP, PO, OS).
+- **`TxId` renamed to `TransactionId`**: consistent naming across the codebase.
+
 ### Fixed
+
+- **Incremental backup could skip WAL records**: backup cursor was not advanced after incremental backup, causing duplicate replay on restore.
+- **File manager leaked temp files on checkpoint failure**: temp files are now cleaned up in the error path.
 
 ## [0.5.36] - 2026-04-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "grafeo-adapters",
  "grafeo-common",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-adapters"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "bincode",
  "grafeo-common",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-bindings-common"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "grafeo-common",
  "grafeo-engine",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-c"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "grafeo-bindings-common",
  "grafeo-common",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-cli"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "anyhow",
  "clap",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-common"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "arcstr",
  "bincode",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-core"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "arcstr",
  "bincode",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-engine"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -1355,14 +1355,14 @@ dependencies = [
 
 [[package]]
 name = "grafeo-examples"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "grafeo",
 ]
 
 [[package]]
 name = "grafeo-node"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "grafeo-adapters",
  "grafeo-bindings-common",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-python"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "grafeo-adapters",
  "grafeo-bindings-common",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-spec-tests"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "grafeo-common",
  "grafeo-engine",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-storage"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-wasm"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.4.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,6 +1498,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.36"
+version = "0.5.37"
 edition = "2024"
 rust-version = "1.91.1"
 license = "Apache-2.0"
@@ -28,13 +28,13 @@ description = "A high-performance, embeddable graph database with support for LP
 
 [workspace.dependencies]
 # Internal crates (default-features = false to allow per-crate control)
-grafeo-common = { path = "crates/grafeo-common", version = "0.5.36" }
-grafeo-core = { path = "crates/grafeo-core", version = "0.5.36", default-features = false }
-grafeo-adapters = { path = "crates/grafeo-adapters", version = "0.5.36", default-features = false }
-grafeo-storage = { path = "crates/grafeo-storage", version = "0.5.36", default-features = false }
-grafeo-engine = { path = "crates/grafeo-engine", version = "0.5.36", default-features = false }
-grafeo = { path = "crates/grafeo", version = "0.5.36" }
-grafeo-bindings-common = { path = "crates/bindings/common", version = "0.5.36", default-features = false }
+grafeo-common = { path = "crates/grafeo-common", version = "0.5.37" }
+grafeo-core = { path = "crates/grafeo-core", version = "0.5.37", default-features = false }
+grafeo-adapters = { path = "crates/grafeo-adapters", version = "0.5.37", default-features = false }
+grafeo-storage = { path = "crates/grafeo-storage", version = "0.5.37", default-features = false }
+grafeo-engine = { path = "crates/grafeo-engine", version = "0.5.37", default-features = false }
+grafeo = { path = "crates/grafeo", version = "0.5.37" }
+grafeo-bindings-common = { path = "crates/bindings/common", version = "0.5.37", default-features = false }
 
 # Error handling
 thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ crossbeam = "0.8"
 rayon = "1"
 
 # Data structures
-hashbrown = "0.16"
+hashbrown = { version = "0.16", features = ["serde"] }
 smallvec = "1"
 bumpalo = "3"
 indexmap = "2"

--- a/crates/bindings/csharp/src/Grafeo/Grafeo.csproj
+++ b/crates/bindings/csharp/src/Grafeo/Grafeo.csproj
@@ -6,7 +6,7 @@
 
     <!-- NuGet metadata -->
     <PackageId>Grafeo</PackageId>
-    <Version>0.5.36</Version>
+    <Version>0.5.37</Version>
     <Description>C# bindings for the Grafeo graph database. Supports GQL queries, ACID transactions, and vector search.</Description>
     <Authors>GrafeoDB</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/crates/bindings/dart/CHANGELOG.md
+++ b/crates/bindings/dart/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.37
+
+- Version bump to match workspace release
+
 ## 0.5.36
 
 - Version bump to match workspace release

--- a/crates/bindings/dart/README.md
+++ b/crates/bindings/dart/README.md
@@ -6,7 +6,7 @@ Dart FFI bindings for the [Grafeo](https://grafeo.dev) graph database. Wraps the
 
 ```yaml
 dependencies:
-  grafeo: ^0.5.36
+  grafeo: ^0.5.37
 ```
 
 You also need the `grafeo-c` native library for your platform. See [Building from Source](#building-from-source) below.

--- a/crates/bindings/dart/pubspec.yaml
+++ b/crates/bindings/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 name: grafeo
-version: 0.5.36
+version: 0.5.37
 description: >-
   High-performance embeddable graph database with GQL support.
   Dart bindings for grafeo-c via dart:ffi.

--- a/crates/bindings/node/index.d.ts
+++ b/crates/bindings/node/index.d.ts
@@ -84,6 +84,12 @@ export declare class GrafeoDB {
    * The original database remains unchanged.
    */
   save(path: string): void
+  /** Create a full backup of the database. */
+  backupFull(backupDir: string): void
+  /** Create an incremental backup (WAL records since last backup). */
+  backupIncremental(backupDir: string): void
+  /** Restore a database to a specific epoch from a backup chain. */
+  static restoreToEpoch(backupDir: string, epoch: number, outputPath: string): void
   /** Close the database. */
   close(): void
   /**
@@ -101,6 +107,18 @@ export declare class GrafeoDB {
   resetSchema(): void
   /** Returns the current schema name, or `null` if no schema is set. */
   currentSchema(): string | null
+  /**
+   * Creates a named graph projection. Returns `true` if created, `false`
+   * if a projection with that name already exists.
+   *
+   * A projection is a read-only, filtered view of the default graph.
+   * Only nodes with matching labels and edges with matching types are visible.
+   */
+  createProjection(name: string, nodeLabels?: Array<string> | undefined | null, edgeTypes?: Array<string> | undefined | null): boolean
+  /** Drops a named graph projection. Returns `true` if it existed. */
+  dropProjection(name: string): boolean
+  /** Returns the names of all graph projections. */
+  listProjections(): Array<string>
   /**
    * Drop a vector index for the given label and property.
    * Returns true if the index existed and was removed.
@@ -167,6 +185,20 @@ export declare class GrafeoDB {
   executeSparql(query: string, params?: any | undefined | null): Promise<QueryResult>
   /** Execute a query in a named language (e.g. `"graphql-rdf"`). */
   executeLanguage(language: string, query: string, params?: any | undefined | null): Promise<QueryResult>
+  /**
+   * Import a CSV file as graph nodes.
+   *
+   * Each row becomes a node with the given label. Column headers are used
+   * as property names. Returns the number of nodes created.
+   */
+  importCsv(path: string, options?: CsvImportOptions | undefined | null): Promise<number>
+  /**
+   * Import a JSON Lines file as graph nodes.
+   *
+   * Each line must be a valid JSON object. Object keys become property names.
+   * Returns the number of nodes created.
+   */
+  importJsonl(path: string, options?: JsonlImportOptions | undefined | null): Promise<number>
 }
 export type JsGrafeoDB = GrafeoDB
 
@@ -226,6 +258,16 @@ export declare class QueryResult {
   edges(): Array<JsEdge>
   /** Returns the result formatted as a Unicode table. */
   toString(): string
+  /**
+   * Returns the result as Arrow IPC stream bytes (Buffer).
+   *
+   * Use with the `apache-arrow` npm package:
+   * ```js
+   * import { tableFromIPC } from 'apache-arrow';
+   * const table = tableFromIPC(result.toArrowIPC());
+   * ```
+   */
+  toArrowIPC(): Buffer
   /** Get all rows as an array of arrays (no column names). */
   rows(): object
 }
@@ -260,6 +302,20 @@ export declare class Transaction {
   executeGraphql(query: string, params?: any | undefined | null): Promise<QueryResult>
   /** Execute a SPARQL query within this transaction. */
   executeSparql(query: string, params?: any | undefined | null): Promise<QueryResult>
+}
+
+/** Options for CSV import. */
+export interface CsvImportOptions {
+  /** Label to assign to created nodes (default: "Row") */
+  label?: string
+  /** Whether the first row contains headers (default: true) */
+  headers?: boolean
+}
+
+/** Options for JSON Lines import. */
+export interface JsonlImportOptions {
+  /** Label to assign to created nodes (default: "Row") */
+  label?: string
 }
 
 /** Returns the active SIMD instruction set for vector operations. */

--- a/crates/bindings/node/index.js
+++ b/crates/bindings/node/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-android-arm64')
         const bindingPackageVersion = require('@grafeo-db/js-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-android-arm-eabi')
         const bindingPackageVersion = require('@grafeo-db/js-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-win32-x64-gnu')
         const bindingPackageVersion = require('@grafeo-db/js-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-win32-x64-msvc')
         const bindingPackageVersion = require('@grafeo-db/js-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-win32-ia32-msvc')
         const bindingPackageVersion = require('@grafeo-db/js-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-win32-arm64-msvc')
         const bindingPackageVersion = require('@grafeo-db/js-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@grafeo-db/js-darwin-universal')
       const bindingPackageVersion = require('@grafeo-db/js-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-darwin-x64')
         const bindingPackageVersion = require('@grafeo-db/js-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-darwin-arm64')
         const bindingPackageVersion = require('@grafeo-db/js-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-freebsd-x64')
         const bindingPackageVersion = require('@grafeo-db/js-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-freebsd-arm64')
         const bindingPackageVersion = require('@grafeo-db/js-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-x64-musl')
           const bindingPackageVersion = require('@grafeo-db/js-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-x64-gnu')
           const bindingPackageVersion = require('@grafeo-db/js-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-arm64-musl')
           const bindingPackageVersion = require('@grafeo-db/js-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-arm64-gnu')
           const bindingPackageVersion = require('@grafeo-db/js-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-arm-musleabihf')
           const bindingPackageVersion = require('@grafeo-db/js-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@grafeo-db/js-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-loong64-musl')
           const bindingPackageVersion = require('@grafeo-db/js-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-loong64-gnu')
           const bindingPackageVersion = require('@grafeo-db/js-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-riscv64-musl')
           const bindingPackageVersion = require('@grafeo-db/js-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-riscv64-gnu')
           const bindingPackageVersion = require('@grafeo-db/js-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-linux-ppc64-gnu')
         const bindingPackageVersion = require('@grafeo-db/js-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-linux-s390x-gnu')
         const bindingPackageVersion = require('@grafeo-db/js-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-openharmony-arm64')
         const bindingPackageVersion = require('@grafeo-db/js-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-openharmony-x64')
         const bindingPackageVersion = require('@grafeo-db/js-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-openharmony-arm')
         const bindingPackageVersion = require('@grafeo-db/js-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.5.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.37' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/crates/bindings/node/npm/darwin-arm64/package.json
+++ b/crates/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js-darwin-arm64",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "os": [
     "darwin"
   ],

--- a/crates/bindings/node/npm/darwin-x64/package.json
+++ b/crates/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js-darwin-x64",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "os": [
     "darwin"
   ],

--- a/crates/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/crates/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js-linux-arm64-gnu",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "os": [
     "linux"
   ],

--- a/crates/bindings/node/npm/linux-arm64-musl/package.json
+++ b/crates/bindings/node/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js-linux-arm64-musl",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "os": [
     "linux"
   ],

--- a/crates/bindings/node/npm/linux-x64-gnu/package.json
+++ b/crates/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js-linux-x64-gnu",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "os": [
     "linux"
   ],

--- a/crates/bindings/node/npm/win32-x64-msvc/package.json
+++ b/crates/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js-win32-x64-msvc",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "os": [
     "win32"
   ],

--- a/crates/bindings/node/package.json
+++ b/crates/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "description": "Node.js/TypeScript bindings for Grafeo - a high-performance embeddable graph database",
   "main": "index.js",
   "types": "index.d.ts",
@@ -20,12 +20,12 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@grafeo-db/js-darwin-x64": "0.5.36",
-    "@grafeo-db/js-win32-x64-msvc": "0.5.36",
-    "@grafeo-db/js-linux-x64-gnu": "0.5.36",
-    "@grafeo-db/js-darwin-arm64": "0.5.36",
-    "@grafeo-db/js-linux-arm64-gnu": "0.5.36",
-    "@grafeo-db/js-linux-arm64-musl": "0.5.36"
+    "@grafeo-db/js-darwin-x64": "0.5.37",
+    "@grafeo-db/js-win32-x64-msvc": "0.5.37",
+    "@grafeo-db/js-linux-x64-gnu": "0.5.37",
+    "@grafeo-db/js-darwin-arm64": "0.5.37",
+    "@grafeo-db/js-linux-arm64-gnu": "0.5.37",
+    "@grafeo-db/js-linux-arm64-musl": "0.5.37"
   },
   "keywords": [
     "graph",

--- a/crates/bindings/python/pyproject.toml
+++ b/crates/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "grafeo"
-version = "0.5.36"
+version = "0.5.37"
 description = "A high-performance, embeddable graph database with Python bindings"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -41,7 +41,7 @@ Issues = "https://github.com/GrafeoDB/grafeo/issues"
 
 [project.optional-dependencies]
 cli = [
-    "grafeo-cli>=0.5.36,<0.6",
+    "grafeo-cli>=0.5.37,<0.6",
 ]
 dev = [
     "pytest>=9",

--- a/crates/bindings/python/src/database.rs
+++ b/crates/bindings/python/src/database.rs
@@ -491,6 +491,7 @@ impl PyGrafeoDB {
     /// Return the physical execution plan for a SPARQL query without executing it.
     ///
     /// Equivalent to ``db.execute_sparql("EXPLAIN " + query)``.
+    #[cfg(feature = "sparql")]
     #[pyo3(signature = (query, params=None))]
     fn explain_sparql(
         &self,

--- a/crates/bindings/python/src/database.rs
+++ b/crates/bindings/python/src/database.rs
@@ -488,6 +488,18 @@ impl PyGrafeoDB {
         self.execute_language_impl("sparql", query, params)
     }
 
+    /// Return the physical execution plan for a SPARQL query without executing it.
+    ///
+    /// Equivalent to ``db.execute_sparql("EXPLAIN " + query)``.
+    #[pyo3(signature = (query, params=None))]
+    fn explain_sparql(
+        &self,
+        query: &str,
+        params: Option<&Bound<'_, pyo3::types::PyDict>>,
+    ) -> PyResult<PyQueryResult> {
+        self.execute_language_impl("sparql", &format!("EXPLAIN {query}"), params)
+    }
+
     /// Execute a query in a named language (e.g. `"graphql-rdf"`).
     #[pyo3(signature = (language, query, params=None))]
     fn execute_language(

--- a/crates/bindings/wasm/package-lite.json
+++ b/crates/bindings/wasm/package-lite.json
@@ -1,7 +1,7 @@
 {
   "name": "@grafeo-db/wasm-lite",
   "type": "module",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "description": "WebAssembly bindings for Grafeo - GQL-only lightweight variant",
   "keywords": [
     "graph",

--- a/crates/bindings/wasm/package.json
+++ b/crates/bindings/wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grafeo-db/wasm",
   "type": "module",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "description": "WebAssembly bindings for Grafeo - a high-performance embeddable graph database",
   "keywords": [
     "graph",

--- a/crates/grafeo-core/Cargo.toml
+++ b/crates/grafeo-core/Cargo.toml
@@ -53,6 +53,7 @@ crc32fast.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
+serde_json = "1"
 tempfile.workspace = true
 
 [features]

--- a/crates/grafeo-core/src/codec/bitvec.rs
+++ b/crates/grafeo-core/src/codec/bitvec.rs
@@ -23,7 +23,7 @@ use std::io;
 ///
 /// Supports bitwise operations ([`and`](Self::and), [`or`](Self::or),
 /// [`not`](Self::not)) for combining filter results efficiently.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct BitVector {
     /// Packed bits (little-endian within each word).
     data: Vec<u64>,

--- a/crates/grafeo-core/src/codec/bitvec.rs
+++ b/crates/grafeo-core/src/codec/bitvec.rs
@@ -19,16 +19,103 @@
 
 use std::io;
 
+use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
+
 /// Stores booleans as individual bits - 8x smaller than `Vec<bool>`.
 ///
 /// Supports bitwise operations ([`and`](Self::and), [`or`](Self::or),
 /// [`not`](Self::not)) for combining filter results efficiently.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct BitVector {
     /// Packed bits (little-endian within each word).
     data: Vec<u64>,
     /// Number of bits stored.
     len: usize,
+}
+
+impl<'de> Deserialize<'de> for BitVector {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Data,
+            Len,
+        }
+
+        struct BitVectorVisitor;
+
+        impl<'de> Visitor<'de> for BitVectorVisitor {
+            type Value = BitVector;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct BitVector with consistent data and len fields")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<BitVector, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let data: Vec<u64> = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let len: usize = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                validate_bitvec(len, &data).map_err(de::Error::custom)
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<BitVector, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut data: Option<Vec<u64>> = None;
+                let mut len: Option<usize> = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Data => {
+                            if data.is_some() {
+                                return Err(de::Error::duplicate_field("data"));
+                            }
+                            data = Some(map.next_value()?);
+                        }
+                        Field::Len => {
+                            if len.is_some() {
+                                return Err(de::Error::duplicate_field("len"));
+                            }
+                            len = Some(map.next_value()?);
+                        }
+                    }
+                }
+
+                let data = data.ok_or_else(|| de::Error::missing_field("data"))?;
+                let len = len.ok_or_else(|| de::Error::missing_field("len"))?;
+                validate_bitvec(len, &data).map_err(de::Error::custom)
+            }
+        }
+
+        const FIELDS: &[&str] = &["data", "len"];
+        deserializer.deserialize_struct("BitVector", FIELDS, BitVectorVisitor)
+    }
+}
+
+/// Validates that `len` and `data` are consistent, returning a valid
+/// `BitVector` or an error message.
+fn validate_bitvec(len: usize, data: &[u64]) -> Result<BitVector, String> {
+    let expected_words = (len + 63) / 64;
+    if data.len() != expected_words {
+        return Err(format!(
+            "BitVector invariant violated: len={len} requires {expected_words} words, but data contains {} words",
+            data.len()
+        ));
+    }
+    Ok(BitVector {
+        data: data.to_vec(),
+        len,
+    })
 }
 
 impl BitVector {

--- a/crates/grafeo-core/src/codec/succinct/rank_select.rs
+++ b/crates/grafeo-core/src/codec/succinct/rank_select.rs
@@ -50,7 +50,7 @@ const SELECT_SAMPLE_RATE: usize = 4096;
 /// // Find position of 50th 1-bit (0-indexed)
 /// assert_eq!(sbv.select1(49), Some(245));
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SuccinctBitVector {
     /// Underlying bit storage.
     inner: BitVector,

--- a/crates/grafeo-core/src/codec/succinct/rank_select.rs
+++ b/crates/grafeo-core/src/codec/succinct/rank_select.rs
@@ -50,7 +50,7 @@ const SELECT_SAMPLE_RATE: usize = 4096;
 /// // Find position of 50th 1-bit (0-indexed)
 /// assert_eq!(sbv.select1(49), Some(245));
 /// ```
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct SuccinctBitVector {
     /// Underlying bit storage.
     inner: BitVector,
@@ -73,6 +73,37 @@ pub struct SuccinctBitVector {
 
     /// Total number of 1-bits (cached for efficiency).
     ones_count: usize,
+}
+
+/// Custom deserialization that accepts the full serialized format (for backward
+/// compatibility) but rebuilds all auxiliary index structures from the raw bit
+/// data. This prevents crafted input from producing inconsistent rank/select
+/// caches that could cause panics or incorrect results.
+impl<'de> serde::Deserialize<'de> for SuccinctBitVector {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        /// Helper struct that mirrors the serialized layout so existing data
+        /// round-trips correctly. The cached fields are read and discarded.
+        #[derive(serde::Deserialize)]
+        struct Raw {
+            inner: BitVector,
+            #[allow(dead_code)]
+            superblock_ranks: Vec<u32>,
+            #[allow(dead_code)]
+            block_ranks: Vec<u8>,
+            #[allow(dead_code)]
+            select1_samples: Vec<u32>,
+            #[allow(dead_code)]
+            select0_samples: Vec<u32>,
+            #[allow(dead_code)]
+            ones_count: usize,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        Ok(Self::from_bitvec(raw.inner))
+    }
 }
 
 impl SuccinctBitVector {

--- a/crates/grafeo-core/src/codec/succinct/wavelet.rs
+++ b/crates/grafeo-core/src/codec/succinct/wavelet.rs
@@ -40,7 +40,7 @@ use super::rank_select::SuccinctBitVector;
 ///
 /// Supports sequences of u64 symbols. Internally builds a binary tree
 /// of bitvectors, one level per bit of the alphabet encoding.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct WaveletTree {
     /// Bitvectors at each level of the tree.
     /// Level 0 is the root, level h-1 is the leaves.

--- a/crates/grafeo-core/src/codec/succinct/wavelet.rs
+++ b/crates/grafeo-core/src/codec/succinct/wavelet.rs
@@ -351,6 +351,103 @@ impl WaveletTree {
     pub fn iter(&self) -> impl Iterator<Item = (usize, u64)> + '_ {
         (0..self.len).map(move |i| (i, self.access(i)))
     }
+
+    /// Validates structural invariants after deserialization.
+    ///
+    /// Checks that:
+    /// - `levels.len()` equals `height`
+    /// - `symbols.len()` equals `sigma`
+    /// - `symbol_to_code` is consistent with `symbols`
+    /// - `height` is consistent with `sigma`
+    /// - Each level bitvector has the expected length
+    ///
+    /// # Errors
+    ///
+    /// Returns a description of the first violated invariant.
+    pub fn validate(&self) -> Result<(), String> {
+        // Empty tree: all fields should be zero/empty
+        if self.len == 0 {
+            if self.height != 0 {
+                return Err(format!("empty tree has non-zero height {}", self.height));
+            }
+            if self.sigma != 0 {
+                return Err(format!("empty tree has non-zero sigma {}", self.sigma));
+            }
+            if !self.levels.is_empty() {
+                return Err(format!("empty tree has {} levels", self.levels.len()));
+            }
+            if !self.symbols.is_empty() {
+                return Err(format!("empty tree has {} symbols", self.symbols.len()));
+            }
+            return Ok(());
+        }
+
+        // Non-empty tree checks
+        if self.levels.len() != self.height {
+            return Err(format!(
+                "levels count {} != height {}",
+                self.levels.len(),
+                self.height
+            ));
+        }
+
+        if self.symbols.len() != self.sigma as usize {
+            return Err(format!(
+                "symbols count {} != sigma {}",
+                self.symbols.len(),
+                self.sigma
+            ));
+        }
+
+        if self.symbol_to_code.len() != self.symbols.len() {
+            return Err(format!(
+                "symbol_to_code size {} != symbols count {}",
+                self.symbol_to_code.len(),
+                self.symbols.len()
+            ));
+        }
+
+        // Height must be consistent with sigma
+        let expected_height = if self.sigma <= 1 {
+            1
+        } else {
+            64 - (self.sigma - 1).leading_zeros() as usize
+        };
+        if self.height != expected_height {
+            return Err(format!(
+                "height {} inconsistent with sigma {} (expected {expected_height})",
+                self.height, self.sigma
+            ));
+        }
+
+        // Each level bitvector must have the same length as the sequence
+        for (i, bv) in self.levels.iter().enumerate() {
+            if bv.len() != self.len {
+                return Err(format!(
+                    "level {i} bitvector length {} != sequence length {}",
+                    bv.len(),
+                    self.len
+                ));
+            }
+        }
+
+        // Verify symbol_to_code maps each symbol to a valid code in [0, sigma)
+        for (i, &sym) in self.symbols.iter().enumerate() {
+            match self.symbol_to_code.get(&sym) {
+                Some(&code) if code == i as u64 => {}
+                Some(&code) => {
+                    return Err(format!("symbol_to_code[{sym}] = {code}, expected {i}"));
+                }
+                None => {
+                    return Err(format!(
+                        "symbol {sym} at index {i} missing from symbol_to_code"
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -523,5 +620,30 @@ mod tests {
 
         assert_eq!(wt.count(1_000_000), 2);
         assert_eq!(wt.rank(1_000_000, 3), 2);
+    }
+
+    #[test]
+    fn test_validate_empty() {
+        let wt = WaveletTree::new(&[]);
+        assert!(wt.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_non_empty() {
+        let wt = WaveletTree::new(&[0, 1, 0, 2, 1, 0, 2, 2]);
+        assert!(wt.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_single_symbol() {
+        let wt = WaveletTree::new(&[7, 7, 7]);
+        assert!(wt.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_large_alphabet() {
+        let seq: Vec<u64> = (0..100).map(|i| i * 7 % 50).collect();
+        let wt = WaveletTree::new(&seq);
+        assert!(wt.validate().is_ok());
     }
 }

--- a/crates/grafeo-core/src/graph/rdf/dictionary.rs
+++ b/crates/grafeo-core/src/graph/rdf/dictionary.rs
@@ -1,0 +1,114 @@
+//! Term dictionary for dictionary-encoded triple scans.
+//!
+//! Maps RDF `Term` values to compact `u32` IDs for efficient join processing.
+//! During query execution, triple scans emit integer term IDs instead of strings,
+//! and a `DictResolve` step at the result boundary converts them back.
+
+use super::term::Term;
+use hashbrown::HashMap;
+
+/// Bidirectional mapping between RDF terms and compact integer IDs.
+///
+/// Built lazily on first query (or during `collect_statistics`). Invalidated
+/// by any store mutation so the planner falls back to string columns.
+#[derive(Debug, Clone)]
+pub struct TermDictionary {
+    term_to_id: HashMap<Term, u32>,
+    id_to_term: Vec<Term>,
+}
+
+impl TermDictionary {
+    /// Creates an empty dictionary.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            term_to_id: HashMap::new(),
+            id_to_term: Vec::new(),
+        }
+    }
+
+    /// Creates a dictionary pre-sized for the given capacity.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            term_to_id: HashMap::with_capacity(capacity),
+            id_to_term: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Inserts a term and returns its ID. If the term already exists, returns
+    /// the existing ID.
+    pub fn get_or_insert(&mut self, term: &Term) -> u32 {
+        if let Some(&id) = self.term_to_id.get(term) {
+            return id;
+        }
+        let id = self.id_to_term.len() as u32;
+        self.id_to_term.push(term.clone());
+        self.term_to_id.insert(term.clone(), id);
+        id
+    }
+
+    /// Looks up the ID for a term, returning `None` if unknown.
+    #[must_use]
+    pub fn get_id(&self, term: &Term) -> Option<u32> {
+        self.term_to_id.get(term).copied()
+    }
+
+    /// Resolves a term ID back to the original term.
+    #[must_use]
+    pub fn get_term(&self, id: u32) -> Option<&Term> {
+        self.id_to_term.get(id as usize)
+    }
+
+    /// Returns the number of distinct terms in the dictionary.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.id_to_term.len()
+    }
+
+    /// Returns true if the dictionary is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.id_to_term.is_empty()
+    }
+}
+
+impl Default for TermDictionary {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let mut dict = TermDictionary::new();
+        let t1 = Term::iri("http://example.org/alix");
+        let t2 = Term::literal("Alix");
+        let t3 = Term::iri("http://example.org/gus");
+
+        let id1 = dict.get_or_insert(&t1);
+        let id2 = dict.get_or_insert(&t2);
+        let id3 = dict.get_or_insert(&t3);
+
+        assert_ne!(id1, id2);
+        assert_ne!(id2, id3);
+        assert_eq!(dict.get_or_insert(&t1), id1, "same term returns same ID");
+
+        assert_eq!(dict.get_term(id1), Some(&t1));
+        assert_eq!(dict.get_term(id2), Some(&t2));
+        assert_eq!(dict.get_term(id3), Some(&t3));
+        assert_eq!(dict.get_id(&t1), Some(id1));
+        assert_eq!(dict.len(), 3);
+    }
+
+    #[test]
+    fn unknown_term_returns_none() {
+        let dict = TermDictionary::new();
+        assert_eq!(dict.get_id(&Term::iri("http://unknown")), None);
+        assert_eq!(dict.get_term(999), None);
+    }
+}

--- a/crates/grafeo-core/src/graph/rdf/dictionary.rs
+++ b/crates/grafeo-core/src/graph/rdf/dictionary.rs
@@ -111,4 +111,50 @@ mod tests {
         assert_eq!(dict.get_id(&Term::iri("http://unknown")), None);
         assert_eq!(dict.get_term(999), None);
     }
+
+    #[test]
+    fn with_capacity_works() {
+        let dict = TermDictionary::with_capacity(100);
+        assert!(dict.is_empty());
+        assert_eq!(dict.len(), 0);
+    }
+
+    #[test]
+    fn default_creates_empty() {
+        let dict = TermDictionary::default();
+        assert!(dict.is_empty());
+    }
+
+    #[test]
+    fn stable_ids_across_inserts() {
+        let mut dict = TermDictionary::new();
+        let t1 = Term::iri("http://example.org/a");
+        let t2 = Term::literal("value");
+        let id1 = dict.get_or_insert(&t1);
+        let id2 = dict.get_or_insert(&t2);
+        // IDs should be sequential starting from 0
+        assert_eq!(id1, 0);
+        assert_eq!(id2, 1);
+        // Re-insert should return same IDs
+        assert_eq!(dict.get_or_insert(&t1), 0);
+        assert_eq!(dict.get_or_insert(&t2), 1);
+        assert_eq!(dict.len(), 2);
+    }
+
+    #[test]
+    fn mixed_term_types() {
+        let mut dict = TermDictionary::new();
+        let iri = Term::iri("http://example.org/x");
+        let lit = Term::literal("hello");
+        let blank = Term::blank("b0");
+        let lang = Term::lang_literal("bonjour".to_string(), "fr".to_string());
+        dict.get_or_insert(&iri);
+        dict.get_or_insert(&lit);
+        dict.get_or_insert(&blank);
+        dict.get_or_insert(&lang);
+        assert_eq!(dict.len(), 4);
+        assert!(dict.get_id(&iri).is_some());
+        assert!(dict.get_id(&blank).is_some());
+        assert!(dict.get_id(&lang).is_some());
+    }
 }

--- a/crates/grafeo-core/src/graph/rdf/mod.rs
+++ b/crates/grafeo-core/src/graph/rdf/mod.rs
@@ -34,6 +34,7 @@
 //! }
 //! ```
 
+mod dictionary;
 mod graph_store_adapter;
 pub mod nquads;
 pub mod section;
@@ -43,6 +44,7 @@ mod term;
 mod triple;
 pub mod turtle;
 
+pub use dictionary::TermDictionary;
 pub use graph_store_adapter::RdfGraphStoreAdapter;
 pub use section::RdfStoreSection;
 pub use sink::{BatchInsertSink, CountSink, TripleSink, VecSink};

--- a/crates/grafeo-core/src/graph/rdf/store.rs
+++ b/crates/grafeo-core/src/graph/rdf/store.rs
@@ -692,6 +692,14 @@ impl RdfStore {
             .store(false, std::sync::atomic::Ordering::Relaxed);
     }
 
+    /// Sets the Ring Index directly (used during container deserialization).
+    #[cfg(feature = "ring-index")]
+    pub fn set_ring(&self, ring: crate::index::ring::TripleRing) {
+        *self.ring.write() = Some(Arc::new(ring));
+        self.ring_stale
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+    }
+
     // =========================================================================
     // Bulk loading
     // =========================================================================

--- a/crates/grafeo-core/src/graph/rdf/store.rs
+++ b/crates/grafeo-core/src/graph/rdf/store.rs
@@ -84,6 +84,8 @@ pub struct RdfStore {
     named_graphs: RwLock<HashMap<String, Arc<RdfStore>>>,
     /// Cached RDF statistics for query optimization. Invalidated on any mutation.
     statistics_cache: RwLock<Option<Arc<crate::statistics::RdfStatistics>>>,
+    /// Cached term dictionary for dictionary-encoded triple scans. Invalidated on any mutation.
+    dictionary_cache: RwLock<Option<Arc<super::dictionary::TermDictionary>>>,
 }
 
 impl RdfStore {
@@ -129,6 +131,7 @@ impl RdfStore {
             tx_buffer: RwLock::new(TransactionBuffer::default()),
             named_graphs: RwLock::new(HashMap::new()),
             statistics_cache: RwLock::new(None),
+            dictionary_cache: RwLock::new(None),
             config,
         }
     }
@@ -603,9 +606,45 @@ impl RdfStore {
         stats
     }
 
-    /// Invalidates the cached RDF statistics. Called after any mutation.
+    /// Invalidates the cached RDF statistics and term dictionary. Called after any mutation.
     fn invalidate_statistics_cache(&self) {
         *self.statistics_cache.write() = None;
+        *self.dictionary_cache.write() = None;
+    }
+
+    /// Returns a cached term dictionary, building it on first call.
+    ///
+    /// The dictionary maps each unique `Term` in the store to a compact `u32` ID.
+    /// It is invalidated by any mutation (insert, delete, bulk load).
+    #[must_use]
+    pub fn get_or_build_dictionary(&self) -> Arc<super::dictionary::TermDictionary> {
+        // Fast path: return cached dictionary
+        {
+            let cache = self.dictionary_cache.read();
+            if let Some(dict) = cache.as_ref() {
+                return Arc::clone(dict);
+            }
+        }
+
+        // Slow path: build dictionary from all triples
+        let triples = self.triples.read();
+        let mut dict =
+            super::dictionary::TermDictionary::with_capacity(triples.len().saturating_mul(3));
+        for triple in triples.iter() {
+            dict.get_or_insert(triple.subject());
+            dict.get_or_insert(triple.predicate());
+            dict.get_or_insert(triple.object());
+        }
+
+        let dict = Arc::new(dict);
+        *self.dictionary_cache.write() = Some(Arc::clone(&dict));
+        dict
+    }
+
+    /// Returns the cached term dictionary if it exists, without building it.
+    #[must_use]
+    pub fn term_dictionary(&self) -> Option<Arc<super::dictionary::TermDictionary>> {
+        self.dictionary_cache.read().clone()
     }
 
     // =========================================================================

--- a/crates/grafeo-core/src/graph/rdf/store.rs
+++ b/crates/grafeo-core/src/graph/rdf/store.rs
@@ -624,8 +624,11 @@ impl RdfStore {
         *self.statistics_cache.write() = None;
         *self.dictionary_cache.write() = None;
         #[cfg(feature = "ring-index")]
-        self.ring_stale
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        {
+            self.ring_stale
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            *self.ring.write() = None;
+        }
     }
 
     /// Returns a cached term dictionary, building it on first call.
@@ -794,6 +797,9 @@ impl RdfStore {
         let stats = stats_collector.build();
         // Cache the freshly-computed statistics from the bulk load pass.
         *self.statistics_cache.write() = Some(Arc::new(stats.clone()));
+        // Invalidate the dictionary cache: the old dictionary mapped terms
+        // from the previous dataset, not the newly loaded one.
+        *self.dictionary_cache.write() = None;
 
         // Build Ring Index automatically during bulk load (when feature is enabled).
         #[cfg(feature = "ring-index")]
@@ -2402,5 +2408,161 @@ this is not valid ntriples
             object: None,
         };
         assert_eq!(ring.count(&alix_pattern), 2);
+    }
+
+    #[test]
+    fn test_batch_insert_composite_indexes() {
+        let store = RdfStore::new();
+        let triples = vec![
+            Triple::new(
+                Term::iri("http://ex.org/alix"),
+                Term::iri("http://ex.org/name"),
+                Term::literal("Alix"),
+            ),
+            Triple::new(
+                Term::iri("http://ex.org/gus"),
+                Term::iri("http://ex.org/name"),
+                Term::literal("Gus"),
+            ),
+            Triple::new(
+                Term::iri("http://ex.org/alix"),
+                Term::iri("http://ex.org/age"),
+                Term::typed_literal("30", "http://www.w3.org/2001/XMLSchema#integer"),
+            ),
+        ];
+        let inserted = store.batch_insert(triples);
+        assert_eq!(inserted, 3);
+        assert_eq!(store.len(), 3);
+
+        // Verify composite indexes via find
+        let sp_result = store.find(&TriplePattern {
+            subject: Some(Term::iri("http://ex.org/alix")),
+            predicate: Some(Term::iri("http://ex.org/name")),
+            object: None,
+        });
+        assert_eq!(sp_result.len(), 1);
+        let po_result = store.find(&TriplePattern {
+            subject: None,
+            predicate: Some(Term::iri("http://ex.org/name")),
+            object: Some(Term::literal("Gus")),
+        });
+        assert_eq!(po_result.len(), 1);
+        let os_result = store.find(&TriplePattern {
+            subject: Some(Term::iri("http://ex.org/alix")),
+            predicate: None,
+            object: Some(Term::literal("Alix")),
+        });
+        assert_eq!(os_result.len(), 1);
+    }
+
+    #[test]
+    fn test_batch_insert_deduplication() {
+        let store = RdfStore::new();
+        let triple = Triple::new(
+            Term::iri("http://ex.org/a"),
+            Term::iri("http://ex.org/b"),
+            Term::literal("c"),
+        );
+        let inserted = store.batch_insert(vec![triple.clone(), triple.clone(), triple]);
+        assert_eq!(inserted, 1);
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn test_composite_index_after_remove() {
+        let store = RdfStore::new();
+        let t1 = Triple::new(
+            Term::iri("http://ex.org/a"),
+            Term::iri("http://ex.org/p"),
+            Term::literal("v1"),
+        );
+        let t2 = Triple::new(
+            Term::iri("http://ex.org/a"),
+            Term::iri("http://ex.org/p"),
+            Term::literal("v2"),
+        );
+        store.insert(t1.clone());
+        store.insert(t2);
+        assert_eq!(
+            store
+                .find(&TriplePattern {
+                    subject: Some(Term::iri("http://ex.org/a")),
+                    predicate: Some(Term::iri("http://ex.org/p")),
+                    object: None
+                })
+                .len(),
+            2
+        );
+        store.remove(&t1);
+        assert_eq!(
+            store
+                .find(&TriplePattern {
+                    subject: Some(Term::iri("http://ex.org/a")),
+                    predicate: Some(Term::iri("http://ex.org/p")),
+                    object: None
+                })
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_named_graph_operations() {
+        let store = RdfStore::new();
+        assert!(store.create_graph("http://ex.org/g1"));
+        assert!(!store.create_graph("http://ex.org/g1")); // already exists
+        let g = store.graph("http://ex.org/g1").unwrap();
+        g.insert(Triple::new(
+            Term::iri("http://ex.org/a"),
+            Term::iri("http://ex.org/b"),
+            Term::literal("c"),
+        ));
+        assert_eq!(g.len(), 1);
+        assert!(store.drop_graph("http://ex.org/g1"));
+        assert!(store.graph("http://ex.org/g1").is_none());
+    }
+
+    #[test]
+    fn test_statistics_cache_invalidation() {
+        let store = RdfStore::new();
+        store.insert(Triple::new(
+            Term::iri("http://ex.org/a"),
+            Term::iri("http://ex.org/p"),
+            Term::literal("v"),
+        ));
+        let stats1 = store.get_or_collect_statistics();
+        // Term::iri.to_string() produces "<http://ex.org/p>"
+        assert!(stats1.get_predicate("<http://ex.org/p>").is_some());
+        // Insert more data: cache should be invalidated
+        store.insert(Triple::new(
+            Term::iri("http://ex.org/b"),
+            Term::iri("http://ex.org/q"),
+            Term::literal("w"),
+        ));
+        let stats2 = store.get_or_collect_statistics();
+        assert!(stats2.get_predicate("<http://ex.org/q>").is_some());
+    }
+
+    #[test]
+    fn test_find_three_bound() {
+        let store = RdfStore::new();
+        let t = Triple::new(
+            Term::iri("http://ex.org/a"),
+            Term::iri("http://ex.org/p"),
+            Term::literal("v"),
+        );
+        store.insert(t.clone());
+        store.insert(Triple::new(
+            Term::iri("http://ex.org/a"),
+            Term::iri("http://ex.org/p"),
+            Term::literal("other"),
+        ));
+        let result = store.find(&TriplePattern {
+            subject: Some(Term::iri("http://ex.org/a")),
+            predicate: Some(Term::iri("http://ex.org/p")),
+            object: Some(Term::literal("v")),
+        });
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].as_ref(), &t);
     }
 }

--- a/crates/grafeo-core/src/graph/rdf/store.rs
+++ b/crates/grafeo-core/src/graph/rdf/store.rs
@@ -86,6 +86,14 @@ pub struct RdfStore {
     statistics_cache: RwLock<Option<Arc<crate::statistics::RdfStatistics>>>,
     /// Cached term dictionary for dictionary-encoded triple scans. Invalidated on any mutation.
     dictionary_cache: RwLock<Option<Arc<super::dictionary::TermDictionary>>>,
+    /// Compact Ring Index for SPARQL query acceleration. Built during `bulk_load()`
+    /// or explicitly via `rebuild_ring()`. Marked stale on incremental mutations,
+    /// falling back to HashMap indexes until rebuilt.
+    #[cfg(feature = "ring-index")]
+    ring: RwLock<Option<Arc<crate::index::ring::TripleRing>>>,
+    /// Whether the Ring is stale (triples changed since last build).
+    #[cfg(feature = "ring-index")]
+    ring_stale: std::sync::atomic::AtomicBool,
 }
 
 impl RdfStore {
@@ -132,6 +140,10 @@ impl RdfStore {
             named_graphs: RwLock::new(HashMap::new()),
             statistics_cache: RwLock::new(None),
             dictionary_cache: RwLock::new(None),
+            #[cfg(feature = "ring-index")]
+            ring: RwLock::new(None),
+            #[cfg(feature = "ring-index")]
+            ring_stale: std::sync::atomic::AtomicBool::new(false),
             config,
         }
     }
@@ -610,6 +622,9 @@ impl RdfStore {
     fn invalidate_statistics_cache(&self) {
         *self.statistics_cache.write() = None;
         *self.dictionary_cache.write() = None;
+        #[cfg(feature = "ring-index")]
+        self.ring_stale
+            .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Returns a cached term dictionary, building it on first call.
@@ -645,6 +660,36 @@ impl RdfStore {
     #[must_use]
     pub fn term_dictionary(&self) -> Option<Arc<super::dictionary::TermDictionary>> {
         self.dictionary_cache.read().clone()
+    }
+
+    /// Returns the Ring Index if it exists and is not stale.
+    #[cfg(feature = "ring-index")]
+    #[must_use]
+    pub fn ring(&self) -> Option<Arc<crate::index::ring::TripleRing>> {
+        if self.ring_stale.load(std::sync::atomic::Ordering::Relaxed) {
+            return None;
+        }
+        self.ring.read().clone()
+    }
+
+    /// Builds or rebuilds the Ring Index from current triples.
+    ///
+    /// The Ring provides ~3x memory reduction and O(log sigma) pattern counting.
+    /// It is automatically built during `bulk_load()` and can be rebuilt
+    /// explicitly after incremental mutations.
+    #[cfg(feature = "ring-index")]
+    pub fn rebuild_ring(&self) {
+        let triples = self.triples.read();
+        if triples.is_empty() {
+            *self.ring.write() = None;
+            return;
+        }
+        let ring = crate::index::ring::TripleRing::from_triples(
+            triples.iter().map(|t| t.as_ref().clone()),
+        );
+        *self.ring.write() = Some(Arc::new(ring));
+        self.ring_stale
+            .store(false, std::sync::atomic::Ordering::Relaxed);
     }
 
     // =========================================================================
@@ -740,6 +785,18 @@ impl RdfStore {
         let stats = stats_collector.build();
         // Cache the freshly-computed statistics from the bulk load pass.
         *self.statistics_cache.write() = Some(Arc::new(stats.clone()));
+
+        // Build Ring Index automatically during bulk load (when feature is enabled).
+        #[cfg(feature = "ring-index")]
+        {
+            let ring = crate::index::ring::TripleRing::from_triples(
+                self.triples.read().iter().map(|t| t.as_ref().clone()),
+            );
+            *self.ring.write() = Some(Arc::new(ring));
+            self.ring_stale
+                .store(false, std::sync::atomic::Ordering::Relaxed);
+        }
+
         BulkLoadResult {
             triple_count: count,
             statistics: stats,
@@ -2231,5 +2288,110 @@ this is not valid ntriples
         // 1 (alix address _:b) + 2 (city, country) = 3
         assert_eq!(count, 3);
         assert_eq!(store.len(), 3);
+    }
+
+    #[test]
+    #[cfg(feature = "ring-index")]
+    fn test_ring_built_during_bulk_load() {
+        let store = RdfStore::new();
+        assert!(
+            store.ring().is_none(),
+            "ring should not exist before bulk load"
+        );
+
+        store.bulk_load(vec![
+            Triple::new(
+                Term::iri("http://ex.org/alix"),
+                Term::iri("http://ex.org/knows"),
+                Term::iri("http://ex.org/gus"),
+            ),
+            Triple::new(
+                Term::iri("http://ex.org/gus"),
+                Term::iri("http://ex.org/knows"),
+                Term::iri("http://ex.org/alix"),
+            ),
+        ]);
+
+        let ring = store.ring().expect("ring should exist after bulk load");
+        assert_eq!(ring.len(), 2);
+    }
+
+    #[test]
+    #[cfg(feature = "ring-index")]
+    fn test_ring_stale_after_insert() {
+        let store = RdfStore::new();
+        store.bulk_load(vec![Triple::new(
+            Term::iri("http://ex.org/a"),
+            Term::iri("http://ex.org/p"),
+            Term::iri("http://ex.org/b"),
+        )]);
+        assert!(store.ring().is_some());
+
+        // Incremental insert marks ring stale
+        store.insert(Triple::new(
+            Term::iri("http://ex.org/c"),
+            Term::iri("http://ex.org/p"),
+            Term::iri("http://ex.org/d"),
+        ));
+        assert!(
+            store.ring().is_none(),
+            "ring should be stale after incremental insert"
+        );
+
+        // Rebuild restores ring
+        store.rebuild_ring();
+        let ring = store.ring().expect("ring should exist after rebuild");
+        assert_eq!(ring.len(), 2);
+    }
+
+    #[test]
+    #[cfg(feature = "ring-index")]
+    fn test_ring_find_matches_store_find() {
+        let triples = vec![
+            Triple::new(
+                Term::iri("http://ex.org/alix"),
+                Term::iri("http://xmlns.com/foaf/0.1/name"),
+                Term::literal("Alix"),
+            ),
+            Triple::new(
+                Term::iri("http://ex.org/gus"),
+                Term::iri("http://xmlns.com/foaf/0.1/name"),
+                Term::literal("Gus"),
+            ),
+            Triple::new(
+                Term::iri("http://ex.org/alix"),
+                Term::iri("http://xmlns.com/foaf/0.1/knows"),
+                Term::iri("http://ex.org/gus"),
+            ),
+        ];
+
+        let store = RdfStore::new();
+        store.bulk_load(triples);
+
+        let ring = store.ring().expect("ring should exist");
+
+        // Fully unbound: ring.count should match store.len
+        let all_pattern = TriplePattern {
+            subject: None,
+            predicate: None,
+            object: None,
+        };
+        assert_eq!(ring.count(&all_pattern), store.len());
+
+        // Predicate-bound: count names
+        let name_pattern = TriplePattern {
+            subject: None,
+            predicate: Some(Term::iri("http://xmlns.com/foaf/0.1/name")),
+            object: None,
+        };
+        assert_eq!(ring.count(&name_pattern), 2);
+
+        // Subject-bound: triples about alix
+        let alix_pattern = TriplePattern {
+            subject: Some(Term::iri("http://ex.org/alix")),
+            predicate: None,
+            object: None,
+        };
+        assert_eq!(ring.count(&alix_pattern), 2);
     }
 }

--- a/crates/grafeo-core/src/graph/rdf/store.rs
+++ b/crates/grafeo-core/src/graph/rdf/store.rs
@@ -564,6 +564,7 @@ impl RdfStore {
         self.sp_index.write().clear();
         self.po_index.write().clear();
         self.os_index.write().clear();
+        self.invalidate_statistics_cache();
     }
 
     /// Returns store statistics.

--- a/crates/grafeo-core/src/index/ring/mod.rs
+++ b/crates/grafeo-core/src/index/ring/mod.rs
@@ -47,8 +47,10 @@
 
 mod leapfrog;
 mod permutation;
+pub mod section;
 mod triple_ring;
 
 pub use leapfrog::{AnnotatedPattern, LeapfrogRing, RingIterator};
 pub use permutation::SuccinctPermutation;
+pub use section::RdfRingSection;
 pub use triple_ring::TripleRing;

--- a/crates/grafeo-core/src/index/ring/mod.rs
+++ b/crates/grafeo-core/src/index/ring/mod.rs
@@ -49,6 +49,6 @@ mod leapfrog;
 mod permutation;
 mod triple_ring;
 
-pub use leapfrog::{LeapfrogRing, RingIterator};
+pub use leapfrog::{AnnotatedPattern, LeapfrogRing, RingIterator};
 pub use permutation::SuccinctPermutation;
 pub use triple_ring::TripleRing;

--- a/crates/grafeo-core/src/index/ring/permutation.rs
+++ b/crates/grafeo-core/src/index/ring/permutation.rs
@@ -12,7 +12,7 @@
 ///
 /// Stores both forward and inverse mappings for O(1) access.
 /// Uses 2n * 32 bits = 8n bytes for n elements.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct SuccinctPermutation {
     /// The number of elements in the permutation.
     n: usize,
@@ -22,6 +22,92 @@ pub struct SuccinctPermutation {
 
     /// Inverse mapping: inverse[j] = π⁻¹(j)
     inverse: Vec<u32>,
+}
+
+impl<'de> serde::Deserialize<'de> for SuccinctPermutation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        #[derive(serde::Deserialize)]
+        struct Raw {
+            n: usize,
+            forward: Vec<u32>,
+            inverse: Vec<u32>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+
+        // Validate that n matches both array lengths
+        if raw.forward.len() != raw.n {
+            return Err(D::Error::custom(format!(
+                "forward length {} does not match n {}",
+                raw.forward.len(),
+                raw.n
+            )));
+        }
+        if raw.inverse.len() != raw.n {
+            return Err(D::Error::custom(format!(
+                "inverse length {} does not match n {}",
+                raw.inverse.len(),
+                raw.n
+            )));
+        }
+
+        // Validate that all values in forward are valid indices (< n)
+        // and that each value appears exactly once (valid permutation)
+        if raw.n > 0 {
+            let n = raw.n;
+            let n32 = n as u32;
+
+            let mut forward_seen = vec![false; n];
+            for (i, &val) in raw.forward.iter().enumerate() {
+                if val >= n32 {
+                    return Err(D::Error::custom(format!(
+                        "forward[{i}] = {val} is out of range for n = {n}"
+                    )));
+                }
+                if forward_seen[val as usize] {
+                    return Err(D::Error::custom(format!(
+                        "duplicate value {val} in forward array"
+                    )));
+                }
+                forward_seen[val as usize] = true;
+            }
+
+            let mut inverse_seen = vec![false; n];
+            for (i, &val) in raw.inverse.iter().enumerate() {
+                if val >= n32 {
+                    return Err(D::Error::custom(format!(
+                        "inverse[{i}] = {val} is out of range for n = {n}"
+                    )));
+                }
+                if inverse_seen[val as usize] {
+                    return Err(D::Error::custom(format!(
+                        "duplicate value {val} in inverse array"
+                    )));
+                }
+                inverse_seen[val as usize] = true;
+            }
+
+            // Validate that forward and inverse are actually inverses of each other
+            for (i, &fwd) in raw.forward.iter().enumerate() {
+                if raw.inverse[fwd as usize] != i as u32 {
+                    return Err(D::Error::custom(format!(
+                        "inverse[forward[{i}]] != {i}: forward and inverse are inconsistent"
+                    )));
+                }
+            }
+        }
+
+        Ok(SuccinctPermutation {
+            n: raw.n,
+            forward: raw.forward,
+            inverse: raw.inverse,
+        })
+    }
 }
 
 impl SuccinctPermutation {
@@ -248,5 +334,92 @@ mod tests {
         let size = perm.size_bytes();
         // Should be reasonable (not huge)
         assert!(size < 1000);
+    }
+
+    #[test]
+    fn test_deserialize_valid_roundtrip() {
+        let original = SuccinctPermutation::new(&[2, 0, 3, 1]);
+        let serialized = serde_json::to_string(&original).unwrap();
+        let deserialized: SuccinctPermutation = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.len(), original.len());
+        for i in 0..original.len() {
+            assert_eq!(deserialized.apply(i), original.apply(i));
+            assert_eq!(deserialized.apply_inverse(i), original.apply_inverse(i));
+        }
+    }
+
+    #[test]
+    fn test_deserialize_empty_roundtrip() {
+        let original = SuccinctPermutation::new(&[]);
+        let serialized = serde_json::to_string(&original).unwrap();
+        let deserialized: SuccinctPermutation = serde_json::from_str(&serialized).unwrap();
+        assert!(deserialized.is_empty());
+    }
+
+    #[test]
+    fn test_deserialize_rejects_mismatched_forward_length() {
+        let json = r#"{"n":3,"forward":[0,1],"inverse":[0,1,2]}"#;
+        let result: Result<SuccinctPermutation, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("forward length"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_deserialize_rejects_mismatched_inverse_length() {
+        let json = r#"{"n":3,"forward":[0,1,2],"inverse":[0,1]}"#;
+        let result: Result<SuccinctPermutation, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("inverse length"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_deserialize_rejects_out_of_range_forward() {
+        let json = r#"{"n":3,"forward":[0,1,5],"inverse":[0,1,2]}"#;
+        let result: Result<SuccinctPermutation, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("out of range"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_deserialize_rejects_out_of_range_inverse() {
+        let json = r#"{"n":3,"forward":[0,1,2],"inverse":[0,1,5]}"#;
+        let result: Result<SuccinctPermutation, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("out of range"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_deserialize_rejects_duplicate_in_forward() {
+        let json = r#"{"n":3,"forward":[0,1,1],"inverse":[0,1,2]}"#;
+        let result: Result<SuccinctPermutation, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("duplicate"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_deserialize_rejects_duplicate_in_inverse() {
+        let json = r#"{"n":3,"forward":[0,1,2],"inverse":[0,0,2]}"#;
+        let result: Result<SuccinctPermutation, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("duplicate"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_deserialize_rejects_inconsistent_forward_inverse() {
+        // Both are valid permutations individually, but they are not inverses
+        // forward: [1, 0, 2] (swap 0 and 1)
+        // inverse: [0, 2, 1] (swap 1 and 2)
+        let json = r#"{"n":3,"forward":[1,0,2],"inverse":[0,2,1]}"#;
+        let result: Result<SuccinctPermutation, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("inconsistent"), "unexpected error: {err}");
     }
 }

--- a/crates/grafeo-core/src/index/ring/permutation.rs
+++ b/crates/grafeo-core/src/index/ring/permutation.rs
@@ -12,7 +12,7 @@
 ///
 /// Stores both forward and inverse mappings for O(1) access.
 /// Uses 2n * 32 bits = 8n bytes for n elements.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SuccinctPermutation {
     /// The number of elements in the permutation.
     n: usize,

--- a/crates/grafeo-core/src/index/ring/section.rs
+++ b/crates/grafeo-core/src/index/ring/section.rs
@@ -1,6 +1,6 @@
 //! Ring Index section for `.grafeo` container persistence.
 //!
-//! Serializes and deserializes the [`TripleRing`] via the [`Section`] trait,
+//! Serializes and deserializes the [`super::TripleRing`] via the [`Section`] trait,
 //! enabling the Ring to survive database restarts without rebuilding from
 //! triples. Uses bincode for encoding.
 

--- a/crates/grafeo-core/src/index/ring/section.rs
+++ b/crates/grafeo-core/src/index/ring/section.rs
@@ -1,0 +1,171 @@
+//! Ring Index section for `.grafeo` container persistence.
+//!
+//! Serializes and deserializes the [`TripleRing`] via the [`Section`] trait,
+//! enabling the Ring to survive database restarts without rebuilding from
+//! triples. Uses bincode for encoding.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use grafeo_common::storage::section::{Section, SectionType};
+use grafeo_common::utils::error::{Error, Result};
+
+use crate::graph::rdf::RdfStore;
+
+const RING_SECTION_VERSION: u8 = 1;
+
+/// Section implementation for the RDF Ring Index.
+///
+/// Wraps an `Arc<RdfStore>` and serializes/deserializes the Ring via
+/// `TripleRing::save_to_bytes()`/`load_from_bytes()`.
+pub struct RdfRingSection {
+    store: Arc<RdfStore>,
+    dirty: AtomicBool,
+}
+
+impl RdfRingSection {
+    /// Creates a new Ring section backed by the given RDF store.
+    #[must_use]
+    pub fn new(store: Arc<RdfStore>) -> Self {
+        Self {
+            store,
+            dirty: AtomicBool::new(false),
+        }
+    }
+
+    /// Marks the section as dirty (Ring was rebuilt or invalidated).
+    pub fn mark_dirty(&self) {
+        self.dirty.store(true, Ordering::Release);
+    }
+}
+
+impl Section for RdfRingSection {
+    fn section_type(&self) -> SectionType {
+        SectionType::RdfRing
+    }
+
+    fn version(&self) -> u8 {
+        RING_SECTION_VERSION
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>> {
+        match self.store.ring() {
+            Some(ring) => ring
+                .save_to_bytes()
+                .map_err(|e| Error::Serialization(e.to_string())),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    fn deserialize(&mut self, data: &[u8]) -> Result<()> {
+        if data.is_empty() {
+            return Ok(());
+        }
+        let ring = super::TripleRing::load_from_bytes(data)
+            .map_err(|e| Error::Serialization(e.to_string()))?;
+        self.store.set_ring(ring);
+        Ok(())
+    }
+
+    fn is_dirty(&self) -> bool {
+        self.dirty.load(Ordering::Acquire)
+    }
+
+    fn mark_clean(&self) {
+        self.dirty.store(false, Ordering::Release);
+    }
+
+    fn memory_usage(&self) -> usize {
+        self.store.ring().map_or(0, |r| r.size_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::rdf::{Term, Triple};
+
+    fn test_store() -> Arc<RdfStore> {
+        let store = Arc::new(RdfStore::new());
+        store.bulk_load(vec![
+            Triple::new(
+                Term::iri("http://ex.org/alix"),
+                Term::iri("http://xmlns.com/foaf/0.1/name"),
+                Term::literal("Alix"),
+            ),
+            Triple::new(
+                Term::iri("http://ex.org/gus"),
+                Term::iri("http://xmlns.com/foaf/0.1/name"),
+                Term::literal("Gus"),
+            ),
+            Triple::new(
+                Term::iri("http://ex.org/alix"),
+                Term::iri("http://xmlns.com/foaf/0.1/knows"),
+                Term::iri("http://ex.org/gus"),
+            ),
+        ]);
+        store
+    }
+
+    #[test]
+    fn section_type_is_rdf_ring() {
+        let store = test_store();
+        let section = RdfRingSection::new(store);
+        assert_eq!(section.section_type(), SectionType::RdfRing);
+        assert_eq!(section.version(), 1);
+    }
+
+    #[test]
+    fn section_dirty_tracking() {
+        let store = test_store();
+        let section = RdfRingSection::new(store);
+        assert!(!section.is_dirty());
+        section.mark_dirty();
+        assert!(section.is_dirty());
+        section.mark_clean();
+        assert!(!section.is_dirty());
+    }
+
+    #[test]
+    fn section_serialize_empty() {
+        let store = Arc::new(RdfStore::new());
+        let section = RdfRingSection::new(store);
+        let bytes = section.serialize().unwrap();
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    fn section_roundtrip() {
+        let store = test_store();
+        let section = RdfRingSection::new(Arc::clone(&store));
+
+        // Serialize
+        let bytes = section.serialize().unwrap();
+        assert!(!bytes.is_empty());
+
+        // Create a fresh store and deserialize into it
+        let store2 = Arc::new(RdfStore::new());
+        let mut section2 = RdfRingSection::new(Arc::clone(&store2));
+        section2.deserialize(&bytes).unwrap();
+
+        // The loaded ring should have the same triple count
+        let ring = store2.ring().expect("ring should be loaded");
+        assert_eq!(ring.len(), 3);
+
+        // Verify count operations work
+        use crate::graph::rdf::TriplePattern;
+        let name_pattern = TriplePattern {
+            subject: None,
+            predicate: Some(Term::iri("http://xmlns.com/foaf/0.1/name")),
+            object: None,
+        };
+        assert_eq!(ring.count(&name_pattern), 2);
+    }
+
+    #[test]
+    fn section_memory_usage() {
+        let store = test_store();
+        let section = RdfRingSection::new(store);
+        assert!(section.memory_usage() > 0);
+    }
+}

--- a/crates/grafeo-core/src/index/ring/triple_ring.rs
+++ b/crates/grafeo-core/src/index/ring/triple_ring.rs
@@ -453,6 +453,32 @@ impl TripleRing {
         let reader = std::io::BufReader::new(file);
         Self::load(reader)
     }
+
+    /// Serializes the Ring to a byte vector.
+    ///
+    /// Used by the Section trait for container persistence.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if encoding fails.
+    pub fn save_to_bytes(&self) -> std::io::Result<Vec<u8>> {
+        bincode::serde::encode_to_vec(self, bincode::config::standard())
+            .map_err(|e| std::io::Error::other(e.to_string()))
+    }
+
+    /// Deserializes a Ring from a byte slice.
+    ///
+    /// Used by the Section trait when loading from the container.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the data is malformed.
+    pub fn load_from_bytes(data: &[u8]) -> std::io::Result<Self> {
+        let (ring, _bytes_read) =
+            bincode::serde::decode_from_slice(data, bincode::config::standard())
+                .map_err(|e| std::io::Error::other(e.to_string()))?;
+        Ok(ring)
+    }
 }
 
 /// Iterator over triples matching a pattern.

--- a/crates/grafeo-core/src/index/ring/triple_ring.rs
+++ b/crates/grafeo-core/src/index/ring/triple_ring.rs
@@ -11,7 +11,7 @@ use hashbrown::HashMap;
 use std::sync::Arc;
 
 /// Term dictionary mapping terms to compact integer IDs.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct TermDictionary {
     /// Term to ID mapping.
     term_to_id: HashMap<Arc<Term>, u32, foldhash::fast::RandomState>,
@@ -107,7 +107,7 @@ struct CompactTriple {
 /// - Term dictionary for string → ID mapping
 /// - Wavelet trees for each triple component
 /// - Succinct permutations for navigating between orderings
-#[derive(Debug)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TripleRing {
     /// Term dictionary.
     dict: TermDictionary,
@@ -406,6 +406,52 @@ impl TripleRing {
         let spo_to_osp = self.spo_to_osp.size_bytes();
 
         base + dict + subjects + predicates + objects + spo_to_pos + spo_to_osp
+    }
+
+    /// Serializes the Ring to a writer using bincode.
+    ///
+    /// The output contains the complete state: term dictionary, wavelet trees,
+    /// and permutations. Use [`TripleRing::load`] to restore.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if writing fails or bincode encoding fails.
+    pub fn save(&self, mut writer: impl std::io::Write) -> std::io::Result<()> {
+        bincode::serde::encode_into_std_write(self, &mut writer, bincode::config::standard())
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Deserializes a Ring from a reader.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if reading fails or the data is malformed.
+    pub fn load(mut reader: impl std::io::Read) -> std::io::Result<Self> {
+        bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard())
+            .map_err(|e| std::io::Error::other(e.to_string()))
+    }
+
+    /// Saves the Ring to a file path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the file cannot be created or writing fails.
+    pub fn save_to_file(&self, path: impl AsRef<std::path::Path>) -> std::io::Result<()> {
+        let file = std::fs::File::create(path)?;
+        let writer = std::io::BufWriter::new(file);
+        self.save(writer)
+    }
+
+    /// Loads a Ring from a file path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the file cannot be opened or the data is malformed.
+    pub fn load_from_file(path: impl AsRef<std::path::Path>) -> std::io::Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let reader = std::io::BufReader::new(file);
+        Self::load(reader)
     }
 }
 
@@ -919,5 +965,79 @@ mod tests {
         // Find on empty ring
         let results: Vec<Triple> = ring.find(&TriplePattern::any()).collect();
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let triples = vec![
+            Triple::new(
+                Term::iri("http://ex.org/alix"),
+                Term::iri("http://xmlns.com/foaf/0.1/name"),
+                Term::literal("Alix"),
+            ),
+            Triple::new(
+                Term::iri("http://ex.org/gus"),
+                Term::iri("http://xmlns.com/foaf/0.1/name"),
+                Term::literal("Gus"),
+            ),
+            Triple::new(
+                Term::iri("http://ex.org/alix"),
+                Term::iri("http://xmlns.com/foaf/0.1/knows"),
+                Term::iri("http://ex.org/gus"),
+            ),
+        ];
+
+        let ring = TripleRing::from_triples(triples.into_iter());
+        assert_eq!(ring.len(), 3);
+
+        // Save to buffer
+        let mut buf = Vec::new();
+        ring.save(&mut buf).expect("save should succeed");
+        assert!(!buf.is_empty());
+
+        // Load from buffer
+        let loaded = TripleRing::load(&buf[..]).expect("load should succeed");
+        assert_eq!(loaded.len(), ring.len());
+        assert_eq!(loaded.num_terms(), ring.num_terms());
+
+        // Verify all triples round-trip
+        let original: Vec<Triple> = ring.find(&TriplePattern::any()).collect();
+        let restored: Vec<Triple> = loaded.find(&TriplePattern::any()).collect();
+        assert_eq!(original.len(), restored.len());
+
+        // Verify count operations work on loaded ring
+        let name_pattern = TriplePattern {
+            subject: None,
+            predicate: Some(Term::iri("http://xmlns.com/foaf/0.1/name")),
+            object: None,
+        };
+        assert_eq!(loaded.count(&name_pattern), 2);
+    }
+
+    #[test]
+    fn test_save_load_file() {
+        let triples = vec![
+            Triple::new(
+                Term::iri("http://ex.org/a"),
+                Term::iri("http://ex.org/p"),
+                Term::iri("http://ex.org/b"),
+            ),
+            Triple::new(
+                Term::iri("http://ex.org/b"),
+                Term::iri("http://ex.org/p"),
+                Term::iri("http://ex.org/c"),
+            ),
+        ];
+
+        let ring = TripleRing::from_triples(triples.into_iter());
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("test.ring");
+
+        ring.save_to_file(&path).expect("save_to_file");
+        let loaded = TripleRing::load_from_file(&path).expect("load_from_file");
+
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded.count(&TriplePattern::any()), 2);
     }
 }

--- a/crates/grafeo-core/src/index/ring/triple_ring.rs
+++ b/crates/grafeo-core/src/index/ring/triple_ring.rs
@@ -422,14 +422,56 @@ impl TripleRing {
         Ok(())
     }
 
+    /// Validates structural invariants after deserialization.
+    ///
+    /// Ensures that all internal arrays are consistent with `num_triples`
+    /// and the term dictionary, preventing panics from corrupted data.
+    fn validate(&self) -> std::io::Result<()> {
+        let n = self.num_triples;
+        if self.subjects.len() != n {
+            return Err(std::io::Error::other(format!(
+                "subjects wavelet tree length {} != num_triples {n}",
+                self.subjects.len()
+            )));
+        }
+        if self.predicates.len() != n {
+            return Err(std::io::Error::other(format!(
+                "predicates wavelet tree length {} != num_triples {n}",
+                self.predicates.len()
+            )));
+        }
+        if self.objects.len() != n {
+            return Err(std::io::Error::other(format!(
+                "objects wavelet tree length {} != num_triples {n}",
+                self.objects.len()
+            )));
+        }
+        if self.spo_to_pos.len() != n {
+            return Err(std::io::Error::other(format!(
+                "spo_to_pos permutation length {} != num_triples {n}",
+                self.spo_to_pos.len()
+            )));
+        }
+        if self.spo_to_osp.len() != n {
+            return Err(std::io::Error::other(format!(
+                "spo_to_osp permutation length {} != num_triples {n}",
+                self.spo_to_osp.len()
+            )));
+        }
+        Ok(())
+    }
+
     /// Deserializes a Ring from a reader.
     ///
     /// # Errors
     ///
     /// Returns an I/O error if reading fails or the data is malformed.
     pub fn load(mut reader: impl std::io::Read) -> std::io::Result<Self> {
-        bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard())
-            .map_err(|e| std::io::Error::other(e.to_string()))
+        let ring: Self =
+            bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard())
+                .map_err(|e| std::io::Error::other(e.to_string()))?;
+        ring.validate()?;
+        Ok(ring)
     }
 
     /// Saves the Ring to a file path.
@@ -474,9 +516,10 @@ impl TripleRing {
     ///
     /// Returns an I/O error if the data is malformed.
     pub fn load_from_bytes(data: &[u8]) -> std::io::Result<Self> {
-        let (ring, _bytes_read) =
+        let (ring, _bytes_read): (Self, _) =
             bincode::serde::decode_from_slice(data, bincode::config::standard())
                 .map_err(|e| std::io::Error::other(e.to_string()))?;
+        ring.validate()?;
         Ok(ring)
     }
 }

--- a/crates/grafeo-core/src/index/ring/triple_ring.rs
+++ b/crates/grafeo-core/src/index/ring/triple_ring.rs
@@ -1261,12 +1261,12 @@ mod tests {
             make_triple("gus", "knows", "vincent"),
         ];
         let ring = TripleRing::from_triples(triples.into_iter());
-        let dir = std::env::temp_dir();
-        let path = dir.join("grafeo_test_ring.bin");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ring_roundtrip.bin");
         ring.save_to_file(&path).unwrap();
         let loaded = TripleRing::load_from_file(&path).unwrap();
         assert_eq!(loaded.len(), ring.len());
-        std::fs::remove_file(&path).ok();
+        // dir dropped here: automatic cleanup even on panic
     }
 
     #[test]

--- a/crates/grafeo-core/src/index/ring/triple_ring.rs
+++ b/crates/grafeo-core/src/index/ring/triple_ring.rs
@@ -428,6 +428,17 @@ impl TripleRing {
     /// and the term dictionary, preventing panics from corrupted data.
     fn validate(&self) -> std::io::Result<()> {
         let n = self.num_triples;
+
+        // --- Term dictionary consistency ---
+        if self.dict.term_to_id.len() != self.dict.id_to_term.len() {
+            return Err(std::io::Error::other(format!(
+                "term dictionary inconsistent: term_to_id has {} entries, id_to_term has {}",
+                self.dict.term_to_id.len(),
+                self.dict.id_to_term.len()
+            )));
+        }
+
+        // --- Wavelet tree lengths must match num_triples ---
         if self.subjects.len() != n {
             return Err(std::io::Error::other(format!(
                 "subjects wavelet tree length {} != num_triples {n}",
@@ -446,6 +457,43 @@ impl TripleRing {
                 self.objects.len()
             )));
         }
+
+        // --- Wavelet tree internal consistency ---
+        self.subjects
+            .validate()
+            .map_err(|e| std::io::Error::other(format!("subjects wavelet tree: {e}")))?;
+        self.predicates
+            .validate()
+            .map_err(|e| std::io::Error::other(format!("predicates wavelet tree: {e}")))?;
+        self.objects
+            .validate()
+            .map_err(|e| std::io::Error::other(format!("objects wavelet tree: {e}")))?;
+
+        // --- Wavelet tree symbols must reference valid dictionary IDs ---
+        let dict_len = self.dict.len() as u64;
+        for sym in self.subjects.alphabet() {
+            if sym >= dict_len {
+                return Err(std::io::Error::other(format!(
+                    "subjects wavelet tree contains symbol {sym} >= dict size {dict_len}"
+                )));
+            }
+        }
+        for sym in self.predicates.alphabet() {
+            if sym >= dict_len {
+                return Err(std::io::Error::other(format!(
+                    "predicates wavelet tree contains symbol {sym} >= dict size {dict_len}"
+                )));
+            }
+        }
+        for sym in self.objects.alphabet() {
+            if sym >= dict_len {
+                return Err(std::io::Error::other(format!(
+                    "objects wavelet tree contains symbol {sym} >= dict size {dict_len}"
+                )));
+            }
+        }
+
+        // --- Permutation lengths must match num_triples ---
         if self.spo_to_pos.len() != n {
             return Err(std::io::Error::other(format!(
                 "spo_to_pos permutation length {} != num_triples {n}",
@@ -458,6 +506,7 @@ impl TripleRing {
                 self.spo_to_osp.len()
             )));
         }
+
         Ok(())
     }
 
@@ -1108,5 +1157,123 @@ mod tests {
 
         assert_eq!(loaded.len(), 2);
         assert_eq!(loaded.count(&TriplePattern::any()), 2);
+    }
+
+    #[test]
+    fn test_load_rejects_truncated_data() {
+        let triples = vec![make_triple("s1", "p1", "o1")];
+        let ring = TripleRing::from_triples(triples.into_iter());
+
+        let bytes = ring.save_to_bytes().expect("save_to_bytes");
+        // Truncate to half the data
+        let truncated = &bytes[..bytes.len() / 2];
+        let result = TripleRing::load_from_bytes(truncated);
+        assert!(result.is_err(), "truncated data should fail to load");
+    }
+
+    #[test]
+    fn test_load_rejects_empty_bytes() {
+        let result = TripleRing::load_from_bytes(&[]);
+        assert!(result.is_err(), "empty bytes should fail to load");
+    }
+
+    #[test]
+    fn test_load_rejects_garbage_bytes() {
+        let garbage = vec![0xFF; 256];
+        let result = TripleRing::load_from_bytes(&garbage);
+        assert!(result.is_err(), "garbage bytes should fail to load");
+    }
+
+    #[test]
+    fn test_load_from_bytes_roundtrip() {
+        let triples = vec![make_triple("s1", "p1", "o1"), make_triple("s2", "p2", "o2")];
+        let ring = TripleRing::from_triples(triples.into_iter());
+
+        let bytes = ring.save_to_bytes().expect("save_to_bytes");
+        let loaded = TripleRing::load_from_bytes(&bytes).expect("load_from_bytes");
+
+        assert_eq!(loaded.len(), ring.len());
+        assert_eq!(loaded.num_terms(), ring.num_terms());
+    }
+
+    #[test]
+    fn test_validate_passes_for_valid_ring() {
+        let triples = vec![
+            make_triple("alix", "knows", "gus"),
+            make_triple("alix", "likes", "vincent"),
+            make_triple("gus", "knows", "vincent"),
+        ];
+        let ring = TripleRing::from_triples(triples.into_iter());
+
+        // Validation should pass for a freshly constructed ring
+        assert!(ring.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_passes_for_empty_ring() {
+        let ring = TripleRing::from_triples(std::iter::empty());
+        assert!(ring.validate().is_ok());
+    }
+
+    #[test]
+    fn test_save_load_bytes_roundtrip() {
+        let triples = vec![
+            make_triple("alix", "knows", "gus"),
+            make_triple("alix", "likes", "vincent"),
+            make_triple("gus", "knows", "vincent"),
+        ];
+        let ring = TripleRing::from_triples(triples.into_iter());
+        let bytes = ring.save_to_bytes().unwrap();
+        let loaded = TripleRing::load_from_bytes(&bytes).unwrap();
+        assert_eq!(loaded.len(), ring.len());
+        // Verify query results match
+        let pattern = TriplePattern {
+            subject: None,
+            predicate: None,
+            object: None,
+        };
+        assert_eq!(loaded.count(&pattern), ring.count(&pattern));
+    }
+
+    #[test]
+    fn test_save_load_writer_reader_roundtrip() {
+        let triples = vec![
+            make_triple("alix", "knows", "gus"),
+            make_triple("gus", "likes", "vincent"),
+        ];
+        let ring = TripleRing::from_triples(triples.into_iter());
+        let mut buf = Vec::new();
+        ring.save(&mut buf).unwrap();
+        let loaded = TripleRing::load(&buf[..]).unwrap();
+        assert_eq!(loaded.len(), ring.len());
+    }
+
+    #[test]
+    fn test_load_from_bytes_corrupt_data_fails() {
+        let result = TripleRing::load_from_bytes(&[0xFF, 0xFE, 0xFD, 0xFC]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_save_load_file_roundtrip() {
+        let triples = vec![
+            make_triple("alix", "knows", "gus"),
+            make_triple("gus", "knows", "vincent"),
+        ];
+        let ring = TripleRing::from_triples(triples.into_iter());
+        let dir = std::env::temp_dir();
+        let path = dir.join("grafeo_test_ring.bin");
+        ring.save_to_file(&path).unwrap();
+        let loaded = TripleRing::load_from_file(&path).unwrap();
+        assert_eq!(loaded.len(), ring.len());
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_save_load_empty_ring() {
+        let ring = TripleRing::from_triples(std::iter::empty());
+        let bytes = ring.save_to_bytes().unwrap();
+        let loaded = TripleRing::load_from_bytes(&bytes).unwrap();
+        assert_eq!(loaded.len(), 0);
     }
 }

--- a/crates/grafeo-engine/Cargo.toml
+++ b/crates/grafeo-engine/Cargo.toml
@@ -77,6 +77,7 @@ gremlin = ["grafeo-adapters/gremlin"]
 graphql = ["grafeo-adapters/graphql"]
 sql-pgq = ["grafeo-adapters/sql-pgq"]  # SQL/PGQ (SQL:2023 GRAPH_TABLE)
 triple-store = ["grafeo-core/triple-store", "grafeo-adapters/triple-store", "md5", "sha1", "sha2", "regex"]  # RDF triple store model and planner
+ring-index = ["grafeo-core/ring-index", "triple-store"]  # Ring Index for compact RDF (3x memory reduction)
 rdf = ["triple-store"]  # Deprecated: use triple-store
 parallel = ["rayon", "crossbeam", "grafeo-core/parallel", "grafeo-adapters/parallel"]  # Parallel execution
 algos = ["grafeo-adapters/algos"]  # Graph algorithm plugin (SSSP, PageRank, etc.)

--- a/crates/grafeo-engine/src/database/admin.rs
+++ b/crates/grafeo-engine/src/database/admin.rs
@@ -347,6 +347,12 @@ impl super::GrafeoDB {
     ///
     /// Returns an error if the checkpoint fails.
     pub fn wal_checkpoint(&self) -> Result<()> {
+        // Read-only databases have no WAL and the on-disk file is already a
+        // valid snapshot: nothing to checkpoint.
+        if self.read_only {
+            return Ok(());
+        }
+
         #[cfg(feature = "wal")]
         if let Some(ref wal) = self.wal {
             let epoch = self.lpg_store().current_epoch();

--- a/crates/grafeo-engine/src/database/async_ops.rs
+++ b/crates/grafeo-engine/src/database/async_ops.rs
@@ -74,6 +74,10 @@ impl GrafeoDB {
     pub async fn async_write_snapshot(self: &Arc<Self>) -> Result<()> {
         let db = Arc::clone(self);
         tokio::task::spawn_blocking(move || {
+            // Read-only databases have nothing to flush.
+            if db.read_only {
+                return Ok(());
+            }
             let Some(ref fm) = db.file_manager else {
                 return Err(Error::Internal(
                     "no file manager configured for snapshot write".to_string(),
@@ -124,6 +128,28 @@ mod tests {
 
         checkpoint_result.unwrap();
         assert_eq!(concurrent_result, 42);
+    }
+
+    /// Regression: async_write_snapshot on a read-only database should be a
+    /// no-op, not an error.
+    #[cfg(feature = "grafeo-file")]
+    #[tokio::test]
+    async fn async_write_snapshot_on_read_only_is_no_op() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro_async.grafeo");
+
+        {
+            let db = GrafeoDB::open(&path).unwrap();
+            let session = db.session();
+            session.execute("INSERT (:Person {name: 'Alix'})").unwrap();
+            db.close().unwrap();
+        }
+
+        let db = Arc::new(GrafeoDB::open_read_only(&path).unwrap());
+        db.async_write_snapshot()
+            .await
+            .expect("async_write_snapshot on read-only should be a no-op");
+        assert_eq!(db.node_count(), 1);
     }
 
     #[cfg(feature = "grafeo-file")]

--- a/crates/grafeo-engine/src/database/backup.rs
+++ b/crates/grafeo-engine/src/database/backup.rs
@@ -289,20 +289,24 @@ pub(super) fn now_ms() -> u64 {
 
 // ── Backup operations (called from GrafeoDB) ───────────────────────
 
+use grafeo_storage::file::GrafeoFileManager;
 use grafeo_storage::wal::LpgWal;
 
 /// Creates a full backup by copying the .grafeo container file.
 ///
-/// 1. Forces a checkpoint so the container has the latest data.
-/// 2. Copies the container file to the backup directory.
-/// 3. Updates the manifest and backup cursor.
+/// 1. Copies the container file to the backup directory via the locked handle.
+/// 2. Updates the manifest and backup cursor.
+///
+/// Uses [`GrafeoFileManager::copy_to`] instead of `std::fs::copy()` so the
+/// copy reads through the already-locked file handle. `std::fs::copy()` opens
+/// a new handle, which fails on Windows when an exclusive lock is held.
 ///
 /// # Errors
 ///
 /// Returns an error if the database has no file manager, or if I/O fails.
 pub(super) fn do_backup_full(
     backup_dir: &Path,
-    grafeo_file_path: &Path,
+    fm: &GrafeoFileManager,
     wal: Option<&LpgWal>,
     current_epoch: EpochId,
 ) -> Result<BackupSegment> {
@@ -315,9 +319,8 @@ pub(super) fn do_backup_full(
     let filename = format!("backup_full_{segment_idx:04}.grafeo");
     let dest_path = backup_dir.join(&filename);
 
-    // Copy the .grafeo file to the backup directory
-    std::fs::copy(grafeo_file_path, &dest_path)
-        .map_err(|e| Error::Internal(format!("failed to copy database file for backup: {e}")))?;
+    // Copy the .grafeo file to the backup directory through the locked handle
+    fm.copy_to(&dest_path)?;
 
     let file_size = std::fs::metadata(&dest_path).map(|m| m.len()).unwrap_or(0);
     let file_data = std::fs::read(&dest_path)

--- a/crates/grafeo-engine/src/database/checkpoint_timer.rs
+++ b/crates/grafeo-engine/src/database/checkpoint_timer.rs
@@ -197,6 +197,12 @@ impl CheckpointTimer {
             sections.push(Box::new(rdf));
         }
 
+        #[cfg(feature = "ring-index")]
+        if rdf_store.ring().is_some() {
+            let ring = grafeo_core::index::ring::RdfRingSection::new(Arc::clone(rdf_store));
+            sections.push(Box::new(ring));
+        }
+
         #[cfg(feature = "vector-index")]
         {
             let indexes = store.vector_index_entries();

--- a/crates/grafeo-engine/src/database/mod.rs
+++ b/crates/grafeo-engine/src/database/mod.rs
@@ -2184,11 +2184,15 @@ impl GrafeoDB {
             .as_ref()
             .ok_or_else(|| Error::Internal("backup requires a persistent database".to_string()))?;
 
-        // Checkpoint first to ensure the container has latest data
-        let _ = self.checkpoint_to_file(fm, flush::FlushReason::Explicit)?;
+        // Checkpoint to ensure the container has the latest data.
+        // Skip for read-only databases: the on-disk file is already a valid
+        // snapshot and the file manager rejects writes.
+        if !self.read_only {
+            let _ = self.checkpoint_to_file(fm, flush::FlushReason::Explicit)?;
+        }
 
         let current_epoch = self.transaction_manager.current_epoch();
-        backup::do_backup_full(backup_dir, fm.path(), self.wal.as_deref(), current_epoch)
+        backup::do_backup_full(backup_dir, fm, self.wal.as_deref(), current_epoch)
     }
 
     /// Creates an incremental backup containing WAL records since the last backup.

--- a/crates/grafeo-engine/src/database/mod.rs
+++ b/crates/grafeo-engine/src/database/mod.rs
@@ -1243,6 +1243,14 @@ impl GrafeoDB {
             section.deserialize(&data)?;
         }
 
+        // Restore Ring Index (if persisted)
+        #[cfg(feature = "ring-index")]
+        if let Some(entry) = dir.find(SectionType::RdfRing) {
+            let data = fm.read_section_data(entry)?;
+            let mut section = grafeo_core::index::ring::RdfRingSection::new(Arc::clone(rdf_store));
+            section.deserialize(&data)?;
+        }
+
         // Restore HNSW topology (if vector indexes exist in both catalog and section)
         #[cfg(feature = "vector-index")]
         if let Some(entry) = dir.find(SectionType::VectorStore) {
@@ -1988,6 +1996,15 @@ impl GrafeoDB {
             ));
         }
 
+        // Ring Index: only when Ring has been built
+        #[cfg(feature = "ring-index")]
+        if self.rdf_store.ring().is_some() {
+            let ring = grafeo_core::index::ring::RdfRingSection::new(Arc::clone(&self.rdf_store));
+            self.buffer_manager.register_consumer(Arc::new(
+                section_consumer::SectionConsumer::new(Arc::new(ring)),
+            ));
+        }
+
         // Vector indexes: dynamic consumer that re-queries the store on each
         // memory_usage() call, so dropped indexes are freed and new ones tracked.
         #[cfg(all(
@@ -2159,6 +2176,12 @@ impl GrafeoDB {
         if !self.rdf_store.is_empty() || self.rdf_store.graph_count() > 0 {
             let rdf = grafeo_core::graph::rdf::RdfStoreSection::new(Arc::clone(&self.rdf_store));
             sections.push(Box::new(rdf));
+        }
+
+        #[cfg(feature = "ring-index")]
+        if self.rdf_store.ring().is_some() {
+            let ring = grafeo_core::index::ring::RdfRingSection::new(Arc::clone(&self.rdf_store));
+            sections.push(Box::new(ring));
         }
 
         sections

--- a/crates/grafeo-engine/src/database/rdf_ops.rs
+++ b/crates/grafeo-engine/src/database/rdf_ops.rs
@@ -49,10 +49,29 @@ impl GrafeoDB {
         let optimizer = Optimizer::from_rdf_statistics((*rdf_stats).clone());
         let optimized_plan = optimizer.optimize(logical_plan)?;
 
-        // EXPLAIN: return the logical plan tree without executing
+        // EXPLAIN: return the physical plan tree without executing
         if optimized_plan.explain {
-            use crate::query::processor::explain_result;
-            return Ok(explain_result(&optimized_plan));
+            let planner = RdfPlanner::new(Arc::clone(&self.rdf_store));
+            let (_, entries) = planner.plan_profiled(&optimized_plan)?;
+            use crate::query::processor::physical_explain_result;
+            return Ok(physical_explain_result(&optimized_plan, entries));
+        }
+
+        // EXPLAIN ANALYZE: execute with profiling, report actual stats
+        if optimized_plan.profile {
+            let planner = RdfPlanner::new(Arc::clone(&self.rdf_store));
+            let (mut physical_plan, entries) = planner.plan_profiled(&optimized_plan)?;
+
+            let start = std::time::Instant::now();
+            let executor = Executor::with_columns(physical_plan.columns.clone());
+            let _result = executor.execute(physical_plan.operator.as_mut())?;
+            let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+            let tree = crate::query::profile::build_profile_tree(
+                &optimized_plan.root,
+                &mut entries.into_iter(),
+            );
+            return Ok(crate::query::profile::profile_result(&tree, elapsed_ms));
         }
 
         // Convert to physical plan using RDF planner

--- a/crates/grafeo-engine/src/query/binder.rs
+++ b/crates/grafeo-engine/src/query/binder.rs
@@ -737,6 +737,7 @@ impl Binder {
                 );
                 Ok(())
             }
+            LogicalOperator::Construct(construct) => self.bind_operator(&construct.input),
         }
     }
 

--- a/crates/grafeo-engine/src/query/optimizer/mod.rs
+++ b/crates/grafeo-engine/src/query/optimizer/mod.rs
@@ -945,12 +945,101 @@ impl Optimizer {
                 input: Box::new(LogicalOperator::NodeScan(scan)),
             }),
 
+            // For TripleScan, try to push equality filters into bound positions
+            #[cfg(feature = "triple-store")]
+            LogicalOperator::TripleScan(scan) => {
+                self.try_push_filter_into_triple_scan(predicate, scan)
+            }
+
             // For other operators, keep filter on top
             other => LogicalOperator::Filter(FilterOp {
                 predicate,
                 pushdown_hint: None,
                 input: Box::new(other),
             }),
+        }
+    }
+
+    /// Tries to push an equality filter into a TripleScan by converting a
+    /// variable position to a bound term.
+    ///
+    /// Example: `FILTER(?name = "Alix")` on `TripleScan(?person <name> ?name)`
+    /// becomes `TripleScan(?person <name> "Alix")` with no filter.
+    #[cfg(feature = "triple-store")]
+    fn try_push_filter_into_triple_scan(
+        &self,
+        predicate: LogicalExpression,
+        mut scan: crate::query::plan::TripleScanOp,
+    ) -> LogicalOperator {
+        use crate::query::plan::{BinaryOp, TripleComponent};
+
+        // Extract equality: Variable = Literal or Literal = Variable
+        let (var_name, value) = match &predicate {
+            LogicalExpression::Binary {
+                left,
+                op: BinaryOp::Eq,
+                right,
+            } => match (left.as_ref(), right.as_ref()) {
+                (LogicalExpression::Variable(v), LogicalExpression::Literal(lit)) => {
+                    (v.clone(), lit.clone())
+                }
+                (LogicalExpression::Literal(lit), LogicalExpression::Variable(v)) => {
+                    (v.clone(), lit.clone())
+                }
+                _ => {
+                    return LogicalOperator::Filter(FilterOp {
+                        predicate,
+                        pushdown_hint: None,
+                        input: Box::new(LogicalOperator::TripleScan(scan)),
+                    });
+                }
+            },
+            _ => {
+                return LogicalOperator::Filter(FilterOp {
+                    predicate,
+                    pushdown_hint: None,
+                    input: Box::new(LogicalOperator::TripleScan(scan)),
+                });
+            }
+        };
+
+        // Check if the variable matches a TripleScan position and bind it
+        let pushed = if scan.subject.as_variable() == Some(var_name.as_str()) {
+            match &value {
+                grafeo_common::types::Value::String(s) => {
+                    scan.subject = TripleComponent::Iri(s.to_string());
+                    true
+                }
+                _ => {
+                    scan.subject = TripleComponent::Literal(value);
+                    true
+                }
+            }
+        } else if scan.predicate.as_variable() == Some(var_name.as_str()) {
+            match &value {
+                grafeo_common::types::Value::String(s) => {
+                    scan.predicate = TripleComponent::Iri(s.to_string());
+                    true
+                }
+                _ => false,
+            }
+        } else if scan.object.as_variable() == Some(var_name.as_str()) {
+            scan.object = TripleComponent::Literal(value);
+            true
+        } else {
+            false
+        };
+
+        if pushed {
+            // Filter was absorbed into the scan
+            LogicalOperator::TripleScan(scan)
+        } else {
+            // Could not push, keep filter
+            LogicalOperator::Filter(FilterOp {
+                predicate,
+                pushdown_hint: None,
+                input: Box::new(LogicalOperator::TripleScan(scan)),
+            })
         }
     }
 
@@ -1016,6 +1105,23 @@ impl Optimizer {
             }
             LogicalOperator::Distinct(distinct) => {
                 Self::collect_output_variables_recursive(&distinct.input, vars);
+            }
+            #[cfg(feature = "triple-store")]
+            LogicalOperator::TripleScan(scan) => {
+                if let Some(v) = scan.subject.as_variable() {
+                    vars.insert(v.to_string());
+                }
+                if let Some(v) = scan.predicate.as_variable() {
+                    vars.insert(v.to_string());
+                }
+                if let Some(v) = scan.object.as_variable() {
+                    vars.insert(v.to_string());
+                }
+                if let Some(ref g) = scan.graph
+                    && let Some(v) = g.as_variable()
+                {
+                    vars.insert(v.to_string());
+                }
             }
             _ => {}
         }

--- a/crates/grafeo-engine/src/query/optimizer/mod.rs
+++ b/crates/grafeo-engine/src/query/optimizer/mod.rs
@@ -676,6 +676,19 @@ impl Optimizer {
                 relations.push((expand.to_variable.clone(), op.clone()));
                 true
             }
+            #[cfg(feature = "triple-store")]
+            LogicalOperator::TripleScan(scan) => {
+                // Use the first variable found as the relation name
+                let name = scan
+                    .subject
+                    .as_variable()
+                    .or_else(|| scan.predicate.as_variable())
+                    .or_else(|| scan.object.as_variable())
+                    .unwrap_or("tp")
+                    .to_string();
+                relations.push((name, op.clone()));
+                true
+            }
             _ => false,
         }
     }

--- a/crates/grafeo-engine/src/query/optimizer/mod.rs
+++ b/crates/grafeo-engine/src/query/optimizer/mod.rs
@@ -945,12 +945,6 @@ impl Optimizer {
                 input: Box::new(LogicalOperator::NodeScan(scan)),
             }),
 
-            // For TripleScan, try to push equality filters into bound positions
-            #[cfg(feature = "triple-store")]
-            LogicalOperator::TripleScan(scan) => {
-                self.try_push_filter_into_triple_scan(predicate, scan)
-            }
-
             // For other operators, keep filter on top
             other => LogicalOperator::Filter(FilterOp {
                 predicate,
@@ -960,88 +954,11 @@ impl Optimizer {
         }
     }
 
-    /// Tries to push an equality filter into a TripleScan by converting a
-    /// variable position to a bound term.
-    ///
-    /// Example: `FILTER(?name = "Alix")` on `TripleScan(?person <name> ?name)`
-    /// becomes `TripleScan(?person <name> "Alix")` with no filter.
-    #[cfg(feature = "triple-store")]
-    fn try_push_filter_into_triple_scan(
-        &self,
-        predicate: LogicalExpression,
-        mut scan: crate::query::plan::TripleScanOp,
-    ) -> LogicalOperator {
-        use crate::query::plan::{BinaryOp, TripleComponent};
-
-        // Extract equality: Variable = Literal or Literal = Variable
-        let (var_name, value) = match &predicate {
-            LogicalExpression::Binary {
-                left,
-                op: BinaryOp::Eq,
-                right,
-            } => match (left.as_ref(), right.as_ref()) {
-                (LogicalExpression::Variable(v), LogicalExpression::Literal(lit)) => {
-                    (v.clone(), lit.clone())
-                }
-                (LogicalExpression::Literal(lit), LogicalExpression::Variable(v)) => {
-                    (v.clone(), lit.clone())
-                }
-                _ => {
-                    return LogicalOperator::Filter(FilterOp {
-                        predicate,
-                        pushdown_hint: None,
-                        input: Box::new(LogicalOperator::TripleScan(scan)),
-                    });
-                }
-            },
-            _ => {
-                return LogicalOperator::Filter(FilterOp {
-                    predicate,
-                    pushdown_hint: None,
-                    input: Box::new(LogicalOperator::TripleScan(scan)),
-                });
-            }
-        };
-
-        // Check if the variable matches a TripleScan position and bind it
-        let pushed = if scan.subject.as_variable() == Some(var_name.as_str()) {
-            match &value {
-                grafeo_common::types::Value::String(s) => {
-                    scan.subject = TripleComponent::Iri(s.to_string());
-                    true
-                }
-                _ => {
-                    scan.subject = TripleComponent::Literal(value);
-                    true
-                }
-            }
-        } else if scan.predicate.as_variable() == Some(var_name.as_str()) {
-            match &value {
-                grafeo_common::types::Value::String(s) => {
-                    scan.predicate = TripleComponent::Iri(s.to_string());
-                    true
-                }
-                _ => false,
-            }
-        } else if scan.object.as_variable() == Some(var_name.as_str()) {
-            scan.object = TripleComponent::Literal(value);
-            true
-        } else {
-            false
-        };
-
-        if pushed {
-            // Filter was absorbed into the scan
-            LogicalOperator::TripleScan(scan)
-        } else {
-            // Could not push, keep filter
-            LogicalOperator::Filter(FilterOp {
-                predicate,
-                pushdown_hint: None,
-                input: Box::new(LogicalOperator::TripleScan(scan)),
-            })
-        }
-    }
+    // NOTE: Filter-into-TripleScan pushdown is intentionally not implemented.
+    // Binding a variable position in the scan removes it from output columns,
+    // which breaks downstream operators (SELECT, ORDER BY) that reference it.
+    // A correct implementation needs a separate `pushed_bindings` field on
+    // TripleScanOp so the variable stays in output while the scan is constrained.
 
     /// Collects all output variable names from an operator.
     fn collect_output_variables(&self, op: &LogicalOperator) -> HashSet<String> {

--- a/crates/grafeo-engine/src/query/plan.rs
+++ b/crates/grafeo-engine/src/query/plan.rs
@@ -1482,6 +1482,17 @@ pub enum TripleComponent {
     BlankNode(String),
 }
 
+impl TripleComponent {
+    /// Returns the variable name if this component is a `Variable`, or `None`.
+    #[must_use]
+    pub fn as_variable(&self) -> Option<&str> {
+        match self {
+            Self::Variable(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
 /// Union of multiple result sets.
 #[derive(Debug, Clone)]
 pub struct UnionOp {

--- a/crates/grafeo-engine/src/query/plan.rs
+++ b/crates/grafeo-engine/src/query/plan.rs
@@ -200,6 +200,10 @@ pub enum LogicalOperator {
     /// Anti-join for MINUS patterns.
     AntiJoin(AntiJoinOp),
 
+    /// SPARQL CONSTRUCT: evaluate WHERE, substitute bindings into template,
+    /// output (subject, predicate, object) columns.
+    Construct(ConstructOp),
+
     /// Bind a variable to an expression.
     Bind(BindOp),
 
@@ -365,6 +369,7 @@ impl LogicalOperator {
             | Self::Empty
             | Self::ParameterScan(_)
             | Self::CallProcedure(_)
+            | Self::Construct(_)
             | Self::LoadData(_) => false,
         }
     }
@@ -397,6 +402,7 @@ impl LogicalOperator {
             Self::Return(op) => vec![&*op.input],
             Self::Unwind(op) => vec![&*op.input],
             Self::Bind(op) => vec![&*op.input],
+            Self::Construct(op) => vec![&*op.input],
             Self::MapCollect(op) => vec![&*op.input],
             Self::ShortestPath(op) => vec![&*op.input],
             Self::Merge(op) => vec![&*op.input],
@@ -1754,6 +1760,18 @@ pub struct TripleTemplate {
     pub object: TripleComponent,
     /// Named graph (optional).
     pub graph: Option<String>,
+}
+
+/// SPARQL CONSTRUCT: evaluate WHERE, substitute bindings into template.
+///
+/// Produces rows with columns `subject`, `predicate`, `object` by instantiating
+/// the template once per binding from the WHERE clause.
+#[derive(Debug, Clone)]
+pub struct ConstructOp {
+    /// Triple templates to instantiate.
+    pub templates: Vec<TripleTemplate>,
+    /// Input operator (WHERE clause evaluation).
+    pub input: Box<LogicalOperator>,
 }
 
 /// Clear all triples from a graph.

--- a/crates/grafeo-engine/src/query/planner/rdf/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/rdf/mod.rs
@@ -151,12 +151,6 @@ impl RdfPlanner {
     /// Creates a new RDF planner with the given store.
     #[must_use]
     pub fn new(store: Arc<RdfStore>) -> Self {
-        // Build the term dictionary eagerly so plan_triple_scan() can use it.
-        let dictionary = if !store.is_empty() {
-            Some(store.get_or_build_dictionary())
-        } else {
-            None
-        };
         Self {
             store,
             chunk_size: DEFAULT_CHUNK_SIZE,
@@ -164,7 +158,7 @@ impl RdfPlanner {
             profiling: std::cell::Cell::new(false),
             profile_entries: std::cell::RefCell::new(Vec::new()),
             needs_companion_columns: std::cell::Cell::new(false),
-            dictionary,
+            dictionary: None,
             encoded_columns: std::cell::RefCell::new(std::collections::HashSet::new()),
             #[cfg(feature = "wal")]
             wal: None,
@@ -1170,9 +1164,13 @@ impl RdfPlanner {
             ));
         }
 
-        // Try Ring-backed LeapfrogRing (WCOJ) when all inputs are TripleScans
+        // Try Ring-backed LeapfrogRing (WCOJ) when all inputs are TripleScans.
+        // Skip when companion columns are needed (LANG/DATATYPE functions)
+        // because the leapfrog operator emits raw variable columns only.
         #[cfg(feature = "ring-index")]
-        if let Some(result) = self.try_leapfrog_ring(mwj) {
+        if !self.needs_companion_columns.get()
+            && let Some(result) = self.try_leapfrog_ring(mwj)
+        {
             return result;
         }
 

--- a/crates/grafeo-engine/src/query/planner/rdf/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/rdf/mod.rs
@@ -138,12 +138,25 @@ pub struct RdfPlanner {
     /// Whether the query uses LANG()/LANGMATCHES()/DATATYPE() functions.
     /// When false, companion columns are not emitted, saving ~66% scan overhead.
     needs_companion_columns: std::cell::Cell<bool>,
+    /// Term dictionary for dictionary-encoded triple scans. When present,
+    /// `plan_triple_scan()` emits Int64 term IDs instead of strings, and a
+    /// `DictResolveOperator` at the result boundary converts them back.
+    dictionary: Option<Arc<grafeo_core::graph::rdf::TermDictionary>>,
+    /// Column names that carry dictionary-encoded Int64 term IDs.
+    /// Populated by `plan_triple_scan()`, consumed by `plan()` for resolution.
+    encoded_columns: std::cell::RefCell<std::collections::HashSet<String>>,
 }
 
 impl RdfPlanner {
     /// Creates a new RDF planner with the given store.
     #[must_use]
     pub fn new(store: Arc<RdfStore>) -> Self {
+        // Build the term dictionary eagerly so plan_triple_scan() can use it.
+        let dictionary = if !store.is_empty() {
+            Some(store.get_or_build_dictionary())
+        } else {
+            None
+        };
         Self {
             store,
             chunk_size: DEFAULT_CHUNK_SIZE,
@@ -151,6 +164,8 @@ impl RdfPlanner {
             profiling: std::cell::Cell::new(false),
             profile_entries: std::cell::RefCell::new(Vec::new()),
             needs_companion_columns: std::cell::Cell::new(false),
+            dictionary,
+            encoded_columns: std::cell::RefCell::new(std::collections::HashSet::new()),
             #[cfg(feature = "wal")]
             wal: None,
             #[cfg(feature = "cdc")]
@@ -205,7 +220,28 @@ impl RdfPlanner {
         self.needs_companion_columns
             .set(uses_lang_or_datatype(&logical_plan.root));
 
-        let (operator, columns, _types) = self.plan_operator(&logical_plan.root)?;
+        let (mut operator, columns, _types) = self.plan_operator(&logical_plan.root)?;
+
+        // Resolve dictionary-encoded columns back to strings at the result boundary.
+        if let Some(ref dict) = self.dictionary {
+            let encoded = self.encoded_columns.borrow();
+            if !encoded.is_empty() {
+                let encoded_indices: Vec<usize> = columns
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, name)| encoded.contains(*name))
+                    .map(|(i, _)| i)
+                    .collect();
+                if !encoded_indices.is_empty() {
+                    operator = Box::new(DictResolveOperator::new(
+                        operator,
+                        Arc::clone(dict),
+                        encoded_indices,
+                    ));
+                }
+            }
+        }
+
         // Strip internal companion columns (__lang_<var>, __datatype_<var>)
         // from the output. They are used by LANG()/LANGMATCHES()/DATATYPE()
         // during evaluation but should never appear in query results.
@@ -368,7 +404,7 @@ impl RdfPlanner {
         };
 
         // Create the lazy scanning operator
-        let operator = Box::new(RdfTripleScanOperator::new(
+        let scan_op = RdfTripleScanOperator::new(
             Arc::clone(&self.store),
             pattern,
             output_mask,
@@ -380,10 +416,18 @@ impl RdfPlanner {
             },
             emit_companion_columns,
             emit_datatype_column,
-        ));
+        );
+
+        // Dictionary encoding is available but not yet automatically enabled for
+        // all queries. The infrastructure (TermDictionary, DictResolveOperator) is
+        // in place for use by the Ring Index planner (Phase 4) and WCOJ joins.
+        // Automatic activation requires detecting whether downstream operators
+        // (FILTER, BIND, ORDER BY) inspect string content, which is deferred.
+        let _ = &self.dictionary; // suppress unused warning
+        let _ = &self.encoded_columns;
 
         let types = vec![LogicalType::String; columns.len()];
-        Ok((operator, columns, types))
+        Ok((Box::new(scan_op), columns, types))
     }
 
     /// Builds a TriplePattern from a TripleScanOp.
@@ -729,6 +773,13 @@ impl RdfPlanner {
         &self,
         agg: &AggregateOp,
     ) -> Result<(Box<dyn Operator>, Vec<String>, Vec<LogicalType>)> {
+        // COUNT(*) fast-path: when the aggregate is a single COUNT(*) with no
+        // GROUP BY, no DISTINCT, no HAVING, and the input is a fully-unbound
+        // TripleScan, short-circuit to store.len() in O(1).
+        if let Some(result) = self.try_count_fast_path(agg) {
+            return Ok(result);
+        }
+
         use grafeo_core::execution::operators::AggregateExpr as PhysicalAggregateExpr;
 
         let (mut input_op, input_columns, input_types) = self.plan_operator(&agg.input)?;
@@ -891,6 +942,115 @@ impl RdfPlanner {
         }
 
         Ok((operator, output_columns, output_schema))
+    }
+
+    /// Detects COUNT(*) over a TripleScan and returns the count directly when possible.
+    ///
+    /// Supported patterns (no GROUP BY, no DISTINCT, no HAVING):
+    /// - `COUNT(*) WHERE { ?s ?p ?o }`: fully unbound, returns `store.len()`
+    /// - `COUNT(*) WHERE { ?s <pred> ?o }`: predicate-bound, returns per-predicate count
+    /// - `COUNT(*) WHERE { GRAPH <g> { ?s ?p ?o } }`: per-graph count
+    fn try_count_fast_path(
+        &self,
+        agg: &AggregateOp,
+    ) -> Option<(Box<dyn Operator>, Vec<String>, Vec<LogicalType>)> {
+        // Must be: no GROUP BY, no HAVING, exactly one aggregate
+        if !agg.group_by.is_empty() || agg.having.is_some() || agg.aggregates.len() != 1 {
+            return None;
+        }
+
+        let agg_expr = &agg.aggregates[0];
+
+        // Must be COUNT(*): Count function, no expression (not COUNT(?x)), no DISTINCT
+        if agg_expr.function != LogicalAggregateFunction::Count
+            || agg_expr.expression.is_some()
+            || agg_expr.distinct
+        {
+            return None;
+        }
+
+        // Input must be a simple TripleScan (no chained input)
+        let scan = Self::find_simple_triple_scan(&agg.input)?;
+
+        // No dataset restriction (FROM / FROM NAMED)
+        if scan.dataset.is_some() {
+            return None;
+        }
+
+        let count = self.count_for_scan(scan)?;
+
+        let alias = agg_expr
+            .alias
+            .clone()
+            .unwrap_or_else(|| "count(*)".to_string());
+
+        Some(Self::make_constant_int64(count, alias))
+    }
+
+    /// Resolves the count for a simple triple scan pattern, or returns `None`
+    /// if the pattern is too complex for a fast-path.
+    fn count_for_scan(&self, scan: &TripleScanOp) -> Option<i64> {
+        let s_var = scan.subject.as_variable().is_some();
+        let p_var = scan.predicate.as_variable().is_some();
+        let o_var = scan.object.as_variable().is_some();
+
+        // Per-graph count: GRAPH <iri> { ?s ?p ?o }
+        if let Some(graph) = &scan.graph {
+            if s_var
+                && p_var
+                && o_var
+                && let TripleComponent::Iri(graph_iri) = graph
+            {
+                let ng = self.store.graph(graph_iri)?;
+                return Some(ng.len() as i64);
+            }
+            return None;
+        }
+
+        // Fully unbound: ?s ?p ?o
+        if s_var && p_var && o_var {
+            return Some(self.store.len() as i64);
+        }
+
+        // Predicate-bound: ?s <pred> ?o
+        if s_var && !p_var && o_var {
+            if let TripleComponent::Iri(pred_iri) = &scan.predicate {
+                let stats = self.store.get_or_collect_statistics();
+                if let Some(pred_stats) = stats.get_predicate(pred_iri) {
+                    return Some(pred_stats.triple_count as i64);
+                }
+            }
+            return None;
+        }
+
+        // Not a fast-path pattern
+        None
+    }
+
+    /// Creates a constant Int64 single-row result.
+    fn make_constant_int64(
+        value: i64,
+        column_name: String,
+    ) -> (Box<dyn Operator>, Vec<String>, Vec<LogicalType>) {
+        let mut chunk = DataChunk::with_capacity(&[LogicalType::Int64], 1);
+        chunk
+            .column_mut(0)
+            .expect("just created")
+            .push_value(Value::Int64(value));
+        chunk.set_count(1);
+        let operator = Box::new(ConstantOperator::new(chunk));
+        (operator, vec![column_name], vec![LogicalType::Int64])
+    }
+
+    /// Walks through the input operator to find a simple TripleScan (no chained input).
+    ///
+    /// Sees through Project operators.
+    fn find_simple_triple_scan(op: &LogicalOperator) -> Option<&TripleScanOp> {
+        match op {
+            LogicalOperator::TripleScan(scan) if scan.input.is_none() => Some(scan),
+            LogicalOperator::Project(proj) => Self::find_simple_triple_scan(&proj.input),
+            _ => None,
+        }
     }
 
     /// Plans a JOIN operator using HashJoin.
@@ -2769,6 +2929,133 @@ struct GraphContext {
     dataset: Option<DatasetRestriction>,
 }
 
+/// Operator that produces a single pre-computed `DataChunk` and then stops.
+///
+/// Used for fast-path results such as `COUNT(*)` short-circuits where the
+/// answer is known without scanning the data.
+struct ConstantOperator {
+    chunk: Option<DataChunk>,
+}
+
+impl ConstantOperator {
+    fn new(chunk: DataChunk) -> Self {
+        Self { chunk: Some(chunk) }
+    }
+}
+
+impl Operator for ConstantOperator {
+    fn next(&mut self) -> grafeo_core::execution::operators::OperatorResult {
+        Ok(self.chunk.take())
+    }
+
+    fn reset(&mut self) {
+        // Cannot reset: the chunk was consumed. This is fine for single-use
+        // fast-path results.
+    }
+
+    fn name(&self) -> &'static str {
+        "Constant"
+    }
+}
+
+/// Resolves dictionary-encoded Int64 term IDs back to String values.
+///
+/// Placed at the result boundary (just before output) so that all intermediate
+/// operators (joins, aggregates, sorts) work with compact Int64 keys.
+struct DictResolveOperator {
+    input: Box<dyn Operator>,
+    dictionary: Arc<grafeo_core::graph::rdf::TermDictionary>,
+    /// Column indices that carry encoded term IDs and need resolution.
+    encoded_col_indices: Vec<usize>,
+}
+
+impl DictResolveOperator {
+    fn new(
+        input: Box<dyn Operator>,
+        dictionary: Arc<grafeo_core::graph::rdf::TermDictionary>,
+        encoded_col_indices: Vec<usize>,
+    ) -> Self {
+        Self {
+            input,
+            dictionary,
+            encoded_col_indices,
+        }
+    }
+}
+
+impl Operator for DictResolveOperator {
+    fn next(&mut self) -> grafeo_core::execution::operators::OperatorResult {
+        let Some(chunk) = self.input.next()? else {
+            return Ok(None);
+        };
+
+        if self.encoded_col_indices.is_empty() {
+            return Ok(Some(chunk));
+        }
+
+        let row_count = chunk.row_count();
+        let col_count = chunk.column_count();
+
+        // Build output schema: replace Int64 encoded columns with String
+        let mut schema = Vec::with_capacity(col_count);
+        for col_idx in 0..col_count {
+            if self.encoded_col_indices.contains(&col_idx) {
+                schema.push(LogicalType::String);
+            } else if let Some(col) = chunk.column(col_idx) {
+                schema.push(col.data_type().clone());
+            } else {
+                schema.push(LogicalType::String);
+            }
+        }
+
+        let mut out = DataChunk::with_capacity(&schema, row_count);
+
+        for row in 0..row_count {
+            for col_idx in 0..col_count {
+                let Some(in_col) = chunk.column(col_idx) else {
+                    continue;
+                };
+                let Some(out_col) = out.column_mut(col_idx) else {
+                    continue;
+                };
+
+                if self.encoded_col_indices.contains(&col_idx) {
+                    // Resolve term ID to string
+                    if in_col.is_null(row) {
+                        out_col.push_value(Value::Null);
+                    } else if let Some(term_id) = in_col.get_int64(row) {
+                        if let Some(term) = self.dictionary.get_term(term_id as u32) {
+                            out_col.push_string(term_to_string(term));
+                        } else {
+                            out_col.push_value(Value::Null);
+                        }
+                    } else {
+                        out_col.push_value(Value::Null);
+                    }
+                } else {
+                    // Pass through non-encoded columns
+                    if let Some(val) = in_col.get_value(row) {
+                        out_col.push_value(val);
+                    } else {
+                        out_col.push_value(Value::Null);
+                    }
+                }
+            }
+        }
+
+        out.set_count(row_count);
+        Ok(Some(out))
+    }
+
+    fn reset(&mut self) {
+        self.input.reset();
+    }
+
+    fn name(&self) -> &'static str {
+        "DictResolve"
+    }
+}
+
 /// Lazy triple scan operator that processes triples in chunks.
 ///
 /// This operator queries the RDF store and emits results in DataChunks
@@ -2792,6 +3079,9 @@ struct RdfTripleScanOperator {
     triples: Option<Vec<(Option<String>, Arc<Triple>)>>,
     /// Current position in the triples.
     position: usize,
+    /// Optional term dictionary for dictionary-encoded output. When present,
+    /// S/P/O variable columns emit Int64 term IDs instead of String values.
+    dictionary: Option<Arc<grafeo_core::graph::rdf::TermDictionary>>,
 }
 
 impl RdfTripleScanOperator {
@@ -2814,7 +3104,18 @@ impl RdfTripleScanOperator {
             chunk_size,
             triples: None,
             position: 0,
+            dictionary: None,
         }
+    }
+
+    /// Enables dictionary-encoded output for S/P/O columns.
+    ///
+    /// Infrastructure for Phase 4 (Ring Index) which will automatically enable
+    /// dictionary encoding when the Ring provides native integer-keyed iteration.
+    #[allow(dead_code)]
+    fn with_dictionary(mut self, dict: Arc<grafeo_core::graph::rdf::TermDictionary>) -> Self {
+        self.dictionary = Some(dict);
+        self
     }
 
     /// Lazily load matching triples on first access.
@@ -2917,6 +3218,33 @@ impl RdfTripleScanOperator {
             base
         }
     }
+
+    /// Builds the output schema. In dictionary mode, S/P/O variable columns
+    /// are Int64 (term IDs), companion and graph columns remain String.
+    fn build_output_schema(&self, col_count: usize, dict_mode: bool) -> Vec<LogicalType> {
+        if !dict_mode {
+            return vec![LogicalType::String; col_count];
+        }
+        let mut schema = Vec::with_capacity(col_count);
+        // S, P, O variable columns get Int64
+        for i in 0..3 {
+            if self.output_mask[i] {
+                schema.push(LogicalType::Int64);
+            }
+        }
+        // Companion columns (lang, datatype) are always String
+        if self.output_mask[2] && self.emit_companion_columns {
+            schema.push(LogicalType::String); // lang
+            if self.emit_datatype_column {
+                schema.push(LogicalType::String); // datatype
+            }
+        }
+        // Graph column is always String
+        if self.output_mask[3] {
+            schema.push(LogicalType::String);
+        }
+        schema
+    }
 }
 
 impl Operator for RdfTripleScanOperator {
@@ -2936,8 +3264,9 @@ impl Operator for RdfTripleScanOperator {
         let batch_size = end - self.position;
         let col_count = self.output_column_count();
 
-        // Create output schema (all String for RDF)
-        let schema: Vec<LogicalType> = (0..col_count).map(|_| LogicalType::String).collect();
+        // Create output schema: Int64 for dictionary-encoded S/P/O, String otherwise
+        let dict_mode = self.dictionary.is_some();
+        let schema: Vec<LogicalType> = self.build_output_schema(col_count, dict_mode);
         let mut chunk = DataChunk::with_capacity(&schema, batch_size);
 
         // Fill the chunk
@@ -2948,25 +3277,49 @@ impl Operator for RdfTripleScanOperator {
             if self.output_mask[0] {
                 // Subject
                 if let Some(col) = chunk.column_mut(col_idx) {
-                    col.push_string(term_to_string(triple.subject()));
+                    if let Some(ref dict) = self.dictionary {
+                        if let Some(id) = dict.get_id(triple.subject()) {
+                            col.push_value(Value::Int64(i64::from(id)));
+                        } else {
+                            col.push_value(Value::Null);
+                        }
+                    } else {
+                        col.push_string(term_to_string(triple.subject()));
+                    }
                 }
                 col_idx += 1;
             }
             if self.output_mask[1] {
                 // Predicate
                 if let Some(col) = chunk.column_mut(col_idx) {
-                    col.push_string(term_to_string(triple.predicate()));
+                    if let Some(ref dict) = self.dictionary {
+                        if let Some(id) = dict.get_id(triple.predicate()) {
+                            col.push_value(Value::Int64(i64::from(id)));
+                        } else {
+                            col.push_value(Value::Null);
+                        }
+                    } else {
+                        col.push_string(term_to_string(triple.predicate()));
+                    }
                 }
                 col_idx += 1;
             }
             if self.output_mask[2] {
-                // Object
+                // Object: dictionary encoding applies here too
                 if let Some(col) = chunk.column_mut(col_idx) {
-                    push_term_value(col, triple.object());
+                    if let Some(ref dict) = self.dictionary {
+                        if let Some(id) = dict.get_id(triple.object()) {
+                            col.push_value(Value::Int64(i64::from(id)));
+                        } else {
+                            col.push_value(Value::Null);
+                        }
+                    } else {
+                        push_term_value(col, triple.object());
+                    }
                 }
                 col_idx += 1;
 
-                // Companion language-tag and datatype columns
+                // Companion language-tag and datatype columns (always String)
                 if self.emit_companion_columns {
                     if let Some(col) = chunk.column_mut(col_idx) {
                         let lang_tag = match triple.object() {
@@ -2990,7 +3343,7 @@ impl Operator for RdfTripleScanOperator {
                 }
             }
             if self.output_mask[3] {
-                // Graph
+                // Graph (always String)
                 if let Some(col) = chunk.column_mut(col_idx) {
                     match graph_name {
                         Some(name) => col.push_string(name.clone()),

--- a/crates/grafeo-engine/src/query/planner/rdf/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/rdf/mod.rs
@@ -1044,6 +1044,13 @@ impl RdfPlanner {
             return Some(self.store.len() as i64);
         }
 
+        // Ring Index: use ring.count() for any partially-bound pattern (O(log sigma))
+        #[cfg(feature = "ring-index")]
+        if let Some(ring) = self.store.ring() {
+            let pattern = self.build_triple_pattern(scan);
+            return Some(ring.count(&pattern) as i64);
+        }
+
         // Predicate-bound: ?s <pred> ?o
         if s_var && !p_var && o_var {
             if let TripleComponent::Iri(pred_iri) = &scan.predicate {
@@ -1148,10 +1155,9 @@ impl RdfPlanner {
         Ok((op, cols, left_types))
     }
 
-    /// Plans a multi-way join as cascading pairwise hash joins.
-    ///
-    /// Sorts inputs by estimated cardinality (smallest first) to minimize
-    /// intermediate result sizes, then folds them left-to-right.
+    /// Plans a multi-way join. When the Ring Index is available and all inputs
+    /// are TripleScans, uses LeapfrogRing (WCOJ) for worst-case optimal joins.
+    /// Otherwise falls back to cascading pairwise hash joins.
     fn plan_multi_way_join(
         &self,
         mwj: &crate::query::plan::MultiWayJoinOp,
@@ -1162,6 +1168,12 @@ impl RdfPlanner {
             return Err(Error::Internal(
                 "MultiWayJoin requires at least one input".to_string(),
             ));
+        }
+
+        // Try Ring-backed LeapfrogRing (WCOJ) when all inputs are TripleScans
+        #[cfg(feature = "ring-index")]
+        if let Some(result) = self.try_leapfrog_ring(mwj) {
+            return result;
         }
 
         // Plan all inputs and estimate cardinalities
@@ -1197,6 +1209,56 @@ impl RdfPlanner {
         }
 
         Ok((current_op, current_cols, current_types))
+    }
+
+    /// Attempts to plan a multi-way join using LeapfrogRing (WCOJ).
+    ///
+    /// Returns `Some(Ok(...))` when the Ring is available and all inputs are
+    /// simple TripleScans, `None` to fall back to cascading hash joins.
+    #[cfg(feature = "ring-index")]
+    fn try_leapfrog_ring(
+        &self,
+        mwj: &crate::query::plan::MultiWayJoinOp,
+    ) -> Option<Result<(Box<dyn Operator>, Vec<String>, Vec<LogicalType>)>> {
+        use grafeo_core::index::ring::AnnotatedPattern;
+
+        let ring = self.store.ring()?;
+
+        // All inputs must be simple TripleScans (no chained input, no graph context)
+        let mut annotated = Vec::new();
+        let mut all_vars: Vec<String> = Vec::new();
+        for input in &mwj.inputs {
+            let LogicalOperator::TripleScan(scan) = input else {
+                return None;
+            };
+            if scan.input.is_some() || scan.graph.is_some() || scan.dataset.is_some() {
+                return None;
+            }
+            let pattern = self.build_triple_pattern(scan);
+            let ap = AnnotatedPattern {
+                pattern,
+                subject_var: scan.subject.as_variable().map(str::to_string),
+                predicate_var: scan.predicate.as_variable().map(str::to_string),
+                object_var: scan.object.as_variable().map(str::to_string),
+            };
+            // Collect output variables in order
+            for v in [&ap.subject_var, &ap.predicate_var, &ap.object_var]
+                .into_iter()
+                .flatten()
+            {
+                if !all_vars.contains(v) {
+                    all_vars.push(v.clone());
+                }
+            }
+            annotated.push(ap);
+        }
+
+        // Build output columns and types
+        let columns = all_vars.clone();
+        let types = vec![LogicalType::String; columns.len()];
+
+        let operator = Box::new(RdfLeapfrogOperator::new(ring, annotated, columns.clone()));
+        Some(Ok((operator, columns, types)))
     }
 
     /// Plans a UNION operator.
@@ -2961,6 +3023,117 @@ struct GraphContext {
     dataset: Option<DatasetRestriction>,
 }
 
+/// LeapfrogRing WCOJ operator for Ring-backed multi-way joins.
+///
+/// Wraps `LeapfrogRing::with_variables()` and converts each join result
+/// (Vec<Triple>) into a `DataChunk` with the appropriate variable columns.
+#[cfg(feature = "ring-index")]
+struct RdfLeapfrogOperator {
+    ring: Arc<grafeo_core::index::ring::TripleRing>,
+    annotated_patterns: Vec<grafeo_core::index::ring::AnnotatedPattern>,
+    /// Output column names (deduplicated variables).
+    output_columns: Vec<String>,
+    /// Buffered results from the LeapfrogRing iterator.
+    results: Vec<Vec<Triple>>,
+    /// Current position in results buffer.
+    position: usize,
+    /// Whether the leapfrog join has been executed.
+    executed: bool,
+}
+
+#[cfg(feature = "ring-index")]
+impl RdfLeapfrogOperator {
+    fn new(
+        ring: Arc<grafeo_core::index::ring::TripleRing>,
+        annotated_patterns: Vec<grafeo_core::index::ring::AnnotatedPattern>,
+        output_columns: Vec<String>,
+    ) -> Self {
+        Self {
+            ring,
+            annotated_patterns,
+            output_columns,
+            results: Vec::new(),
+            position: 0,
+            executed: false,
+        }
+    }
+
+    fn execute_join(&mut self) {
+        if self.executed {
+            return;
+        }
+        self.executed = true;
+
+        let join = grafeo_core::index::ring::LeapfrogRing::with_variables(
+            &self.ring,
+            self.annotated_patterns.clone(),
+        );
+        self.results = join.collect();
+    }
+
+    /// Extracts the value for a variable from a set of matched triples.
+    fn resolve_variable(&self, var: &str, matched_triples: &[Triple]) -> Option<String> {
+        for (i, ap) in self.annotated_patterns.iter().enumerate() {
+            if let Some(triple) = matched_triples.get(i) {
+                if ap.subject_var.as_deref() == Some(var) {
+                    return Some(term_to_string(triple.subject()));
+                }
+                if ap.predicate_var.as_deref() == Some(var) {
+                    return Some(term_to_string(triple.predicate()));
+                }
+                if ap.object_var.as_deref() == Some(var) {
+                    return Some(term_to_string(triple.object()));
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(feature = "ring-index")]
+impl Operator for RdfLeapfrogOperator {
+    fn next(&mut self) -> grafeo_core::execution::operators::OperatorResult {
+        self.execute_join();
+
+        if self.position >= self.results.len() {
+            return Ok(None);
+        }
+
+        let end = (self.position + DEFAULT_CHUNK_SIZE).min(self.results.len());
+        let batch_size = end - self.position;
+        let col_count = self.output_columns.len();
+
+        let schema = vec![LogicalType::String; col_count];
+        let mut chunk = DataChunk::with_capacity(&schema, batch_size);
+
+        for i in self.position..end {
+            let matched = &self.results[i];
+            for (col_idx, var_name) in self.output_columns.iter().enumerate() {
+                if let Some(col) = chunk.column_mut(col_idx) {
+                    if let Some(val) = self.resolve_variable(var_name, matched) {
+                        col.push_string(val);
+                    } else {
+                        col.push_value(Value::Null);
+                    }
+                }
+            }
+        }
+
+        chunk.set_count(batch_size);
+        self.position = end;
+        Ok(Some(chunk))
+    }
+
+    fn reset(&mut self) {
+        self.position = 0;
+        // Keep results cached
+    }
+
+    fn name(&self) -> &'static str {
+        "RdfLeapfrog"
+    }
+}
+
 /// CONSTRUCT operator: instantiates triple templates from variable bindings.
 ///
 /// For each input row, substitutes variables in each template triple to produce
@@ -3344,12 +3517,30 @@ impl RdfTripleScanOperator {
                         Vec::new()
                     }
                 } else {
-                    // No dataset restriction: use actual default graph
-                    self.store
-                        .find(&self.pattern)
-                        .into_iter()
-                        .map(|t| (None, t))
-                        .collect()
+                    // No dataset restriction: use actual default graph.
+                    // Prefer Ring Index when available (O(log sigma) access).
+                    #[cfg(feature = "ring-index")]
+                    {
+                        if let Some(ring) = self.store.ring() {
+                            ring.find(&self.pattern)
+                                .map(|t| (None, Arc::new(t)))
+                                .collect()
+                        } else {
+                            self.store
+                                .find(&self.pattern)
+                                .into_iter()
+                                .map(|t| (None, t))
+                                .collect()
+                        }
+                    }
+                    #[cfg(not(feature = "ring-index"))]
+                    {
+                        self.store
+                            .find(&self.pattern)
+                            .into_iter()
+                            .map(|t| (None, t))
+                            .collect()
+                    }
                 }
             });
         }

--- a/crates/grafeo-engine/src/query/planner/rdf/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/rdf/mod.rs
@@ -5102,8 +5102,9 @@ fn uses_lang_or_datatype(op: &LogicalOperator) -> bool {
         Skip(s) => uses_lang_or_datatype(&s.input),
         Unwind(u) => uses_lang_or_datatype(&u.input),
         TripleScan(t) => t.input.as_ref().is_some_and(|i| uses_lang_or_datatype(i)),
+        LogicalOperator::MultiWayJoin(mwj) => mwj.inputs.iter().any(uses_lang_or_datatype),
         // For any other operator, conservatively assume companion columns are needed
-        _ => false,
+        _ => true,
     }
 }
 
@@ -5806,5 +5807,1082 @@ mod tests {
         });
         let (_op, _cols, skip_types) = planner.plan_operator(&skipped).unwrap();
         assert_eq!(scan_types, skip_types, "Skip preserves types");
+    }
+
+    #[test]
+    fn test_plan_filter_with_comparison() {
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/age"),
+            Term::typed_literal("30", "http://www.w3.org/2001/XMLSchema#integer"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/gus"),
+            Term::iri("http://xmlns.com/foaf/0.1/age"),
+            Term::typed_literal("20", "http://www.w3.org/2001/XMLSchema#integer"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let scan = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/age".to_string()),
+            object: TripleComponent::Variable("age".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let filter = LogicalOperator::Filter(FilterOp {
+            predicate: LogicalExpression::Binary {
+                left: Box::new(LogicalExpression::Variable("age".to_string())),
+                op: crate::query::plan::BinaryOp::Gt,
+                right: Box::new(LogicalExpression::Literal(Value::String("25".into()))),
+            },
+            input: Box::new(scan),
+            pushdown_hint: None,
+        });
+        let physical = planner.plan(&LogicalPlan::new(filter)).unwrap();
+        assert_eq!(physical.columns, vec!["s", "age"]);
+        let mut op = physical.operator;
+        let mut rows = 0;
+        while let Ok(Some(c)) = op.next() {
+            rows += c.row_count();
+        }
+        assert_eq!(rows, 1);
+    }
+
+    #[test]
+    fn test_plan_aggregate_count_star_fast_path() {
+        use crate::query::plan::{AggregateExpr, AggregateFunction, AggregateOp};
+        let store = Arc::new(RdfStore::new());
+        for i in 0..10 {
+            store.insert(Triple::new(
+                Term::iri(format!("http://example.org/item{i}")),
+                Term::iri("http://example.org/value"),
+                Term::literal(i.to_string()),
+            ));
+        }
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let scan = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Variable("p".to_string()),
+            object: TripleComponent::Variable("o".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let agg = LogicalOperator::Aggregate(AggregateOp {
+            input: Box::new(scan),
+            group_by: vec![],
+            aggregates: vec![AggregateExpr {
+                function: AggregateFunction::Count,
+                expression: None,
+                expression2: None,
+                distinct: false,
+                alias: Some("cnt".to_string()),
+                percentile: None,
+                separator: None,
+            }],
+            having: None,
+        });
+        let physical = planner.plan(&LogicalPlan::new(agg)).unwrap();
+        let mut op = physical.operator;
+        let chunk = op.next().unwrap().unwrap();
+        assert_eq!(
+            chunk.column(0).unwrap().get_value(0),
+            Some(Value::Int64(10))
+        );
+    }
+
+    #[test]
+    fn test_plan_aggregate_with_having() {
+        use crate::query::plan::{AggregateExpr, AggregateFunction, AggregateOp};
+        let store = Arc::new(RdfStore::new());
+        for i in 0..3 {
+            store.insert(Triple::new(
+                Term::iri("http://example.org/alix"),
+                Term::iri(format!("http://example.org/p{i}")),
+                Term::literal(format!("val{i}")),
+            ));
+        }
+        store.insert(Triple::new(
+            Term::iri("http://example.org/gus"),
+            Term::iri("http://example.org/p0"),
+            Term::literal("gus_val"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let scan = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Variable("p".to_string()),
+            object: TripleComponent::Variable("o".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let agg = LogicalOperator::Aggregate(AggregateOp {
+            input: Box::new(scan),
+            group_by: vec![LogicalExpression::Variable("s".to_string())],
+            aggregates: vec![AggregateExpr {
+                function: AggregateFunction::Count,
+                expression: None,
+                expression2: None,
+                distinct: false,
+                alias: Some("cnt".to_string()),
+                percentile: None,
+                separator: None,
+            }],
+            having: Some(LogicalExpression::Binary {
+                left: Box::new(LogicalExpression::Variable("cnt".to_string())),
+                op: crate::query::plan::BinaryOp::Gt,
+                right: Box::new(LogicalExpression::Literal(Value::String("1".into()))),
+            }),
+        });
+        let physical = planner.plan(&LogicalPlan::new(agg)).unwrap();
+        let mut op = physical.operator;
+        let mut rows = 0;
+        while let Ok(Some(c)) = op.next() {
+            rows += c.row_count();
+        }
+        assert_eq!(rows, 1);
+    }
+
+    #[test]
+    fn test_plan_aggregate_sum_avg() {
+        use crate::query::plan::{AggregateExpr, AggregateFunction, AggregateOp};
+        let store = Arc::new(RdfStore::new());
+        for i in 1..=4 {
+            store.insert(Triple::new(
+                Term::iri("http://example.org/a"),
+                Term::iri("http://example.org/val"),
+                Term::typed_literal(i.to_string(), "http://www.w3.org/2001/XMLSchema#integer"),
+            ));
+        }
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let scan = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://example.org/val".to_string()),
+            object: TripleComponent::Variable("v".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let agg = LogicalOperator::Aggregate(AggregateOp {
+            input: Box::new(scan),
+            group_by: vec![],
+            aggregates: vec![
+                AggregateExpr {
+                    function: AggregateFunction::Sum,
+                    expression: Some(LogicalExpression::Variable("v".to_string())),
+                    expression2: None,
+                    distinct: false,
+                    alias: Some("total".to_string()),
+                    percentile: None,
+                    separator: None,
+                },
+                AggregateExpr {
+                    function: AggregateFunction::Avg,
+                    expression: Some(LogicalExpression::Variable("v".to_string())),
+                    expression2: None,
+                    distinct: false,
+                    alias: Some("average".to_string()),
+                    percentile: None,
+                    separator: None,
+                },
+            ],
+            having: None,
+        });
+        let physical = planner.plan(&LogicalPlan::new(agg)).unwrap();
+        assert_eq!(physical.columns, vec!["total", "average"]);
+    }
+
+    #[test]
+    fn test_plan_join_execution() {
+        use crate::query::plan::JoinOp;
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Alix"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/age"),
+            Term::typed_literal("30", "http://www.w3.org/2001/XMLSchema#integer"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/gus"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Gus"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let left = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+            object: TripleComponent::Variable("name".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let right = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/age".to_string()),
+            object: TripleComponent::Variable("age".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let join = LogicalOperator::Join(JoinOp {
+            left: Box::new(left),
+            right: Box::new(right),
+            join_type: JoinType::Inner,
+            conditions: vec![],
+        });
+        let physical = planner.plan(&LogicalPlan::new(join)).unwrap();
+        let mut op = physical.operator;
+        let mut rows = 0;
+        while let Ok(Some(c)) = op.next() {
+            rows += c.row_count();
+        }
+        assert_eq!(rows, 1);
+    }
+
+    #[test]
+    fn test_plan_left_join() {
+        use crate::query::plan::LeftJoinOp;
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Alix"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/gus"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Gus"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/age"),
+            Term::typed_literal("30", "http://www.w3.org/2001/XMLSchema#integer"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let left = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+            object: TripleComponent::Variable("name".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let right = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/age".to_string()),
+            object: TripleComponent::Variable("age".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let join = LogicalOperator::LeftJoin(LeftJoinOp {
+            left: Box::new(left),
+            right: Box::new(right),
+            condition: None,
+        });
+        let physical = planner.plan(&LogicalPlan::new(join)).unwrap();
+        let mut op = physical.operator;
+        let mut rows = 0;
+        while let Ok(Some(c)) = op.next() {
+            rows += c.row_count();
+        }
+        assert_eq!(rows, 2);
+    }
+
+    #[test]
+    fn test_plan_anti_join() {
+        use crate::query::plan::AntiJoinOp;
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Alix"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/gus"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Gus"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/age"),
+            Term::typed_literal("30", "http://www.w3.org/2001/XMLSchema#integer"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let left = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+            object: TripleComponent::Variable("name".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let right = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/age".to_string()),
+            object: TripleComponent::Variable("age".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let anti = LogicalOperator::AntiJoin(AntiJoinOp {
+            left: Box::new(left),
+            right: Box::new(right),
+        });
+        let physical = planner.plan(&LogicalPlan::new(anti)).unwrap();
+        let mut op = physical.operator;
+        let mut rows = 0;
+        while let Ok(Some(c)) = op.next() {
+            rows += c.row_count();
+        }
+        assert_eq!(rows, 1);
+    }
+
+    #[test]
+    fn test_plan_sort() {
+        use crate::query::plan::{SortKey, SortOp, SortOrder};
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/c"),
+            Term::iri("http://example.org/val"),
+            Term::literal("3"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/a"),
+            Term::iri("http://example.org/val"),
+            Term::literal("1"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/b"),
+            Term::iri("http://example.org/val"),
+            Term::literal("2"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let scan = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://example.org/val".to_string()),
+            object: TripleComponent::Variable("v".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let sort = LogicalOperator::Sort(SortOp {
+            keys: vec![SortKey {
+                expression: LogicalExpression::Variable("v".to_string()),
+                order: SortOrder::Ascending,
+                nulls: None,
+            }],
+            input: Box::new(scan),
+        });
+        let physical = planner.plan(&LogicalPlan::new(sort)).unwrap();
+        assert_eq!(physical.columns, vec!["s", "v"]);
+        let mut op = physical.operator;
+        let mut vals = Vec::new();
+        while let Ok(Some(chunk)) = op.next() {
+            if let Some(col) = chunk.column(1) {
+                for row in 0..chunk.row_count() {
+                    if let Some(v) = col.get_value(row) {
+                        vals.push(v);
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            vals,
+            vec![
+                Value::String("1".into()),
+                Value::String("2".into()),
+                Value::String("3".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_plan_insert_triple_concrete() {
+        let store = Arc::new(RdfStore::new());
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let insert = LogicalOperator::InsertTriple(InsertTripleOp {
+            subject: TripleComponent::Iri("http://example.org/alix".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+            object: TripleComponent::Literal(Value::String("Alix".into())),
+            graph: None,
+            input: None,
+        });
+        let physical = planner.plan(&LogicalPlan::new(insert)).unwrap();
+        let mut op = physical.operator;
+        while op.next().unwrap().is_some() {}
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn test_plan_insert_triple_into_named_graph() {
+        let store = Arc::new(RdfStore::new());
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let insert = LogicalOperator::InsertTriple(InsertTripleOp {
+            subject: TripleComponent::Iri("http://example.org/alix".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+            object: TripleComponent::Literal(Value::String("Alix".into())),
+            graph: Some("http://example.org/g1".to_string()),
+            input: None,
+        });
+        let physical = planner.plan(&LogicalPlan::new(insert)).unwrap();
+        let mut op = physical.operator;
+        while op.next().unwrap().is_some() {}
+        assert_eq!(store.graph("http://example.org/g1").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_plan_delete_triple_concrete() {
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Alix"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let delete = LogicalOperator::DeleteTriple(DeleteTripleOp {
+            subject: TripleComponent::Iri("http://example.org/alix".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+            object: TripleComponent::Literal(Value::String("Alix".into())),
+            graph: None,
+            input: None,
+        });
+        let physical = planner.plan(&LogicalPlan::new(delete)).unwrap();
+        let mut op = physical.operator;
+        while op.next().unwrap().is_some() {}
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn test_plan_insert_pattern_from_where() {
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Alix"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let where_scan = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+            object: TripleComponent::Variable("name".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let insert = LogicalOperator::InsertTriple(InsertTripleOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://example.org/label".to_string()),
+            object: TripleComponent::Variable("name".to_string()),
+            graph: None,
+            input: Some(Box::new(where_scan)),
+        });
+        let physical = planner.plan(&LogicalPlan::new(insert)).unwrap();
+        let mut op = physical.operator;
+        while op.next().unwrap().is_some() {}
+        assert_eq!(store.len(), 2);
+    }
+
+    #[test]
+    fn test_plan_delete_pattern_from_where() {
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Alix"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/gus"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Gus"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let where_scan = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Variable("p".to_string()),
+            object: TripleComponent::Variable("o".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let delete = LogicalOperator::DeleteTriple(DeleteTripleOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Variable("p".to_string()),
+            object: TripleComponent::Variable("o".to_string()),
+            graph: None,
+            input: Some(Box::new(where_scan)),
+        });
+        let physical = planner.plan(&LogicalPlan::new(delete)).unwrap();
+        let mut op = physical.operator;
+        while op.next().unwrap().is_some() {}
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn test_plan_modify_delete_insert_where() {
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Alix"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let where_scan = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+            object: TripleComponent::Variable("old".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let modify = LogicalOperator::Modify(ModifyOp {
+            delete_templates: vec![TripleTemplate {
+                subject: TripleComponent::Variable("s".to_string()),
+                predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+                object: TripleComponent::Variable("old".to_string()),
+                graph: None,
+            }],
+            insert_templates: vec![TripleTemplate {
+                subject: TripleComponent::Variable("s".to_string()),
+                predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+                object: TripleComponent::Literal(Value::String("Alix R.".into())),
+                graph: None,
+            }],
+            where_clause: Box::new(where_scan),
+            graph: None,
+        });
+        let physical = planner.plan(&LogicalPlan::new(modify)).unwrap();
+        let mut op = physical.operator;
+        while op.next().unwrap().is_some() {}
+        assert_eq!(store.len(), 1);
+        let all = store.find(&TriplePattern {
+            subject: None,
+            predicate: None,
+            object: None,
+        });
+        assert_eq!(all[0].object().to_string(), "\"Alix R.\"");
+    }
+
+    #[test]
+    fn test_plan_union() {
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Alix"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/gus"),
+            Term::iri("http://example.org/label"),
+            Term::literal("Gus"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let scan1 = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+            object: TripleComponent::Variable("o".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let scan2 = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://example.org/label".to_string()),
+            object: TripleComponent::Variable("o".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let union = LogicalOperator::Union(crate::query::plan::UnionOp {
+            inputs: vec![scan1, scan2],
+        });
+        let physical = planner.plan(&LogicalPlan::new(union)).unwrap();
+        let mut op = physical.operator;
+        let mut rows = 0;
+        while let Ok(Some(c)) = op.next() {
+            rows += c.row_count();
+        }
+        assert_eq!(rows, 2);
+    }
+
+    #[test]
+    fn test_plan_construct() {
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Alix"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let scan = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+            object: TripleComponent::Variable("name".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let construct = LogicalOperator::Construct(ConstructOp {
+            templates: vec![TripleTemplate {
+                subject: TripleComponent::Variable("s".to_string()),
+                predicate: TripleComponent::Iri("http://example.org/label".to_string()),
+                object: TripleComponent::Variable("name".to_string()),
+                graph: None,
+            }],
+            input: Box::new(scan),
+        });
+        let physical = planner.plan(&LogicalPlan::new(construct)).unwrap();
+        assert_eq!(physical.columns, vec!["subject", "predicate", "object"]);
+        let mut op = physical.operator;
+        let mut rows = 0;
+        while let Ok(Some(c)) = op.next() {
+            rows += c.row_count();
+        }
+        assert_eq!(rows, 1);
+    }
+
+    #[test]
+    fn test_plan_bind_execution() {
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Alix"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let scan = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+            object: TripleComponent::Variable("name".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let bind = LogicalOperator::Bind(BindOp {
+            input: Box::new(scan),
+            variable: "upper".to_string(),
+            expression: crate::query::plan::LogicalExpression::FunctionCall {
+                name: "UCASE".to_string(),
+                args: vec![crate::query::plan::LogicalExpression::Variable(
+                    "name".to_string(),
+                )],
+                distinct: false,
+            },
+        });
+        let physical = planner.plan(&LogicalPlan::new(bind)).unwrap();
+        assert!(physical.columns.contains(&"upper".to_string()));
+        let mut op = physical.operator;
+        let chunk = op.next().unwrap().unwrap();
+        let upper_idx = physical.columns.iter().position(|c| c == "upper").unwrap();
+        assert_eq!(
+            chunk.column(upper_idx).unwrap().get_value(0),
+            Some(Value::String("ALIX".into()))
+        );
+    }
+
+    #[test]
+    fn test_plan_project_with_expression() {
+        use crate::query::plan::{ProjectOp, Projection};
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Alix"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let scan = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+            object: TripleComponent::Variable("name".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let project = LogicalOperator::Project(ProjectOp {
+            projections: vec![
+                Projection {
+                    expression: LogicalExpression::Variable("name".to_string()),
+                    alias: Some("n".to_string()),
+                },
+                Projection {
+                    expression: LogicalExpression::Literal(Value::String("const".into())),
+                    alias: Some("c".to_string()),
+                },
+            ],
+            input: Box::new(scan),
+            pass_through_input: false,
+        });
+        let physical = planner.plan(&LogicalPlan::new(project)).unwrap();
+        assert_eq!(physical.columns, vec!["n", "c"]);
+        let mut op = physical.operator;
+        let chunk = op.next().unwrap().unwrap();
+        assert_eq!(
+            chunk.column(0).unwrap().get_value(0),
+            Some(Value::String("Alix".into()))
+        );
+        assert_eq!(
+            chunk.column(1).unwrap().get_value(0),
+            Some(Value::String("const".into()))
+        );
+    }
+
+    #[test]
+    fn test_plan_create_graph() {
+        let store = Arc::new(RdfStore::new());
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let physical = planner
+            .plan(&LogicalPlan::new(LogicalOperator::CreateGraph(
+                CreateGraphOp {
+                    graph: "http://example.org/g1".to_string(),
+                    silent: false,
+                },
+            )))
+            .unwrap();
+        let mut op = physical.operator;
+        while op.next().unwrap().is_some() {}
+        assert!(store.graph("http://example.org/g1").is_some());
+    }
+
+    #[test]
+    fn test_plan_create_graph_already_exists_errors() {
+        let store = Arc::new(RdfStore::new());
+        store.create_graph("http://example.org/g1");
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let mut physical = planner
+            .plan(&LogicalPlan::new(LogicalOperator::CreateGraph(
+                CreateGraphOp {
+                    graph: "http://example.org/g1".to_string(),
+                    silent: false,
+                },
+            )))
+            .unwrap();
+        assert!(physical.operator.next().is_err());
+    }
+
+    #[test]
+    fn test_plan_create_graph_silent() {
+        let store = Arc::new(RdfStore::new());
+        store.create_graph("http://example.org/g1");
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let mut physical = planner
+            .plan(&LogicalPlan::new(LogicalOperator::CreateGraph(
+                CreateGraphOp {
+                    graph: "http://example.org/g1".to_string(),
+                    silent: true,
+                },
+            )))
+            .unwrap();
+        assert!(physical.operator.next().is_ok());
+    }
+
+    #[test]
+    fn test_plan_drop_graph() {
+        let store = Arc::new(RdfStore::new());
+        store.create_graph("http://example.org/g1");
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let physical = planner
+            .plan(&LogicalPlan::new(LogicalOperator::DropGraph(DropGraphOp {
+                graph: Some("http://example.org/g1".to_string()),
+                silent: false,
+            })))
+            .unwrap();
+        let mut op = physical.operator;
+        while op.next().unwrap().is_some() {}
+        assert!(store.graph("http://example.org/g1").is_none());
+    }
+
+    #[test]
+    fn test_plan_drop_nonexistent_graph_errors() {
+        let store = Arc::new(RdfStore::new());
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let mut physical = planner
+            .plan(&LogicalPlan::new(LogicalOperator::DropGraph(DropGraphOp {
+                graph: Some("http://example.org/nope".to_string()),
+                silent: false,
+            })))
+            .unwrap();
+        assert!(physical.operator.next().is_err());
+    }
+
+    #[test]
+    fn test_plan_drop_default_graph() {
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/a"),
+            Term::iri("http://example.org/b"),
+            Term::literal("c"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let physical = planner
+            .plan(&LogicalPlan::new(LogicalOperator::DropGraph(DropGraphOp {
+                graph: None,
+                silent: false,
+            })))
+            .unwrap();
+        let mut op = physical.operator;
+        while op.next().unwrap().is_some() {}
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn test_plan_clear_graph_default() {
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/a"),
+            Term::iri("http://example.org/b"),
+            Term::literal("c"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let physical = planner
+            .plan(&LogicalPlan::new(LogicalOperator::ClearGraph(
+                ClearGraphOp {
+                    graph: None,
+                    silent: false,
+                },
+            )))
+            .unwrap();
+        let mut op = physical.operator;
+        while op.next().unwrap().is_some() {}
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn test_plan_clear_all_graphs() {
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/a"),
+            Term::iri("http://example.org/b"),
+            Term::literal("c"),
+        ));
+        store.create_graph("http://example.org/g1");
+        store
+            .graph("http://example.org/g1")
+            .unwrap()
+            .insert(Triple::new(
+                Term::iri("http://example.org/x"),
+                Term::iri("http://example.org/y"),
+                Term::literal("z"),
+            ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let physical = planner
+            .plan(&LogicalPlan::new(LogicalOperator::ClearGraph(
+                ClearGraphOp {
+                    graph: Some(String::new()),
+                    silent: false,
+                },
+            )))
+            .unwrap();
+        let mut op = physical.operator;
+        while op.next().unwrap().is_some() {}
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn test_plan_multi_way_join_hash_fallback() {
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Alix"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/age"),
+            Term::typed_literal("30", "http://www.w3.org/2001/XMLSchema#integer"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/knows"),
+            Term::iri("http://example.org/gus"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let scan1 = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/name".to_string()),
+            object: TripleComponent::Variable("name".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let scan2 = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/age".to_string()),
+            object: TripleComponent::Variable("age".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let scan3 = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://xmlns.com/foaf/0.1/knows".to_string()),
+            object: TripleComponent::Variable("friend".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let mwj = LogicalOperator::MultiWayJoin(crate::query::plan::MultiWayJoinOp {
+            inputs: vec![scan1, scan2, scan3],
+            conditions: vec![],
+            shared_variables: vec!["s".to_string()],
+        });
+        let physical = planner.plan(&LogicalPlan::new(mwj)).unwrap();
+        let mut op = physical.operator;
+        let mut rows = 0;
+        while let Ok(Some(c)) = op.next() {
+            rows += c.row_count();
+        }
+        assert_eq!(rows, 1);
+    }
+
+    #[test]
+    fn test_plan_profiled() {
+        let store = Arc::new(RdfStore::new());
+        store.insert(Triple::new(
+            Term::iri("http://example.org/alix"),
+            Term::iri("http://xmlns.com/foaf/0.1/name"),
+            Term::literal("Alix"),
+        ));
+        let planner = RdfPlanner::new(store);
+        let plan = LogicalPlan::new(LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Variable("p".to_string()),
+            object: TripleComponent::Variable("o".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        }));
+        let (physical, entries) = planner.plan_profiled(&plan).unwrap();
+        assert_eq!(physical.columns, vec!["s", "p", "o"]);
+        assert!(!entries.is_empty());
+    }
+
+    #[test]
+    fn test_plan_unsupported_operator_returns_error() {
+        let store = Arc::new(RdfStore::new());
+        let planner = RdfPlanner::new(store);
+        let map = LogicalOperator::MapCollect(crate::query::plan::MapCollectOp {
+            input: Box::new(LogicalOperator::Empty),
+            key_var: "k".to_string(),
+            value_var: "v".to_string(),
+            alias: "m".to_string(),
+        });
+        assert!(planner.plan(&LogicalPlan::new(map)).is_err());
+    }
+
+    #[test]
+    fn test_plan_empty_operator() {
+        let store = Arc::new(RdfStore::new());
+        let planner = RdfPlanner::new(store);
+        let physical = planner
+            .plan(&LogicalPlan::new(LogicalOperator::Empty))
+            .unwrap();
+        assert!(physical.columns.is_empty());
+    }
+
+    #[test]
+    fn test_component_to_term_conversions() {
+        let store = Arc::new(RdfStore::new());
+        let planner = RdfPlanner::new(store);
+        assert!(matches!(
+            planner
+                .component_to_term(&TripleComponent::Iri("http://example.org/x".to_string()))
+                .unwrap(),
+            Term::Iri(_)
+        ));
+        assert!(matches!(
+            planner
+                .component_to_term(&TripleComponent::Literal(Value::String("hello".into())))
+                .unwrap(),
+            Term::Literal(_)
+        ));
+        assert!(matches!(
+            planner
+                .component_to_term(&TripleComponent::Literal(Value::Int64(42)))
+                .unwrap(),
+            Term::Literal(_)
+        ));
+        assert!(matches!(
+            planner
+                .component_to_term(&TripleComponent::Literal(Value::Float64(2.72)))
+                .unwrap(),
+            Term::Literal(_)
+        ));
+        assert!(matches!(
+            planner
+                .component_to_term(&TripleComponent::Literal(Value::Bool(true)))
+                .unwrap(),
+            Term::Literal(_)
+        ));
+        assert!(matches!(
+            planner
+                .component_to_term(&TripleComponent::LangLiteral {
+                    value: "hello".to_string(),
+                    lang: "en".to_string()
+                })
+                .unwrap(),
+            Term::Literal(_)
+        ));
+        assert!(matches!(
+            planner
+                .component_to_term(&TripleComponent::BlankNode("b0".to_string()))
+                .unwrap(),
+            Term::BlankNode(_)
+        ));
+        assert!(
+            planner
+                .component_to_term(&TripleComponent::Variable("x".to_string()))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_count_fast_path_predicate_bound() {
+        use crate::query::plan::{AggregateExpr, AggregateFunction, AggregateOp};
+        let store = Arc::new(RdfStore::new());
+        for i in 0..5 {
+            store.insert(Triple::new(
+                Term::iri(format!("http://example.org/item{i}")),
+                Term::iri("http://example.org/type"),
+                Term::literal(format!("val{i}")),
+            ));
+        }
+        store.insert(Triple::new(
+            Term::iri("http://example.org/other"),
+            Term::iri("http://example.org/other_pred"),
+            Term::literal("x"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let scan = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://example.org/type".to_string()),
+            object: TripleComponent::Variable("o".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let agg = LogicalOperator::Aggregate(AggregateOp {
+            input: Box::new(scan),
+            group_by: vec![],
+            aggregates: vec![AggregateExpr {
+                function: AggregateFunction::Count,
+                expression: None,
+                expression2: None,
+                distinct: false,
+                alias: Some("cnt".to_string()),
+                percentile: None,
+                separator: None,
+            }],
+            having: None,
+        });
+        let physical = planner.plan(&LogicalPlan::new(agg)).unwrap();
+        let mut op = physical.operator;
+        let chunk = op.next().unwrap().unwrap();
+        assert_eq!(chunk.column(0).unwrap().get_value(0), Some(Value::Int64(5)));
     }
 }

--- a/crates/grafeo-engine/src/query/planner/rdf/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/rdf/mod.rs
@@ -23,10 +23,10 @@ use grafeo_core::graph::rdf::{Literal, RdfStore, Term, Triple, TriplePattern};
 
 use crate::query::plan::{
     AddGraphOp, AggregateFunction as LogicalAggregateFunction, AggregateOp, AntiJoinOp, BindOp,
-    ClearGraphOp, CopyGraphOp, CreateGraphOp, DatasetRestriction, DeleteTripleOp, DistinctOp,
-    DropGraphOp, FilterOp, InsertTripleOp, LeftJoinOp, LimitOp, LogicalExpression, LogicalOperator,
-    LogicalPlan, ModifyOp, MoveGraphOp, SkipOp, SortOp, TripleComponent, TripleScanOp,
-    TripleTemplate,
+    ClearGraphOp, ConstructOp, CopyGraphOp, CreateGraphOp, DatasetRestriction, DeleteTripleOp,
+    DistinctOp, DropGraphOp, FilterOp, InsertTripleOp, LeftJoinOp, LimitOp, LogicalExpression,
+    LogicalOperator, LogicalPlan, ModifyOp, MoveGraphOp, SkipOp, SortOp, TripleComponent,
+    TripleScanOp, TripleTemplate,
 };
 use crate::query::planner::{PhysicalPlan, convert_aggregate_function, convert_filter_expression};
 
@@ -333,6 +333,7 @@ impl RdfPlanner {
             LogicalOperator::MoveGraph(move_op) => self.plan_move_graph(move_op),
             LogicalOperator::AddGraph(add) => self.plan_add_graph(add),
             LogicalOperator::Bind(bind) => self.plan_bind(bind),
+            LogicalOperator::Construct(construct) => self.plan_construct(construct),
             LogicalOperator::MultiWayJoin(mwj) => self.plan_multi_way_join(mwj),
             LogicalOperator::Empty => {
                 let op: Box<dyn Operator> = Box::new(SingleRowOperator::new());
@@ -766,6 +767,37 @@ impl RdfPlanner {
             variable_columns,
         ));
         Ok((operator, output_columns, input_types))
+    }
+
+    /// Plans a CONSTRUCT operator.
+    ///
+    /// Evaluates the WHERE clause, then for each row substitutes variable
+    /// bindings into the template to produce (subject, predicate, object) rows.
+    fn plan_construct(
+        &self,
+        construct: &ConstructOp,
+    ) -> Result<(Box<dyn Operator>, Vec<String>, Vec<LogicalType>)> {
+        let (input_op, input_columns, _input_types) = self.plan_operator(&construct.input)?;
+
+        let variable_columns: HashMap<String, usize> = input_columns
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.clone(), i))
+            .collect();
+
+        let operator = Box::new(ConstructOperator::new(
+            input_op,
+            construct.templates.clone(),
+            variable_columns,
+        ));
+
+        let columns = vec![
+            "subject".to_string(),
+            "predicate".to_string(),
+            "object".to_string(),
+        ];
+        let types = vec![LogicalType::String; 3];
+        Ok((operator, columns, types))
     }
 
     /// Plans an AGGREGATE operator.
@@ -2927,6 +2959,120 @@ struct GraphContext {
     scan_all_graphs: bool,
     /// SPARQL dataset restriction from FROM / FROM NAMED clauses.
     dataset: Option<DatasetRestriction>,
+}
+
+/// CONSTRUCT operator: instantiates triple templates from variable bindings.
+///
+/// For each input row, substitutes variables in each template triple to produce
+/// (subject, predicate, object) output rows. Skips template triples where a
+/// variable has no binding (unbound variables produce no triple).
+struct ConstructOperator {
+    input: Box<dyn Operator>,
+    templates: Vec<TripleTemplate>,
+    variable_columns: HashMap<String, usize>,
+}
+
+impl ConstructOperator {
+    fn new(
+        input: Box<dyn Operator>,
+        templates: Vec<TripleTemplate>,
+        variable_columns: HashMap<String, usize>,
+    ) -> Self {
+        Self {
+            input,
+            templates,
+            variable_columns,
+        }
+    }
+
+    /// Resolves a `TripleComponent` to a string using the current row bindings.
+    fn resolve_component(
+        &self,
+        component: &TripleComponent,
+        chunk: &DataChunk,
+        row: usize,
+    ) -> Option<String> {
+        match component {
+            TripleComponent::Variable(name) => {
+                let col_idx = *self.variable_columns.get(name)?;
+                let col = chunk.column(col_idx)?;
+                let val = col.get_value(row)?;
+                if val.is_null() {
+                    None
+                } else {
+                    Some(val.to_string())
+                }
+            }
+            TripleComponent::Iri(iri) => Some(iri.clone()),
+            TripleComponent::Literal(val) => Some(val.to_string()),
+            TripleComponent::LangLiteral { value, lang } => Some(format!("\"{value}\"@{lang}")),
+            TripleComponent::BlankNode(label) => Some(format!("_:{label}")),
+        }
+    }
+}
+
+impl Operator for ConstructOperator {
+    fn next(&mut self) -> grafeo_core::execution::operators::OperatorResult {
+        loop {
+            let Some(input_chunk) = self.input.next()? else {
+                return Ok(None);
+            };
+
+            let row_count = input_chunk.row_count();
+            if row_count == 0 {
+                continue;
+            }
+
+            // Each input row can produce up to templates.len() output rows
+            let max_output = row_count * self.templates.len();
+            let schema = vec![LogicalType::String; 3];
+            let mut output = DataChunk::with_capacity(&schema, max_output);
+            let mut actual_count = 0;
+
+            for row in 0..row_count {
+                for template in &self.templates {
+                    let Some(subject) =
+                        self.resolve_component(&template.subject, &input_chunk, row)
+                    else {
+                        continue;
+                    };
+                    let Some(predicate) =
+                        self.resolve_component(&template.predicate, &input_chunk, row)
+                    else {
+                        continue;
+                    };
+                    let Some(object) = self.resolve_component(&template.object, &input_chunk, row)
+                    else {
+                        continue;
+                    };
+
+                    if let Some(col) = output.column_mut(0) {
+                        col.push_string(subject);
+                    }
+                    if let Some(col) = output.column_mut(1) {
+                        col.push_string(predicate);
+                    }
+                    if let Some(col) = output.column_mut(2) {
+                        col.push_string(object);
+                    }
+                    actual_count += 1;
+                }
+            }
+
+            if actual_count > 0 {
+                output.set_count(actual_count);
+                return Ok(Some(output));
+            }
+        }
+    }
+
+    fn reset(&mut self) {
+        self.input.reset();
+    }
+
+    fn name(&self) -> &'static str {
+        "Construct"
+    }
 }
 
 /// Operator that produces a single pre-computed `DataChunk` and then stops.

--- a/crates/grafeo-engine/src/query/processor.rs
+++ b/crates/grafeo-engine/src/query/processor.rs
@@ -497,8 +497,12 @@ impl QueryProcessor {
         let mut binder = Binder::new();
         let _binding_context = binder.bind(&logical_plan)?;
 
-        // 3. Optimize the plan
-        let optimized_plan = self.optimizer.optimize(logical_plan)?;
+        // 3. Optimize the plan (use RDF statistics for cost-based optimization)
+        let rdf_optimizer = {
+            let stats = rdf_store.get_or_collect_statistics();
+            Optimizer::from_rdf_statistics((*stats).clone())
+        };
+        let optimized_plan = rdf_optimizer.optimize(logical_plan)?;
 
         // 3a. EXPLAIN: return the optimized plan tree without executing
         if optimized_plan.explain {

--- a/crates/grafeo-engine/src/query/processor.rs
+++ b/crates/grafeo-engine/src/query/processor.rs
@@ -504,9 +504,29 @@ impl QueryProcessor {
         };
         let optimized_plan = rdf_optimizer.optimize(logical_plan)?;
 
-        // 3a. EXPLAIN: return the optimized plan tree without executing
+        // 3a. EXPLAIN: return the plan tree without executing.
+        // Includes physical operator names by planning with profiling to collect entries.
         if optimized_plan.explain {
-            return Ok(explain_result(&optimized_plan));
+            let planner = RdfPlanner::new(Arc::clone(rdf_store));
+            let (_, entries) = planner.plan_profiled(&optimized_plan)?;
+            return Ok(physical_explain_result(&optimized_plan, entries));
+        }
+
+        // 3b. EXPLAIN ANALYZE (PROFILE): execute with instrumentation, report stats.
+        if optimized_plan.profile {
+            let planner = RdfPlanner::new(Arc::clone(rdf_store));
+            let (mut physical_plan, entries) = planner.plan_profiled(&optimized_plan)?;
+
+            let start = std::time::Instant::now();
+            let executor = Executor::with_columns(physical_plan.columns.clone());
+            let _result = executor.execute(physical_plan.operator.as_mut())?;
+            let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+            let tree = crate::query::profile::build_profile_tree(
+                &optimized_plan.root,
+                &mut entries.into_iter(),
+            );
+            return Ok(crate::query::profile::profile_result(&tree, elapsed_ms));
         }
 
         // 4. Convert to physical plan (using RDF planner)
@@ -682,6 +702,38 @@ pub(crate) fn explain_result(plan: &LogicalPlan) -> QueryResult {
         rows_scanned: None,
         status_message: None,
         gql_status: grafeo_common::utils::GqlStatus::SUCCESS,
+    }
+}
+
+/// Formats a physical EXPLAIN result showing both the logical plan and the
+/// physical operator names mapped to each logical operator.
+pub(crate) fn physical_explain_result(
+    plan: &LogicalPlan,
+    entries: Vec<crate::query::profile::ProfileEntry>,
+) -> QueryResult {
+    let tree = crate::query::profile::build_profile_tree(&plan.root, &mut entries.into_iter());
+
+    let mut output = String::new();
+    format_physical_node(&mut output, &tree, 0);
+
+    QueryResult {
+        columns: vec!["plan".to_string()],
+        column_types: vec![grafeo_common::types::LogicalType::String],
+        rows: vec![vec![Value::String(output.into())]],
+        execution_time_ms: None,
+        rows_scanned: None,
+        status_message: None,
+        gql_status: grafeo_common::utils::GqlStatus::SUCCESS,
+    }
+}
+
+/// Recursively formats a physical plan node showing operator name and label.
+fn format_physical_node(out: &mut String, node: &crate::query::profile::ProfileNode, depth: usize) {
+    use std::fmt::Write;
+    let indent = "  ".repeat(depth);
+    let _ = writeln!(out, "{indent}{} {}", node.name, node.label);
+    for child in &node.children {
+        format_physical_node(out, child, depth + 1);
     }
 }
 

--- a/crates/grafeo-engine/src/query/processor.rs
+++ b/crates/grafeo-engine/src/query/processor.rs
@@ -924,6 +924,10 @@ fn substitute_in_operator(op: &mut LogicalOperator, params: &QueryParams) -> Res
         LogicalOperator::CallProcedure(_) => {}
         // LoadData: file path is a literal, no parameter substitution needed
         LogicalOperator::LoadData(_) => {}
+        // Construct: template uses variables, substitute in the WHERE input
+        LogicalOperator::Construct(construct) => {
+            substitute_in_operator(&mut construct.input, params)?;
+        }
     }
     Ok(())
 }

--- a/crates/grafeo-engine/src/query/translators/sparql.rs
+++ b/crates/grafeo-engine/src/query/translators/sparql.rs
@@ -25,24 +25,37 @@ static QUERY_ID_COUNTER: AtomicU32 = AtomicU32::new(0);
 ///
 /// Returns an error if the query cannot be parsed or translated.
 pub fn translate(query: &str) -> Result<LogicalPlan> {
-    // Check for EXPLAIN prefix (case-insensitive, non-standard extension)
+    // Check for EXPLAIN [ANALYZE] prefix (case-insensitive, non-standard extension).
+    // EXPLAIN: show physical plan without executing.
+    // EXPLAIN ANALYZE: execute with profiling, show actual vs estimated stats.
     let trimmed = query.trim_start();
-    let (explain, actual_query) = if trimmed.len() >= 7
+    let (explain, profile, actual_query) = if trimmed.len() >= 7
         && trimmed[..7].eq_ignore_ascii_case("EXPLAIN")
         && trimmed
             .as_bytes()
             .get(7)
             .is_some_and(u8::is_ascii_whitespace)
     {
-        (true, trimmed[7..].trim_start())
+        let rest = trimmed[7..].trim_start();
+        if rest.len() >= 7
+            && rest[..7].eq_ignore_ascii_case("ANALYZE")
+            && rest.as_bytes().get(7).is_some_and(u8::is_ascii_whitespace)
+        {
+            // EXPLAIN ANALYZE: execute with profiling
+            (false, true, rest[7..].trim_start())
+        } else {
+            // EXPLAIN: show plan only
+            (true, false, rest)
+        }
     } else {
-        (false, query)
+        (false, false, query)
     };
 
     let sparql_query = sparql::parse(actual_query)?;
     let mut translator = SparqlTranslator::new();
     let mut plan = translator.translate_query(&sparql_query)?;
     plan.explain = explain;
+    plan.profile = profile;
     Ok(plan)
 }
 

--- a/crates/grafeo-engine/src/query/translators/sparql.rs
+++ b/crates/grafeo-engine/src/query/translators/sparql.rs
@@ -5,10 +5,10 @@
 use super::common::{wrap_distinct, wrap_filter, wrap_limit, wrap_skip, wrap_sort};
 use crate::query::plan::{
     AddGraphOp, AggregateExpr, AggregateFunction, AggregateOp, AntiJoinOp, BinaryOp, BindOp,
-    ClearGraphOp, CopyGraphOp, CreateGraphOp, DatasetRestriction, DeleteTripleOp, DropGraphOp,
-    InsertTripleOp, JoinCondition, JoinOp, JoinType, LeftJoinOp, LoadGraphOp, LogicalExpression,
-    LogicalOperator, LogicalPlan, ModifyOp, MoveGraphOp, ProjectOp, Projection, SortKey, SortOrder,
-    TripleComponent, TripleScanOp, TripleTemplate, UnaryOp, UnionOp,
+    ClearGraphOp, ConstructOp, CopyGraphOp, CreateGraphOp, DatasetRestriction, DeleteTripleOp,
+    DropGraphOp, InsertTripleOp, JoinCondition, JoinOp, JoinType, LeftJoinOp, LoadGraphOp,
+    LogicalExpression, LogicalOperator, LogicalPlan, ModifyOp, MoveGraphOp, ProjectOp, Projection,
+    SortKey, SortOrder, TripleComponent, TripleScanOp, TripleTemplate, UnaryOp, UnionOp,
 };
 use grafeo_adapters::query::sparql::{self, ast};
 use grafeo_common::types::Value;
@@ -173,8 +173,13 @@ impl SparqlTranslator {
             plan = wrap_sort(plan, keys);
         }
 
-        // Apply DISTINCT/REDUCED (after projection, before OFFSET/LIMIT)
-        if select.modifier == ast::SelectModifier::Distinct {
+        // Apply DISTINCT/REDUCED (after projection, before OFFSET/LIMIT).
+        // REDUCED is treated identically to DISTINCT: the spec allows an
+        // implementation to eliminate all, some, or no duplicates.
+        if matches!(
+            select.modifier,
+            ast::SelectModifier::Distinct | ast::SelectModifier::Reduced
+        ) {
             plan = wrap_distinct(plan);
         }
 
@@ -211,21 +216,43 @@ impl SparqlTranslator {
         // Apply dataset restriction from FROM / FROM NAMED clauses
         self.dataset = self.translate_dataset_clause(&construct.dataset);
 
-        // For CONSTRUCT, we need to evaluate the WHERE pattern and then
-        // produce triples according to the template
-        let plan = self.translate_graph_pattern(&construct.where_clause)?;
+        // Evaluate the WHERE pattern to produce variable bindings
+        let mut plan = self.translate_graph_pattern(&construct.where_clause)?;
 
         // Clear dataset after translating the WHERE clause
         self.dataset = None;
 
-        // Apply solution modifiers
-        let mut plan = plan;
+        // Apply solution modifiers to the WHERE output
         if let Some(limit) = construct.solution_modifiers.limit {
             plan = wrap_limit(plan, limit as usize);
         }
 
-        // The template will be processed at execution time
-        Ok(LogicalPlan::new(plan))
+        // Translate template triples: substitute variable bindings from WHERE
+        let mut templates = Vec::new();
+        for tp in &construct.template {
+            let subject = self.translate_triple_term(&tp.subject)?;
+            // CONSTRUCT templates use simple predicates (IRIs/variables), not paths
+            let predicate = match &tp.predicate {
+                ast::PropertyPath::Predicate(iri) => TripleComponent::Iri(self.resolve_iri(iri)),
+                ast::PropertyPath::Variable(name) => TripleComponent::Variable(name.clone()),
+                ast::PropertyPath::RdfType => TripleComponent::Iri(
+                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".to_string(),
+                ),
+                _ => continue, // Skip complex property paths in templates
+            };
+            let object = self.translate_triple_term(&tp.object)?;
+            templates.push(TripleTemplate {
+                subject,
+                predicate,
+                object,
+                graph: None,
+            });
+        }
+
+        Ok(LogicalPlan::new(LogicalOperator::Construct(ConstructOp {
+            templates,
+            input: Box::new(plan),
+        })))
     }
 
     fn translate_describe(&mut self, describe: &ast::DescribeQuery) -> Result<LogicalPlan> {
@@ -1293,8 +1320,9 @@ impl SparqlTranslator {
     fn translate_unary_op(&self, op: ast::UnaryOperator) -> UnaryOp {
         match op {
             ast::UnaryOperator::Not => UnaryOp::Not,
-            // Plus is handled as a no-op at the call site; this arm is unreachable
-            ast::UnaryOperator::Plus => UnaryOp::Not,
+            ast::UnaryOperator::Plus => {
+                unreachable!("unary plus is handled as a no-op at the call site")
+            }
             ast::UnaryOperator::Minus => UnaryOp::Neg,
         }
     }

--- a/crates/grafeo-engine/src/query/translators/sparql.rs
+++ b/crates/grafeo-engine/src/query/translators/sparql.rs
@@ -6,9 +6,9 @@ use super::common::{wrap_distinct, wrap_filter, wrap_limit, wrap_skip, wrap_sort
 use crate::query::plan::{
     AddGraphOp, AggregateExpr, AggregateFunction, AggregateOp, AntiJoinOp, BinaryOp, BindOp,
     ClearGraphOp, CopyGraphOp, CreateGraphOp, DatasetRestriction, DeleteTripleOp, DropGraphOp,
-    InsertTripleOp, JoinOp, JoinType, LeftJoinOp, LoadGraphOp, LogicalExpression, LogicalOperator,
-    LogicalPlan, ModifyOp, MoveGraphOp, ProjectOp, Projection, SortKey, SortOrder, TripleComponent,
-    TripleScanOp, TripleTemplate, UnaryOp, UnionOp,
+    InsertTripleOp, JoinCondition, JoinOp, JoinType, LeftJoinOp, LoadGraphOp, LogicalExpression,
+    LogicalOperator, LogicalPlan, ModifyOp, MoveGraphOp, ProjectOp, Projection, SortKey, SortOrder,
+    TripleComponent, TripleScanOp, TripleTemplate, UnaryOp, UnionOp,
 };
 use grafeo_adapters::query::sparql::{self, ast};
 use grafeo_common::types::Value;
@@ -1529,13 +1529,96 @@ impl SparqlTranslator {
             return left;
         }
 
-        // For basic patterns, use inner join on shared variables
+        // Collect output variables from each side and build explicit join
+        // conditions for shared variables. This enables the DPccp optimizer
+        // to reorder SPARQL triple patterns by selectivity.
+        let left_vars = Self::collect_operator_variables(&left);
+        let right_vars = Self::collect_operator_variables(&right);
+
+        let mut conditions = Vec::new();
+        for var in &left_vars {
+            if right_vars.contains(var) {
+                conditions.push(JoinCondition {
+                    left: LogicalExpression::Variable(var.clone()),
+                    right: LogicalExpression::Variable(var.clone()),
+                });
+            }
+        }
+
         LogicalOperator::Join(JoinOp {
             left: Box::new(left),
             right: Box::new(right),
             join_type: JoinType::Inner,
-            conditions: vec![], // Shared variables are implicit join conditions
+            conditions,
         })
+    }
+
+    /// Collects all variable names produced by an operator subtree.
+    ///
+    /// Walks `TripleScan`, `Join`, `LeftJoin`, `Union`, `Filter`, `Bind`,
+    /// and `Project` operators to gather the set of variable names that
+    /// appear in the output.
+    fn collect_operator_variables(op: &LogicalOperator) -> Vec<String> {
+        let mut vars = Vec::new();
+        Self::collect_variables_recursive(op, &mut vars);
+        vars
+    }
+
+    fn collect_variables_recursive(op: &LogicalOperator, vars: &mut Vec<String>) {
+        match op {
+            LogicalOperator::TripleScan(scan) => {
+                if let TripleComponent::Variable(v) = &scan.subject
+                    && !vars.contains(v)
+                {
+                    vars.push(v.clone());
+                }
+                if let TripleComponent::Variable(v) = &scan.predicate
+                    && !vars.contains(v)
+                {
+                    vars.push(v.clone());
+                }
+                if let TripleComponent::Variable(v) = &scan.object
+                    && !vars.contains(v)
+                {
+                    vars.push(v.clone());
+                }
+                if let Some(TripleComponent::Variable(v)) = &scan.graph
+                    && !vars.contains(v)
+                {
+                    vars.push(v.clone());
+                }
+                if let Some(input) = &scan.input {
+                    Self::collect_variables_recursive(input, vars);
+                }
+            }
+            LogicalOperator::Join(join) => {
+                Self::collect_variables_recursive(&join.left, vars);
+                Self::collect_variables_recursive(&join.right, vars);
+            }
+            LogicalOperator::LeftJoin(join) => {
+                Self::collect_variables_recursive(&join.left, vars);
+                Self::collect_variables_recursive(&join.right, vars);
+            }
+            LogicalOperator::Union(union) => {
+                // Union outputs variables from both branches
+                for input in &union.inputs {
+                    Self::collect_variables_recursive(input, vars);
+                }
+            }
+            LogicalOperator::Filter(filter) => {
+                Self::collect_variables_recursive(&filter.input, vars);
+            }
+            LogicalOperator::Bind(bind) => {
+                Self::collect_variables_recursive(&bind.input, vars);
+                if !vars.contains(&bind.variable) {
+                    vars.push(bind.variable.clone());
+                }
+            }
+            LogicalOperator::Project(proj) => {
+                Self::collect_variables_recursive(&proj.input, vars);
+            }
+            _ => {}
+        }
     }
 
     fn resolve_iri(&self, iri: &ast::Iri) -> String {

--- a/crates/grafeo-engine/src/query/translators/sparql.rs
+++ b/crates/grafeo-engine/src/query/translators/sparql.rs
@@ -186,13 +186,9 @@ impl SparqlTranslator {
             plan = wrap_sort(plan, keys);
         }
 
-        // Apply DISTINCT/REDUCED (after projection, before OFFSET/LIMIT).
-        // REDUCED is treated identically to DISTINCT: the spec allows an
-        // implementation to eliminate all, some, or no duplicates.
-        if matches!(
-            select.modifier,
-            ast::SelectModifier::Distinct | ast::SelectModifier::Reduced
-        ) {
+        // Apply DISTINCT (after projection, before OFFSET/LIMIT).
+        // REDUCED is a no-op: the spec allows returning all rows unchanged.
+        if matches!(select.modifier, ast::SelectModifier::Distinct) {
             plan = wrap_distinct(plan);
         }
 
@@ -240,10 +236,13 @@ impl SparqlTranslator {
             plan = wrap_limit(plan, limit as usize);
         }
 
-        // Translate template triples: substitute variable bindings from WHERE
+        // Translate template triples: substitute variable bindings from WHERE.
+        // Use translate_data_term for subject/object so that blank nodes become
+        // TripleComponent::BlankNode (constants in output) rather than variables
+        // that would fail to bind against the WHERE clause results.
         let mut templates = Vec::new();
         for tp in &construct.template {
-            let subject = self.translate_triple_term(&tp.subject)?;
+            let subject = self.translate_data_term(&tp.subject)?;
             // CONSTRUCT templates use simple predicates (IRIs/variables), not paths
             let predicate = match &tp.predicate {
                 ast::PropertyPath::Predicate(iri) => TripleComponent::Iri(self.resolve_iri(iri)),
@@ -253,7 +252,7 @@ impl SparqlTranslator {
                 ),
                 _ => continue, // Skip complex property paths in templates
             };
-            let object = self.translate_triple_term(&tp.object)?;
+            let object = self.translate_data_term(&tp.object)?;
             templates.push(TripleTemplate {
                 subject,
                 predicate,

--- a/crates/grafeo-engine/src/session/mod.rs
+++ b/crates/grafeo-engine/src/session/mod.rs
@@ -691,7 +691,15 @@ impl Session {
 
     /// Checks that the session's identity is permitted to execute the given
     /// statement kind. Returns an error if the role is insufficient.
+    ///
+    /// Short-circuits for Admin identities (the common case for embedded use
+    /// and benchmarks) to avoid any overhead on the hot path.
+    #[inline]
     fn require_permission(&self, kind: crate::auth::StatementKind) -> Result<()> {
+        // Fast path: Admin can do everything
+        if self.identity.can_admin() {
+            return Ok(());
+        }
         crate::auth::check_permission(&self.identity, kind).map_err(|denied| {
             grafeo_common::utils::error::Error::Query(grafeo_common::utils::error::QueryError::new(
                 grafeo_common::utils::error::QueryErrorKind::Semantic,
@@ -2531,12 +2539,17 @@ impl Session {
                 return self.execute_schema_command(cmd);
             }
             gql::GqlTranslationResult::Plan(plan) => {
-                // Check role-based permission before read-only transaction check
-                if plan.root.has_mutations() {
+                // Only walk the operator tree when it matters: non-admin
+                // identities need permission checks, read-only transactions
+                // need mutation blocking. Admin sessions in auto-commit mode
+                // skip the tree walk entirely.
+                let read_only = *self.read_only_tx.lock();
+                let need_check = read_only || !self.identity.can_admin();
+                let is_mutation = need_check && plan.root.has_mutations();
+                if is_mutation {
                     self.require_permission(crate::auth::StatementKind::Write)?;
                 }
-                // Block mutations in read-only transactions
-                if *self.read_only_tx.lock() && plan.root.has_mutations() {
+                if read_only && is_mutation {
                     return Err(grafeo_common::utils::error::Error::Transaction(
                         grafeo_common::utils::error::TransactionError::ReadOnly,
                     ));

--- a/crates/grafeo-engine/src/session/rdf.rs
+++ b/crates/grafeo-engine/src/session/rdf.rs
@@ -98,7 +98,7 @@ impl Session {
         let optimizer = Optimizer::from_graph_store(&*active);
         let optimized_plan = optimizer.optimize(logical_plan)?;
 
-        if optimized_plan.root.has_mutations() {
+        if !self.identity.can_admin() && optimized_plan.root.has_mutations() {
             self.require_permission(crate::auth::StatementKind::Write)?;
         }
 
@@ -158,7 +158,7 @@ impl Session {
         let optimized_plan = optimizer.optimize(logical_plan)?;
 
         // Check role-based permission for mutations
-        if optimized_plan.root.has_mutations() {
+        if !self.identity.can_admin() && optimized_plan.root.has_mutations() {
             self.require_permission(crate::auth::StatementKind::Write)?;
         }
 
@@ -212,8 +212,8 @@ impl Session {
         let optimizer = Optimizer::from_rdf_statistics((*rdf_stats).clone());
         let optimized_plan = optimizer.optimize(logical_plan)?;
 
-        // Check role-based permission for mutations
-        if optimized_plan.root.has_mutations() {
+        // Check role-based permission for mutations (skip tree walk for admin)
+        if !self.identity.can_admin() && optimized_plan.root.has_mutations() {
             self.require_permission(crate::auth::StatementKind::Write)?;
         }
 
@@ -274,8 +274,8 @@ impl Session {
         let optimizer = Optimizer::from_rdf_statistics((*rdf_stats).clone());
         let optimized_plan = optimizer.optimize(logical_plan)?;
 
-        // Check role-based permission for mutations
-        if optimized_plan.root.has_mutations() {
+        // Check role-based permission for mutations (skip tree walk for admin)
+        if !self.identity.can_admin() && optimized_plan.root.has_mutations() {
             self.require_permission(crate::auth::StatementKind::Write)?;
         }
 

--- a/crates/grafeo-engine/tests/backup_restore.rs
+++ b/crates/grafeo-engine/tests/backup_restore.rs
@@ -3,11 +3,6 @@
 //! Covers: full backup, incremental backup, restore to epoch, and the
 //! backup chain model.
 //!
-//! Note: `backup_full()` copies the .grafeo file while it is open, which
-//! fails on Windows due to file locking. Tests that call `backup_full()`
-//! are gated to non-Windows platforms. The `restore_to_epoch` and manifest
-//! tests work on all platforms.
-//!
 //! ```bash
 //! cargo test -p grafeo-engine --features full --test backup_restore
 //! ```
@@ -17,9 +12,8 @@
 use grafeo_common::types::EpochId;
 use grafeo_engine::GrafeoDB;
 
-// ── Full backup roundtrip (Linux/macOS only: Windows file locking) ──
+// ── Full backup roundtrip ─────────────────────────────────────────
 
-#[cfg(not(target_os = "windows"))]
 #[test]
 fn full_backup_and_restore_to_epoch() {
     let dir = tempfile::tempdir().expect("create temp dir");
@@ -64,9 +58,8 @@ fn full_backup_and_restore_to_epoch() {
     restored.close().expect("close");
 }
 
-// ── Full + incremental backup cycle (Linux/macOS only) ────────────
+// ── Full + incremental backup cycle ───────────────────────────────
 
-#[cfg(not(target_os = "windows"))]
 #[test]
 fn incremental_backup_captures_new_data() {
     let dir = tempfile::tempdir().expect("create temp dir");
@@ -115,9 +108,8 @@ fn incremental_backup_captures_new_data() {
     assert_eq!(manifest.segments.len(), 2);
 }
 
-// ── Backup cursor tracking (Linux/macOS only) ─────────────────────
+// ── Backup cursor tracking ────────────────────────────────────────
 
-#[cfg(not(target_os = "windows"))]
 #[test]
 fn backup_cursor_updated_after_full_backup() {
     let dir = tempfile::tempdir().expect("create temp dir");
@@ -148,9 +140,8 @@ fn backup_cursor_updated_after_full_backup() {
     db.close().expect("close");
 }
 
-// ── Backup manifest metadata (Linux/macOS only) ───────────────────
+// ── Backup manifest metadata ──────────────────────────────────────
 
-#[cfg(not(target_os = "windows"))]
 #[test]
 fn backup_manifest_tracks_segments() {
     let dir = tempfile::tempdir().expect("create temp dir");
@@ -197,4 +188,90 @@ fn restore_nonexistent_backup_fails() {
 
     let result = GrafeoDB::restore_to_epoch(&backup_dir, EpochId::new(100), &restore_path);
     assert!(result.is_err(), "restore from empty dir should fail");
+}
+
+// ── Bug regression tests ─────────────────────────────────────────
+
+/// Regression: backup_full() on a read-only database should succeed.
+///
+/// The on-disk `.grafeo` file is already a valid snapshot, so there is
+/// nothing to flush. Previously, backup_full() unconditionally called
+/// checkpoint_to_file() which rejects writes on read-only file managers.
+#[test]
+fn backup_full_on_read_only_database() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let db_path = dir.path().join("readonly_backup.grafeo");
+    let backup_dir = dir.path().join("backups");
+
+    // Create and populate a database, then close it so the file is complete.
+    {
+        let db = GrafeoDB::open(&db_path).expect("open");
+        let session = db.session();
+        session
+            .execute("INSERT (:Person {name: 'Alix'})")
+            .expect("insert");
+        session
+            .execute("INSERT (:Person {name: 'Gus'})")
+            .expect("insert");
+        db.close().expect("close");
+    }
+
+    // Re-open in read-only mode and take a full backup.
+    let db = GrafeoDB::open_read_only(&db_path).expect("open read-only");
+    let segment = db
+        .backup_full(&backup_dir)
+        .expect("backup_full on read-only should succeed");
+
+    assert_eq!(segment.start_epoch, EpochId::new(0));
+    assert!(segment.size_bytes > 0, "backup file should not be empty");
+
+    // Verify the backup is a valid database by restoring and querying.
+    let restore_path = dir.path().join("restored.grafeo");
+    GrafeoDB::restore_to_epoch(&backup_dir, segment.end_epoch, &restore_path)
+        .expect("restore should succeed");
+
+    let restored = GrafeoDB::open(&restore_path).expect("open restored");
+    assert_eq!(restored.node_count(), 2, "restored should have 2 nodes");
+    restored.close().expect("close");
+}
+
+/// Regression: backup_full() must work on Windows where the .grafeo file
+/// is held open with an exclusive lock.
+///
+/// Previously, do_backup_full() used std::fs::copy() which tries to open
+/// the source file with a new handle. On Windows, that fails because the
+/// GrafeoFileManager already holds an exclusive lock.
+#[test]
+fn backup_full_works_while_database_is_open() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let db_path = dir.path().join("open_backup.grafeo");
+    let backup_dir = dir.path().join("backups");
+
+    let db = GrafeoDB::open(&db_path).expect("open");
+    let session = db.session();
+    session
+        .execute("INSERT (:Person {name: 'Alix'})")
+        .expect("insert");
+    session
+        .execute("INSERT (:Person {name: 'Gus'})")
+        .expect("insert");
+
+    // This should succeed on ALL platforms, including Windows.
+    let segment = db
+        .backup_full(&backup_dir)
+        .expect("backup_full on open database should work on all platforms");
+
+    assert_eq!(segment.start_epoch, EpochId::new(0));
+    assert!(segment.size_bytes > 0);
+
+    db.close().expect("close");
+
+    // Verify the backup is restorable.
+    let restore_path = dir.path().join("restored.grafeo");
+    GrafeoDB::restore_to_epoch(&backup_dir, segment.end_epoch, &restore_path)
+        .expect("restore should succeed");
+
+    let restored = GrafeoDB::open(&restore_path).expect("open restored");
+    assert_eq!(restored.node_count(), 2, "restored should have 2 nodes");
+    restored.close().expect("close");
 }

--- a/crates/grafeo-engine/tests/backup_restore.rs
+++ b/crates/grafeo-engine/tests/backup_restore.rs
@@ -275,3 +275,46 @@ fn backup_full_works_while_database_is_open() {
     assert_eq!(restored.node_count(), 2, "restored should have 2 nodes");
     restored.close().expect("close");
 }
+
+/// Two full backups into the same directory produce two distinct segments
+/// in the manifest. The second backup does not overwrite the first.
+#[test]
+fn backup_full_twice_produces_two_segments() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let db_path = dir.path().join("double.grafeo");
+    let backup_dir = dir.path().join("backups");
+
+    let db = GrafeoDB::open(&db_path).expect("open");
+    let session = db.session();
+    session
+        .execute("INSERT (:Person {name: 'Alix'})")
+        .expect("insert");
+
+    let seg1 = db.backup_full(&backup_dir).expect("first backup");
+    assert_eq!(seg1.filename, "backup_full_0000.grafeo");
+
+    // Add more data between backups
+    session
+        .execute("INSERT (:Person {name: 'Gus'})")
+        .expect("insert");
+
+    let seg2 = db.backup_full(&backup_dir).expect("second backup");
+    assert_eq!(seg2.filename, "backup_full_0001.grafeo");
+    assert!(seg2.end_epoch >= seg1.end_epoch);
+
+    let manifest = GrafeoDB::read_backup_manifest(&backup_dir)
+        .unwrap()
+        .unwrap();
+    assert_eq!(manifest.segments.len(), 2);
+
+    // Restore from the second backup (latest state)
+    let restore_path = dir.path().join("restored.grafeo");
+    GrafeoDB::restore_to_epoch(&backup_dir, seg2.end_epoch, &restore_path)
+        .expect("restore should succeed");
+
+    let restored = GrafeoDB::open(&restore_path).expect("open restored");
+    assert_eq!(restored.node_count(), 2);
+    restored.close().expect("close");
+
+    db.close().expect("close");
+}

--- a/crates/grafeo-engine/tests/grafeo_file.rs
+++ b/crates/grafeo-engine/tests/grafeo_file.rs
@@ -1258,3 +1258,54 @@ fn wal_data_after_checkpoint_survives_drop() {
         db.close().unwrap();
     }
 }
+
+// ── Read-only checkpoint guard tests ─────────────────────────────
+
+/// Regression: wal_checkpoint() on a read-only database should be a no-op,
+/// not an error. Read-only databases have no WAL and the on-disk file is
+/// already a valid snapshot.
+#[cfg(all(feature = "wal", feature = "lpg"))]
+#[test]
+fn wal_checkpoint_on_read_only_is_no_op() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ro_checkpoint.grafeo");
+
+    {
+        let db = GrafeoDB::open(&path).unwrap();
+        let session = db.session();
+        session.execute("INSERT (:Person {name: 'Alix'})").unwrap();
+        db.close().unwrap();
+    }
+
+    let db = GrafeoDB::open_read_only(&path).unwrap();
+    // Should succeed (no-op), not fail with "read-only mode" error.
+    db.wal_checkpoint()
+        .expect("wal_checkpoint on read-only should be a no-op");
+    assert_eq!(db.node_count(), 1);
+}
+
+/// Regression: save() from a read-only database should succeed.
+/// save() creates a NEW file at the target path, reading from self.
+#[cfg(all(feature = "wal", feature = "lpg"))]
+#[test]
+fn save_from_read_only_database() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_path = dir.path().join("ro_save_src.grafeo");
+    let dest_path = dir.path().join("ro_save_dest.grafeo");
+
+    {
+        let db = GrafeoDB::open(&src_path).unwrap();
+        let session = db.session();
+        session.execute("INSERT (:Person {name: 'Alix'})").unwrap();
+        session.execute("INSERT (:Person {name: 'Gus'})").unwrap();
+        db.close().unwrap();
+    }
+
+    let db = GrafeoDB::open_read_only(&src_path).unwrap();
+    db.save(&dest_path)
+        .expect("save from read-only should succeed");
+
+    let restored = GrafeoDB::open(&dest_path).unwrap();
+    assert_eq!(restored.node_count(), 2);
+    restored.close().unwrap();
+}

--- a/crates/grafeo-engine/tests/sparql_w3c_execution_tests.rs
+++ b/crates/grafeo-engine/tests/sparql_w3c_execution_tests.rs
@@ -1481,4 +1481,45 @@ mod tests {
         // Two distinct types: Person, City (REDUCED may deduplicate like DISTINCT)
         assert_eq!(r.row_count(), 2);
     }
+
+    #[test]
+    fn physical_explain_shows_operator_names() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        let r = db
+            .execute_sparql(
+                r#"EXPLAIN SELECT ?name WHERE {
+                    ?s <http://xmlns.com/foaf/0.1/name> ?name .
+                    ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>
+                }"#,
+            )
+            .unwrap();
+        assert_eq!(r.row_count(), 1);
+        let plan = r.rows()[0][0].to_string();
+        // Physical plan should contain physical operator names
+        assert!(
+            plan.contains("RdfTripleScan") || plan.contains("HashJoin") || plan.contains("Project"),
+            "EXPLAIN should show physical operator names, got: {plan}"
+        );
+    }
+
+    #[test]
+    fn explain_analyze_shows_timing() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        let r = db
+            .execute_sparql(
+                r#"EXPLAIN ANALYZE SELECT ?name WHERE {
+                    ?s <http://xmlns.com/foaf/0.1/name> ?name
+                }"#,
+            )
+            .unwrap();
+        assert!(r.row_count() >= 1);
+        let profile = r.rows()[0][0].to_string();
+        // EXPLAIN ANALYZE should show timing or operator stats
+        assert!(
+            profile.contains("time") || profile.contains("rows") || profile.contains("ms"),
+            "EXPLAIN ANALYZE should show execution stats, got: {profile}"
+        );
+    }
 }

--- a/crates/grafeo-engine/tests/sparql_w3c_execution_tests.rs
+++ b/crates/grafeo-engine/tests/sparql_w3c_execution_tests.rs
@@ -1470,7 +1470,7 @@ mod tests {
     }
 
     #[test]
-    fn select_reduced_deduplicates() {
+    fn select_reduced_returns_results() {
         let db = rdf_db();
         insert_foaf_data(&db);
         let r = db
@@ -1478,8 +1478,12 @@ mod tests {
                 "SELECT REDUCED ?type WHERE { ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type }",
             )
             .unwrap();
-        // Two distinct types: Person, City (REDUCED may deduplicate like DISTINCT)
-        assert_eq!(r.row_count(), 2);
+        // REDUCED may or may not eliminate duplicates (spec allows either).
+        // Our implementation treats REDUCED as a no-op, returning all rows.
+        assert!(
+            r.row_count() >= 2,
+            "REDUCED should return at least the distinct count"
+        );
     }
 
     #[test]

--- a/crates/grafeo-engine/tests/sparql_w3c_execution_tests.rs
+++ b/crates/grafeo-engine/tests/sparql_w3c_execution_tests.rs
@@ -1372,4 +1372,113 @@ mod tests {
         // alix livesIn amsterdam, gus livesIn amsterdam
         assert_eq!(r.row_count(), 2);
     }
+
+    // ====================================================================
+    // Phase 3: SPARQL Spec Compliance (0.5.37)
+    // ====================================================================
+
+    #[test]
+    fn bind_typed_literal_integer() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        let r = db
+            .execute_sparql(
+                r#"PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                SELECT ?x WHERE {
+                    ?s <http://xmlns.com/foaf/0.1/name> "Alix" .
+                    BIND("42"^^xsd:integer AS ?x)
+                }"#,
+            )
+            .unwrap();
+        assert_eq!(r.row_count(), 1);
+        let val = &r.rows()[0][0];
+        // Should be integer 42, not empty string
+        assert!(
+            val.as_int64() == Some(42) || val.to_string() == "42",
+            "expected 42, got: {val:?}"
+        );
+    }
+
+    #[test]
+    fn bind_typed_literal_double() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        let r = db
+            .execute_sparql(
+                r#"PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                SELECT ?x WHERE {
+                    ?s <http://xmlns.com/foaf/0.1/name> "Alix" .
+                    BIND("3.14"^^xsd:double AS ?x)
+                }"#,
+            )
+            .unwrap();
+        assert_eq!(r.row_count(), 1);
+        let val = &r.rows()[0][0];
+        assert!(
+            val.to_string().starts_with("3.14"),
+            "expected 3.14, got: {val:?}"
+        );
+    }
+
+    #[test]
+    fn filter_equality_pushdown_into_scan() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        // FILTER(?name = "Alix") should be pushed into the TripleScan
+        // so only matching triples are scanned (index lookup, not full scan + filter)
+        let r = db
+            .execute_sparql(
+                r#"SELECT ?s WHERE {
+                    ?s <http://xmlns.com/foaf/0.1/name> ?name .
+                    FILTER(?name = "Alix")
+                }"#,
+            )
+            .unwrap();
+        assert_eq!(r.row_count(), 1);
+        assert!(r.rows()[0][0].to_string().contains("alix"));
+    }
+
+    #[test]
+    fn filter_equality_on_predicate() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        // FILTER on a predicate variable
+        let r = db
+            .execute_sparql(
+                r#"SELECT ?s ?o WHERE {
+                    ?s ?p ?o .
+                    FILTER(?p = <http://xmlns.com/foaf/0.1/name>)
+                }"#,
+            )
+            .unwrap();
+        // 4 names: Alix, Gus, Vincent, Amsterdam
+        assert_eq!(r.row_count(), 4);
+    }
+
+    #[test]
+    fn describe_without_where_clause() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        // DESCRIBE <iri> without WHERE should return CBD for that resource
+        let r = db.execute_sparql("DESCRIBE <http://ex.org/alix>").unwrap();
+        // alix has 5 triples: type, name, age, knows, mbox
+        assert!(
+            r.row_count() >= 5,
+            "DESCRIBE without WHERE should return triples, got {} rows",
+            r.row_count()
+        );
+    }
+
+    #[test]
+    fn select_reduced_deduplicates() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        let r = db
+            .execute_sparql(
+                "SELECT REDUCED ?type WHERE { ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type }",
+            )
+            .unwrap();
+        // Two distinct types: Person, City (REDUCED may deduplicate like DISTINCT)
+        assert_eq!(r.row_count(), 2);
+    }
 }

--- a/crates/grafeo-engine/tests/sparql_w3c_execution_tests.rs
+++ b/crates/grafeo-engine/tests/sparql_w3c_execution_tests.rs
@@ -1233,4 +1233,143 @@ mod tests {
             .unwrap();
         assert_eq!(r.row_count(), 1, "!BOUND(?age) should match only Vincent");
     }
+
+    // ====================================================================
+    // COUNT(*) Fast-Path (0.5.37 - Optimizer Foundation)
+    // ====================================================================
+
+    #[test]
+    fn count_star_fully_unbound() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        // 15 triples in the foaf data
+        let r = db
+            .execute_sparql("SELECT (COUNT(*) AS ?cnt) WHERE { ?s ?p ?o }")
+            .unwrap();
+        assert_eq!(r.row_count(), 1);
+        let count = r.rows()[0][0].as_int64().unwrap();
+        assert_eq!(count, 15);
+    }
+
+    #[test]
+    fn count_star_predicate_bound() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        let r = db
+            .execute_sparql(
+                "SELECT (COUNT(*) AS ?cnt) WHERE { ?s <http://xmlns.com/foaf/0.1/knows> ?o }",
+            )
+            .unwrap();
+        assert_eq!(r.row_count(), 1);
+        let count = r.rows()[0][0].as_int64().unwrap();
+        assert_eq!(count, 2, "alix knows gus, gus knows alix");
+    }
+
+    #[test]
+    fn count_star_with_group_by_not_fast_path() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        // GROUP BY prevents fast-path, should still work via normal aggregate
+        let r = db
+            .execute_sparql(
+                r#"SELECT ?s (COUNT(*) AS ?cnt) WHERE { ?s ?p ?o } GROUP BY ?s ORDER BY ?s"#,
+            )
+            .unwrap();
+        // Each subject should have its own count
+        assert!(r.row_count() > 1, "GROUP BY should produce multiple rows");
+    }
+
+    #[test]
+    fn count_star_with_distinct_not_fast_path() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        // DISTINCT prevents fast-path, should still work
+        let r = db
+            .execute_sparql("SELECT (COUNT(DISTINCT ?s) AS ?cnt) WHERE { ?s ?p ?o }")
+            .unwrap();
+        assert_eq!(r.row_count(), 1);
+        let count = r.rows()[0][0].as_int64().unwrap();
+        // Unique subjects: alix, gus, vincent, amsterdam
+        assert!(count > 0);
+    }
+
+    #[test]
+    fn count_star_per_named_graph() {
+        let db = rdf_db();
+        db.execute_sparql(
+            r#"INSERT DATA {
+                GRAPH <http://ex.org/g1> {
+                    <http://ex.org/alix> <http://xmlns.com/foaf/0.1/name> "Alix" .
+                    <http://ex.org/gus> <http://xmlns.com/foaf/0.1/name> "Gus" .
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let r = db
+            .execute_sparql(
+                "SELECT (COUNT(*) AS ?cnt) WHERE { GRAPH <http://ex.org/g1> { ?s ?p ?o } }",
+            )
+            .unwrap();
+        assert_eq!(r.row_count(), 1);
+        let count = r.rows()[0][0].as_int64().unwrap();
+        assert_eq!(count, 2);
+    }
+
+    // ====================================================================
+    // Optimizer: Join Conditions + TripleScan in DPccp (0.5.37)
+    // ====================================================================
+
+    #[test]
+    fn two_hop_join_produces_correct_results() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        // Two-hop: ?a knows ?b, ?b has name ?name
+        let r = db
+            .execute_sparql(
+                r#"SELECT ?a ?name WHERE {
+                    ?a <http://xmlns.com/foaf/0.1/knows> ?b .
+                    ?b <http://xmlns.com/foaf/0.1/name> ?name .
+                }"#,
+            )
+            .unwrap();
+        // alix knows gus (name "Gus"), gus knows alix (name "Alix")
+        assert_eq!(r.row_count(), 2);
+    }
+
+    #[test]
+    fn three_hop_join_produces_correct_results() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        // Three-hop: ?a knows ?b, ?b knows ?c, ?c has name ?name
+        let r = db
+            .execute_sparql(
+                r#"SELECT ?a ?name WHERE {
+                    ?a <http://xmlns.com/foaf/0.1/knows> ?b .
+                    ?b <http://xmlns.com/foaf/0.1/knows> ?c .
+                    ?c <http://xmlns.com/foaf/0.1/name> ?name .
+                }"#,
+            )
+            .unwrap();
+        // alix->gus->alix (name "Alix"), gus->alix->gus (name "Gus")
+        assert_eq!(r.row_count(), 2);
+    }
+
+    #[test]
+    fn selective_predicate_join_correct() {
+        let db = rdf_db();
+        insert_foaf_data(&db);
+        // Join with selective predicate: livesIn (2 triples) + name (4 triples)
+        let r = db
+            .execute_sparql(
+                r#"SELECT ?name ?city WHERE {
+                    ?s <http://ex.org/livesIn> ?c .
+                    ?s <http://xmlns.com/foaf/0.1/name> ?name .
+                    ?c <http://xmlns.com/foaf/0.1/name> ?city .
+                }"#,
+            )
+            .unwrap();
+        // alix livesIn amsterdam, gus livesIn amsterdam
+        assert_eq!(r.row_count(), 2);
+    }
 }

--- a/crates/grafeo-storage/src/file/manager.rs
+++ b/crates/grafeo-storage/src/file/manager.rs
@@ -642,6 +642,25 @@ impl GrafeoFileManager {
         ))
     }
 
+    /// Copies the database file to `dest` using the already-locked file handle.
+    ///
+    /// `std::fs::copy()` opens the source with a new handle, which fails on
+    /// Windows when an exclusive lock is held. This method reads through the
+    /// existing handle, avoiding lock conflicts.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the read or write fails.
+    pub fn copy_to(&self, dest: &Path) -> Result<u64> {
+        let mut file = self.file.lock();
+        file.seek(SeekFrom::Start(0))?;
+
+        let mut dest_file = fs::File::create(dest)?;
+        let bytes = std::io::copy(&mut *file, &mut dest_file).map_err(Error::Io)?;
+        dest_file.sync_all()?;
+        Ok(bytes)
+    }
+
     /// Releases the file lock and syncs.
     ///
     /// # Errors

--- a/crates/grafeo-storage/src/file/manager.rs
+++ b/crates/grafeo-storage/src/file/manager.rs
@@ -1297,4 +1297,59 @@ mod tests {
         let path = dir.path().join("beatrix_missing.grafeo");
         assert!(GrafeoFileManager::open_read_only(&path).is_err());
     }
+
+    #[test]
+    fn copy_to_produces_identical_file() {
+        let dir = test_dir();
+        let src = dir.path().join("copy_src.grafeo");
+        let dest = dir.path().join("copy_dest.grafeo");
+
+        let manager = GrafeoFileManager::create(&src).unwrap();
+        manager
+            .write_snapshot(b"copy test payload", 5, 3, 10, 20)
+            .unwrap();
+
+        // copy_to reads through the locked handle (no new open)
+        let bytes = manager.copy_to(&dest).unwrap();
+        assert!(bytes > 0);
+
+        // The original is still usable
+        let snap = manager.read_snapshot().unwrap();
+        assert_eq!(snap, b"copy test payload");
+        manager.close().unwrap();
+
+        // The copy is a valid .grafeo file
+        let copy = GrafeoFileManager::open(&dest).unwrap();
+        let snap = copy.read_snapshot().unwrap();
+        assert_eq!(snap, b"copy test payload");
+
+        let header = copy.active_header();
+        assert_eq!(header.epoch, 5);
+        assert_eq!(header.node_count, 10);
+        assert_eq!(header.edge_count, 20);
+        copy.close().unwrap();
+    }
+
+    #[test]
+    fn copy_to_from_read_only_manager() {
+        let dir = test_dir();
+        let src = dir.path().join("ro_copy_src.grafeo");
+        let dest = dir.path().join("ro_copy_dest.grafeo");
+
+        {
+            let manager = GrafeoFileManager::create(&src).unwrap();
+            manager
+                .write_snapshot(b"read-only copy data", 7, 4, 3, 1)
+                .unwrap();
+            manager.close().unwrap();
+        }
+
+        let ro = GrafeoFileManager::open_read_only(&src).unwrap();
+        let bytes = ro.copy_to(&dest).unwrap();
+        assert!(bytes > 0);
+
+        let copy = GrafeoFileManager::open(&dest).unwrap();
+        assert_eq!(copy.read_snapshot().unwrap(), b"read-only copy data");
+        copy.close().unwrap();
+    }
 }

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -97,7 +97,7 @@ grafeo shell ./mydb
 ```
 
 ```
-Grafeo 0.5.36 - Lpg mode, 42 nodes, 87 edges
+Grafeo 0.5.37 - Lpg mode, 42 nodes, 87 edges
 Type :help for commands, :quit to exit.
 
 grafeo> MATCH (n:Person) RETURN n.name, n.age
@@ -231,7 +231,7 @@ grafeo completions powershell >> $PROFILE
 
 ```bash
 $ grafeo version
-grafeo 0.5.36
+grafeo 0.5.37
 
 Build:
   rustc:    1.91.1

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -122,7 +122,7 @@ Add to `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  grafeo: ^0.5.36
+  grafeo: ^0.5.37
 ```
 
 ### Verify Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -291,7 +291,7 @@ Choose the query language that fits the project:
     ```yaml
     # pubspec.yaml
     dependencies:
-      grafeo: ^0.5.36
+      grafeo: ^0.5.37
     ```
 
 === "WASM"

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -2,6 +2,6 @@
 
 {% block announce %}
   <a href="https://github.com/GrafeoDB/grafeo/releases">
-    Grafeo v0.5.36 is now available!
+    Grafeo v0.5.37 is now available!
   </a>
 {% endblock %}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -97,7 +97,7 @@ The beta series focuses on correctness, completeness and real-world durability. 
 
 | Version    | Focus                                                                                |
 |------------|--------------------------------------------------------------------------------------|
-| **0.5.37** | RDF ecosystem: SPARQL HTTP Protocol, SHACL validation, bulk load                     |
+| **0.5.37** | RDF ecosystem: SPARQL execution overhaul, Ring Index planner, WCOJ, EXPLAIN ANALYZE  |
 | **0.5.38** | Algorithms, streaming results, memory introspection, testing unification             |
 | **0.5.39** | API stability markers, feature profile deprecation warnings, C FFI parity            |
 

--- a/packages/grafeo-cli-npm/package.json
+++ b/packages/grafeo-cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/cli",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "description": "Command-line interface for Grafeo graph database",
   "license": "Apache-2.0",
   "repository": {
@@ -25,11 +25,11 @@
     "LICENSE"
   ],
   "optionalDependencies": {
-    "@grafeo-db/cli-linux-x64": "0.5.36",
-    "@grafeo-db/cli-linux-arm64": "0.5.36",
-    "@grafeo-db/cli-darwin-x64": "0.5.36",
-    "@grafeo-db/cli-darwin-arm64": "0.5.36",
-    "@grafeo-db/cli-win32-x64": "0.5.36"
+    "@grafeo-db/cli-linux-x64": "0.5.37",
+    "@grafeo-db/cli-linux-arm64": "0.5.37",
+    "@grafeo-db/cli-darwin-x64": "0.5.37",
+    "@grafeo-db/cli-darwin-arm64": "0.5.37",
+    "@grafeo-db/cli-win32-x64": "0.5.37"
   },
   "engines": {
     "node": ">=18"

--- a/packages/grafeo-cli-python/grafeo_cli/__init__.py
+++ b/packages/grafeo-cli-python/grafeo_cli/__init__.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-__version__ = "0.5.36"
+__version__ = "0.5.37"
 
 # GitHub release download URL template
 _GITHUB_RELEASE = "https://github.com/GrafeoDB/grafeo/releases/download"

--- a/packages/grafeo-cli-python/pyproject.toml
+++ b/packages/grafeo-cli-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grafeo-cli"
-version = "0.5.36"
+version = "0.5.37"
 description = "Command-line interface for Grafeo graph database"
 readme = "README.md"
 license = { text = "Apache-2.0"}


### PR DESCRIPTION
## What does this PR do?

RDF ecosystem: bulk load, RDF performance improvements using the new storage container, RDF ring index and new planner architecture. 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 0.5.37 overhauls SPARQL execution for higher compliance and faster joins via the new Ring Index, and adds dictionary‑encoded scans plus physical EXPLAIN/EXPLAIN ANALYZE. It also fixes Windows backups, makes read‑only checkpoints/snapshots no‑ops, adds JS backup/restore APIs, and bumps versions across `@grafeo-db/js`, `@grafeo-db/wasm`, `grafeo` (Python/Dart), and `@grafeo-db/cli`.

- **New Features**
  - SPARQL: big compliance pass with `CONSTRUCT`, `BIND`, `OPTIONAL`, `UNION`, `MINUS`, `FILTER`, `EXISTS`/`NOT EXISTS`, SPARQL UPDATE (`INSERT/DELETE DATA`, `DELETE/INSERT WHERE`), and named graph CRUD (`CREATE/DROP/COPY/MOVE/ADD/CLEAR`); composite (SP/PO/OS) lookups; physical `EXPLAIN`/`EXPLAIN ANALYZE`.
  - Ring Index: wavelet‑tree triple index integrated into the planner with a worst‑case optimal leapfrog join; persisted as a `.grafeo` section and restored on open.
  - RDF: dictionary‑encoded triple scans with a lazy `TermDictionary` and result‑time term resolution.
  - Bindings: `@grafeo-db/js` adds `backupFull()`, `backupIncremental()`, and static `restoreToEpoch()`; Python adds `explain_sparql()`.

- **Bug Fixes**
  - Full backups on Windows: copy the `.grafeo` file via the locked handle to avoid file‑lock errors.
  - Read‑only DBs: `wal_checkpoint()` and async snapshot are no‑ops; faster Admin permission checks on the hot path.
  - Safer deserialization for succinct bitvectors, wavelet trees, and permutations to prevent inconsistent caches on load.

<sup>Written for commit 9fc09ef134d9c6654eba83475d1e08d8d2ad6f7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



