### PR TITLE
bugfix and tests for #272

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Grafeo, for future reference (and enjoyment).
 
 Hardening, ISO compliance, and vector search improvements driven by persona-based exploratory testing. Parser security limits prevent stack overflow attacks, all six query languages gain EXPLAIN support, Unicode identifiers bring GQL closer to ISO 39075, and quantized vector indexes cut memory usage up to 4x for large embedding workloads.
 
+**Breaking:** `QueryBuilder.param()` now raises `ValueError` on unsupported types instead of silently dropping them: code that relied on silent fallthrough will see exceptions and should fix the type conversion. Parser error messages now include a language prefix (e.g., `[GQL] Unexpected token`): code that pattern-matches on error strings may need updating. SPARQL `SERVICE` clauses now return an explicit error instead of silently executing the inner pattern against the local store: queries that appeared to work but returned incorrect results will now fail with a clear message. SPARQL property path `+`/`*` expansion depth raised from 10 to 50: queries on deep hierarchies will return more complete results, which may increase result set sizes and execution time.
+
 ### Added
 
 - **Quantized vector indexes**: `create_vector_index()` accepts `quantization` parameter (`"scalar"`, `"binary"`, `"product"`) for 4x memory reduction on large vector datasets. `VectorIndexKind` enum unifies plain and quantized indexes throughout the engine. All bindings (Python, Node.js, WASM, C) updated.
@@ -33,6 +35,7 @@ Hardening, ISO compliance, and vector search improvements driven by persona-base
 - **RDF blank node collisions across imports**: Turtle parser now prefixes blank node IDs per-import (`_:imp{N}_b0`), preventing cross-file collisions.
 - **Incremental backup always failed after full backup** (#267): the backup cursor stored the active WAL file's sequence without rotating, so post-backup writes stayed invisible to incremental. Both `backup_full` and `backup_incremental` now rotate the WAL after completing, ensuring new writes land in a file the next incremental will pick up.
 - **Edge variables in multi-hop queries returned as raw IDs** (#268): `plan_expand_chain` and `plan_factorized_aggregate` did not register edge columns in the planner's tracking set, causing RETURN to emit `NodeResolve` instead of `EdgeResolve`. Edge variables now resolve to full maps with `_id`, `_type`, `_source`, `_target`, and properties.
+- **Arrow/DataFrame export dropped user properties named `source`/`target`/`id`/`type`** (#272): structural columns in `edges_to_arrow()`, `edges_df()`, `nodes_to_arrow()`, and `nodes_df()` collided with user property names, silently dropping them. Structural columns are now underscore-prefixed (`_id`, `_type`, `_source`, `_target`, `_labels`) to match the engine's `edge_to_map()`/`node_to_map()` convention. **Breaking:** code referencing `df["source"]` must change to `df["_source"]`.
 - **Weighted hybrid search inverted vector ranking**: `hybrid_search()` with `fusion="weighted"` applied min-max normalization to raw vector distances, causing the farthest node to score highest. Vector distances are now negated before fusion so that closer vectors rank higher.
 
 ### Documentation

--- a/crates/bindings/python/src/database.rs
+++ b/crates/bindings/python/src/database.rs
@@ -2509,7 +2509,7 @@ impl PyGrafeoDB {
         // Collect all nodes and discover property keys.
         // Skip properties whose names collide with structural columns
         // to prevent silent overwrites (GrafeoDB/grafeo#254).
-        const RESERVED_NODE_COLS: &[&str] = &["id", "labels"];
+        const RESERVED_NODE_COLS: &[&str] = &["_id", "_labels"];
         let nodes: Vec<_> = store.all_nodes().collect();
         let mut prop_keys: Vec<String> = Vec::new();
         let mut prop_key_set = std::collections::HashSet::new();
@@ -2549,8 +2549,8 @@ impl PyGrafeoDB {
         }
 
         let data = pyo3::types::PyDict::new(py);
-        data.set_item("id", ids)?;
-        data.set_item("labels", labels)?;
+        data.set_item("_id", ids)?;
+        data.set_item("_labels", labels)?;
         for (key, col) in prop_keys.iter().zip(prop_columns.iter()) {
             data.set_item(key, col)?;
         }
@@ -2598,7 +2598,7 @@ impl PyGrafeoDB {
     /// Example:
     /// ```python
     /// df = db.edges_to_polars()
-    /// print(df.filter(pl.col("type") == "KNOWS"))
+    /// print(df.filter(pl.col("_type") == "KNOWS"))
     /// ```
     #[cfg(feature = "arrow-export")]
     #[pyo3(signature = ())]
@@ -2629,7 +2629,7 @@ impl PyGrafeoDB {
 
     /// Export all edges as a pandas DataFrame.
     ///
-    /// Columns: `id` (int), `source` (int), `target` (int), `type` (str),
+    /// Columns: `_id` (int), `_source` (int), `_target` (int), `_type` (str),
     /// plus one column per unique property key. Missing properties are `None`.
     ///
     /// Requires pandas (`uv add pandas`).
@@ -2637,7 +2637,7 @@ impl PyGrafeoDB {
     /// Example:
     /// ```python
     /// df = db.edges_df()
-    /// print(df[df["type"] == "KNOWS"])
+    /// print(df[df["_type"] == "KNOWS"])
     /// ```
     #[pyo3(signature = ())]
     fn edges_df(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
@@ -2660,7 +2660,7 @@ impl PyGrafeoDB {
         // Collect all edges and discover property keys.
         // Skip properties whose names collide with structural columns
         // to prevent silent overwrites (GrafeoDB/grafeo#254).
-        const RESERVED_EDGE_COLS: &[&str] = &["id", "source", "target", "type"];
+        const RESERVED_EDGE_COLS: &[&str] = &["_id", "_source", "_target", "_type"];
         let edges: Vec<_> = store.all_edges().collect();
         let mut prop_keys: Vec<String> = Vec::new();
         let mut prop_key_set = std::collections::HashSet::new();
@@ -2701,10 +2701,10 @@ impl PyGrafeoDB {
         }
 
         let data = pyo3::types::PyDict::new(py);
-        data.set_item("id", ids)?;
-        data.set_item("source", sources)?;
-        data.set_item("target", targets)?;
-        data.set_item("type", types)?;
+        data.set_item("_id", ids)?;
+        data.set_item("_source", sources)?;
+        data.set_item("_target", targets)?;
+        data.set_item("_type", types)?;
         for (key, col) in prop_keys.iter().zip(prop_columns.iter()) {
             data.set_item(key, col)?;
         }

--- a/crates/bindings/python/tests/bases/test_dataframe.py
+++ b/crates/bindings/python/tests/bases/test_dataframe.py
@@ -121,7 +121,7 @@ class TestNodesDf:
 
         assert isinstance(df, pd.DataFrame)
         assert "id" in df.columns
-        assert "labels" in df.columns
+        assert "_labels" in df.columns
         assert "name" in df.columns
         assert len(df) == 4  # 3 persons + 1 company
 
@@ -138,12 +138,12 @@ class TestNodesDf:
         """Nodes without a property should have None in that column."""
         df = populated_db.nodes_df()
         # Company node shouldn't have 'age'
-        company_rows = df[df["labels"].apply(lambda labels: "Company" in labels)]
+        company_rows = df[df["_labels"].apply(lambda labels: "Company" in labels)]
         assert company_rows["age"].isna().all()
 
     def test_labels_are_lists(self, populated_db):
         df = populated_db.nodes_df()
-        for labels in df["labels"]:
+        for labels in df["_labels"]:
             assert isinstance(labels, list)
 
     def test_empty_graph(self):
@@ -151,7 +151,7 @@ class TestNodesDf:
         df = db.nodes_df()
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 0
-        assert list(df.columns) == ["id", "labels"]
+        assert list(df.columns) == ["_id", "_labels"]
 
 
 # --- db.edges_df() ---
@@ -163,15 +163,15 @@ class TestEdgesDf:
         df = populated_db.edges_df()
 
         assert isinstance(df, pd.DataFrame)
-        assert "id" in df.columns
-        assert "source" in df.columns
-        assert "target" in df.columns
-        assert "type" in df.columns
+        assert "_id" in df.columns
+        assert "_source" in df.columns
+        assert "_target" in df.columns
+        assert "_type" in df.columns
         assert len(df) == 2  # KNOWS + WORKS_AT
 
     def test_edge_types(self, populated_db):
         df = populated_db.edges_df()
-        types = set(df["type"])
+        types = set(df["_type"])
         assert types == {"KNOWS", "WORKS_AT"}
 
     def test_property_columns(self, populated_db):
@@ -182,7 +182,7 @@ class TestEdgesDf:
     def test_missing_properties_are_none(self, populated_db):
         df = populated_db.edges_df()
         # KNOWS edge has 'since' but not 'role', WORKS_AT has 'role' but not 'since'
-        knows_rows = df[df["type"] == "KNOWS"]
+        knows_rows = df[df["_type"] == "KNOWS"]
         assert knows_rows["role"].isna().all()
 
     def test_empty_graph(self):
@@ -190,7 +190,7 @@ class TestEdgesDf:
         df = db.edges_df()
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 0
-        assert list(df.columns) == ["id", "source", "target", "type"]
+        assert list(df.columns) == ["_id", "_type", "_source", "_target"]
 
 
 # --- Error handling ---

--- a/crates/grafeo-engine/src/database/arrow.rs
+++ b/crates/grafeo-engine/src/database/arrow.rs
@@ -351,10 +351,10 @@ mod bulk_export {
     use super::{ArrowExportError, build_array, infer_column_type, record_batch_to_ipc_stream};
 
     /// Structural column names for nodes (property keys matching these are skipped).
-    const RESERVED_NODE_COLS: &[&str] = &["id", "labels"];
+    const RESERVED_NODE_COLS: &[&str] = &["_id", "_labels"];
 
     /// Structural column names for edges (property keys matching these are skipped).
-    const RESERVED_EDGE_COLS: &[&str] = &["id", "source", "target", "type"];
+    const RESERVED_EDGE_COLS: &[&str] = &["_id", "_source", "_target", "_type"];
 
     /// Discovers property keys in first-seen order, skipping reserved column names.
     fn discover_property_keys<'a>(
@@ -375,9 +375,10 @@ mod bulk_export {
 
     /// Converts a slice of [`Node`]s to an Arrow [`RecordBatch`].
     ///
-    /// Schema: `id` (UInt64), `labels` (List\<Utf8\>), plus one nullable column per
-    /// unique property key. Property types are inferred from values; mixed-type
-    /// columns fall back to Utf8.
+    /// Schema: `_id` (UInt64), `_labels` (List\<Utf8\>), plus one nullable column per
+    /// unique property key. Structural columns are underscore-prefixed to avoid
+    /// collision with user property names. Property types are inferred from
+    /// values; mixed-type columns fall back to Utf8.
     ///
     /// # Errors
     ///
@@ -406,9 +407,9 @@ mod bulk_export {
         }
 
         let mut fields: Vec<Field> = vec![
-            Field::new("id", DataType::UInt64, false),
+            Field::new("_id", DataType::UInt64, false),
             Field::new(
-                "labels",
+                "_labels",
                 DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
                 false,
             ),
@@ -436,8 +437,9 @@ mod bulk_export {
 
     /// Converts a slice of [`Edge`]s to an Arrow [`RecordBatch`].
     ///
-    /// Schema: `id` (UInt64), `type` (Utf8), `source` (UInt64), `target` (UInt64),
-    /// plus one nullable column per unique property key.
+    /// Schema: `_id` (UInt64), `_type` (Utf8), `_source` (UInt64), `_target` (UInt64),
+    /// plus one nullable column per unique property key. Structural columns are
+    /// underscore-prefixed to avoid collision with user property names.
     ///
     /// # Errors
     ///
@@ -467,10 +469,10 @@ mod bulk_export {
         }
 
         let mut fields: Vec<Field> = vec![
-            Field::new("id", DataType::UInt64, false),
-            Field::new("type", DataType::Utf8, false),
-            Field::new("source", DataType::UInt64, false),
-            Field::new("target", DataType::UInt64, false),
+            Field::new("_id", DataType::UInt64, false),
+            Field::new("_type", DataType::Utf8, false),
+            Field::new("_source", DataType::UInt64, false),
+            Field::new("_target", DataType::UInt64, false),
         ];
         let mut arrays: Vec<ArrayRef> = vec![
             Arc::new(id_builder.finish()),
@@ -879,8 +881,8 @@ mod tests {
             assert_eq!(batch.num_rows(), 2);
             // id, labels, name, age
             assert_eq!(batch.num_columns(), 4);
-            assert_eq!(batch.schema().field(0).name(), "id");
-            assert_eq!(batch.schema().field(1).name(), "labels");
+            assert_eq!(batch.schema().field(0).name(), "_id");
+            assert_eq!(batch.schema().field(1).name(), "_labels");
             assert_eq!(batch.schema().field(2).name(), "name");
             assert_eq!(batch.schema().field(3).name(), "age");
         }
@@ -889,14 +891,43 @@ mod tests {
         fn test_nodes_reserved_column_skipped() {
             let mut node = make_node(1, &["Test"]);
             node.properties
-                .insert(PropertyKey::new("id"), Value::Int64(999)); // should be skipped
+                .insert(PropertyKey::new("_id"), Value::Int64(999)); // should be skipped
             node.properties
                 .insert(PropertyKey::new("score"), Value::Float64(0.95));
 
             let batch = crate::database::arrow::nodes_to_record_batch(&[node]).unwrap();
-            // id (structural), labels (structural), score (property)
+            // _id (structural), _labels (structural), score (property)
             assert_eq!(batch.num_columns(), 3);
             assert_eq!(batch.schema().field(2).name(), "score");
+        }
+
+        /// Regression: properties named "id" or "labels" must NOT be dropped.
+        /// Old code reserved these bare names, causing silent data loss.
+        #[test]
+        fn test_nodes_property_named_id_preserved() {
+            let mut node = make_node(1, &["Method"]);
+            node.properties
+                .insert(PropertyKey::new("id"), Value::String("custom-uuid".into()));
+            node.properties
+                .insert(PropertyKey::new("labels"), Value::String("meta".into()));
+
+            let batch = crate::database::arrow::nodes_to_record_batch(&[node]).unwrap();
+            // _id, _labels, id (property), labels (property)
+            assert_eq!(batch.num_columns(), 4);
+            let names: Vec<_> = batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect();
+            assert!(
+                names.contains(&"id".to_string()),
+                "property 'id' must be preserved"
+            );
+            assert!(
+                names.contains(&"labels".to_string()),
+                "property 'labels' must be preserved"
+            );
         }
 
         #[test]
@@ -919,7 +950,7 @@ mod tests {
         fn test_edges_empty() {
             let batch = crate::database::arrow::edges_to_record_batch(&[]).unwrap();
             assert_eq!(batch.num_rows(), 0);
-            assert_eq!(batch.num_columns(), 4); // id, type, source, target
+            assert_eq!(batch.num_columns(), 4); // _id, _type, _source, _target
         }
 
         #[test]
@@ -930,13 +961,67 @@ mod tests {
 
             let batch = crate::database::arrow::edges_to_record_batch(&[edge]).unwrap();
             assert_eq!(batch.num_rows(), 1);
-            // id, type, source, target, since
+            // _id, _type, _source, _target, since
             assert_eq!(batch.num_columns(), 5);
-            assert_eq!(batch.schema().field(0).name(), "id");
-            assert_eq!(batch.schema().field(1).name(), "type");
-            assert_eq!(batch.schema().field(2).name(), "source");
-            assert_eq!(batch.schema().field(3).name(), "target");
+            assert_eq!(batch.schema().field(0).name(), "_id");
+            assert_eq!(batch.schema().field(1).name(), "_type");
+            assert_eq!(batch.schema().field(2).name(), "_source");
+            assert_eq!(batch.schema().field(3).name(), "_target");
             assert_eq!(batch.schema().field(4).name(), "since");
+        }
+
+        /// Regression: properties named "source" or "target" must NOT be dropped.
+        /// Old code reserved these bare names, causing silent data loss.
+        #[test]
+        fn test_edges_property_named_source_preserved() {
+            let mut edge = make_edge(1, 10, 20, "CALLS");
+            edge.properties
+                .insert(PropertyKey::new("source"), Value::String("jdt".into()));
+            edge.properties
+                .insert(PropertyKey::new("confidence"), Value::Float64(0.9));
+
+            let batch = crate::database::arrow::edges_to_record_batch(&[edge]).unwrap();
+            // _id, _type, _source, _target, source (property), confidence
+            assert_eq!(batch.num_columns(), 6);
+            let names: Vec<_> = batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect();
+            assert!(
+                names.contains(&"source".to_string()),
+                "property 'source' must be preserved"
+            );
+            assert!(names.contains(&"confidence".to_string()));
+        }
+
+        /// Regression: boolean properties must appear in Arrow export.
+        #[test]
+        fn test_nodes_boolean_properties_preserved() {
+            let mut node = make_node(1, &["Method"]);
+            node.properties
+                .insert(PropertyKey::new("name"), Value::String("foo".into()));
+            node.properties
+                .insert(PropertyKey::new("is_exported"), Value::Bool(true));
+            node.properties
+                .insert(PropertyKey::new("is_test"), Value::Bool(false));
+
+            let batch = crate::database::arrow::nodes_to_record_batch(&[node]).unwrap();
+            let names: Vec<_> = batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect();
+            assert!(
+                names.contains(&"is_exported".to_string()),
+                "bool property 'is_exported' must be present"
+            );
+            assert!(
+                names.contains(&"is_test".to_string()),
+                "bool property 'is_test' must be present"
+            );
         }
 
         #[test]

--- a/crates/grafeo-engine/tests/auth_permissions.rs
+++ b/crates/grafeo-engine/tests/auth_permissions.rs
@@ -239,7 +239,7 @@ fn get_projection_by_name() {
 
 // ── SPARQL permission checks ────────────────────────────────────
 
-#[cfg(feature = "sparql")]
+#[cfg(all(feature = "sparql", feature = "triple-store"))]
 #[test]
 fn sparql_select_with_readonly_succeeds() {
     let db = GrafeoDB::new_in_memory();
@@ -259,7 +259,7 @@ fn sparql_select_with_readonly_succeeds() {
     );
 }
 
-#[cfg(feature = "sparql")]
+#[cfg(all(feature = "sparql", feature = "triple-store"))]
 #[test]
 fn sparql_insert_with_readonly_fails() {
     let db = GrafeoDB::new_in_memory();
@@ -278,7 +278,7 @@ fn sparql_insert_with_readonly_fails() {
 
 // ── SPARQL permission checks on RDF-model database ─────────────
 
-#[cfg(feature = "sparql")]
+#[cfg(all(feature = "sparql", feature = "triple-store"))]
 #[test]
 fn sparql_select_on_rdf_database_with_readonly_succeeds() {
     use grafeo_engine::config::{Config, GraphModel};
@@ -302,7 +302,7 @@ fn sparql_select_on_rdf_database_with_readonly_succeeds() {
     );
 }
 
-#[cfg(feature = "sparql")]
+#[cfg(all(feature = "sparql", feature = "triple-store"))]
 #[test]
 fn sparql_insert_on_rdf_database_with_readonly_fails() {
     use grafeo_engine::config::{Config, GraphModel};

--- a/crates/grafeo-engine/tests/error_paths.rs
+++ b/crates/grafeo-engine/tests/error_paths.rs
@@ -565,7 +565,7 @@ fn test_cypher_error_shows_position() {
 }
 
 #[test]
-#[cfg(feature = "sparql")]
+#[cfg(all(feature = "sparql", feature = "triple-store"))]
 fn test_sparql_error_shows_position() {
     let db = GrafeoDB::new_in_memory();
     let session = db.session();
@@ -717,7 +717,7 @@ fn test_gql_error_includes_caret_marker() {
 }
 
 #[test]
-#[cfg(feature = "sparql")]
+#[cfg(all(feature = "sparql", feature = "triple-store"))]
 fn test_sparql_error_includes_position() {
     let db = GrafeoDB::new_in_memory();
     let session = db.session();

--- a/crates/grafeo-engine/tests/sparql_translator_tests.rs
+++ b/crates/grafeo-engine/tests/sparql_translator_tests.rs
@@ -1,6 +1,6 @@
 //! Integration tests for SPARQL translator.
 
-#[cfg(feature = "sparql")]
+#[cfg(all(feature = "sparql", feature = "triple-store"))]
 mod tests {
     use grafeo_engine::query::translators::sparql::translate;
 

--- a/crates/grafeo-engine/tests/temporal_types.rs
+++ b/crates/grafeo-engine/tests/temporal_types.rs
@@ -329,7 +329,7 @@ fn gql_date_json_param_roundtrip() {
 // ============================================================================
 
 #[test]
-#[cfg(feature = "sparql")]
+#[cfg(all(feature = "sparql", feature = "triple-store"))]
 fn sparql_xsd_date_literal() {
     let db = GrafeoDB::new_in_memory();
     let result = db
@@ -345,7 +345,7 @@ fn sparql_xsd_date_literal() {
 }
 
 #[test]
-#[cfg(feature = "sparql")]
+#[cfg(all(feature = "sparql", feature = "triple-store"))]
 fn sparql_xsd_duration_literal() {
     let db = GrafeoDB::new_in_memory();
     let result = db


### PR DESCRIPTION
## What does this PR do?

Fixes #272 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes property collisions in Arrow/DataFrame export by prefixing structural columns with underscores so user properties named id/type/source/target/labels are preserved. Addresses #272 and updates Python exporters, Arrow schemas, and tests.

- **Bug Fixes**
  - Structural columns renamed to `_id`, `_labels` (nodes) and `_id`, `_type`, `_source`, `_target` (edges) in Arrow and `nodes_df`/`edges_df`.
  - Reserved-column filters updated to the underscore forms to stop dropping user properties with bare names.
  - Added regression tests for property preservation (including booleans) and updated Python tests/docstrings.
  - Test gating adjusted to `#[cfg(all(feature = "sparql", feature = "triple-store"))]` to run SPARQL tests only when a triple store is enabled.

- **Migration**
  - Update code to use underscore-prefixed columns (e.g., `df["_source"]`, `df["_type"]`, `df["_labels"]`, `df["_id"]`).
  - Note: edge DataFrame/Arrow column order is now `_id`, `_type`, `_source`, `_target`.

<sup>Written for commit de83eb7dd71df9b624dac8cd8103fa1b2ba5c50d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

