### PR TITLE
feat: HybridStore — columnar base with mutable MVCC overlay

### DIFF
--- a/crates/grafeo-core/src/codec/bitpack.rs
+++ b/crates/grafeo-core/src/codec/bitpack.rs
@@ -26,7 +26,7 @@ use std::io;
 ///
 /// Pass your values to [`pack()`](Self::pack) and we'll figure out the optimal
 /// bit width automatically. Random access via [`get()`](Self::get) is O(1).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BitPackedInts {
     /// Packed data.
     data: Vec<u64>,

--- a/crates/grafeo-core/src/codec/dictionary.rs
+++ b/crates/grafeo-core/src/codec/dictionary.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 /// Each unique string appears once in the dictionary. Values are stored as u32
 /// indices pointing into that dictionary. Great for labels, categories, and
 /// other low-cardinality string columns.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DictionaryEncoding {
     /// The dictionary of unique strings.
     dictionary: Arc<[Arc<str>]>,

--- a/crates/grafeo-core/src/graph/compact/builder.rs
+++ b/crates/grafeo-core/src/graph/compact/builder.rs
@@ -889,6 +889,635 @@ pub fn from_graph_store(
     builder.build()
 }
 
+/// Incrementally converts a [`GraphStore`](crate::graph::traits::GraphStore)
+/// into a [`CompactStore`], reusing unchanged tables from a previous snapshot.
+///
+/// For node tables listed in `unchanged_node_tables`, the previous `NodeTable`
+/// is cloned directly and the `id_map` is populated from the old compact store.
+/// For all other node tables the function falls back to the same encoding path
+/// used by [`from_graph_store`].
+///
+/// For rel tables listed in `unchanged_rel_tables` the previous `RelTable` is
+/// cloned.  All other rel tables are rebuilt from the merged `GraphStore` view.
+///
+/// # Errors
+///
+/// Propagates any [`CompactStoreError`] from the underlying builder.
+#[allow(clippy::too_many_lines)]
+pub fn from_graph_store_incremental(
+    store: &dyn crate::graph::traits::GraphStore,
+    old_compact: &CompactStore,
+    unchanged_node_tables: &FxHashSet<u16>,
+    unchanged_rel_tables: &FxHashSet<u16>,
+) -> Result<CompactStore, CompactStoreError> {
+    use super::id::encode_node_id;
+
+    let labels = store.all_labels();
+    if labels.is_empty() {
+        return CompactStoreBuilder::new().build();
+    }
+
+    // old_node_id -> (label_key, offset_within_label)
+    let mut id_map: FxHashMap<grafeo_common::types::NodeId, (ArcStr, u32)> =
+        FxHashMap::default();
+
+    // label_key -> (ordered node IDs, property_key -> Vec<Value>)
+    let mut label_data: Vec<(
+        ArcStr,
+        Vec<grafeo_common::types::NodeId>,
+        FxHashMap<PropertyKey, Vec<Value>>,
+    )> = Vec::new();
+
+    let mut seen_node_ids: FxHashSet<grafeo_common::types::NodeId> = FxHashSet::default();
+    let mut label_key_index: FxHashMap<ArcStr, usize> = FxHashMap::default();
+
+    // Step 1: Populate id_map for unchanged tables directly from old compact.
+    // For unchanged tables we skip the expensive per-entity property scan.
+    for (table_id, label) in old_compact.table_id_to_label().iter().enumerate() {
+        let tid = table_id as u16;
+        if !unchanged_node_tables.contains(&tid) {
+            continue;
+        }
+        let Some(nt) = old_compact.node_table(label.as_str()) else {
+            continue;
+        };
+        let node_count = nt.len();
+        let label_key = label.clone();
+
+        // Ensure the label_data entry exists (with empty props — we'll clone the table).
+        if !label_key_index.contains_key(&label_key) {
+            let idx = label_data.len();
+            label_key_index.insert(label_key.clone(), idx);
+            label_data.push((label_key.clone(), Vec::new(), FxHashMap::default()));
+        }
+        let entry_idx = label_key_index[&label_key];
+        let (_, ref mut node_ids_vec, _) = label_data[entry_idx];
+
+        for offset in 0..node_count {
+            let nid = encode_node_id(tid, offset as u64);
+            node_ids_vec.push(nid);
+            seen_node_ids.insert(nid);
+            id_map.insert(nid, (label_key.clone(), offset as u32));
+        }
+    }
+
+    // Step 2: Collect changed tables from the GraphStore (same as from_graph_store).
+    for label in &labels {
+        let node_ids = store.nodes_by_label(label);
+        for &nid in &node_ids {
+            if !seen_node_ids.insert(nid) {
+                continue;
+            }
+
+            let Some(node) = store.get_node(nid) else {
+                continue;
+            };
+
+            let label_key: ArcStr = if node.labels.len() <= 1 {
+                ArcStr::from(label.as_str())
+            } else {
+                let mut sorted: Vec<&str> = node.labels.iter().map(|l| l.as_str()).collect();
+                sorted.sort_unstable();
+                ArcStr::from(sorted.join("|"))
+            };
+
+            let entry_idx = if let Some(&idx) = label_key_index.get(&label_key) {
+                idx
+            } else {
+                let idx = label_data.len();
+                label_key_index.insert(label_key.clone(), idx);
+                label_data.push((label_key.clone(), Vec::new(), FxHashMap::default()));
+                idx
+            };
+
+            let (_, ref mut node_ids_vec, ref mut props_map) = label_data[entry_idx];
+            let offset = node_ids_vec.len() as u32;
+            node_ids_vec.push(nid);
+            id_map.insert(nid, (label_key, offset));
+
+            for (key, value) in node.properties.iter() {
+                let col = props_map
+                    .entry(key.clone())
+                    .or_insert_with(|| vec![Value::Null; offset as usize]);
+                while col.len() < offset as usize {
+                    col.push(Value::Null);
+                }
+                col.push(value.clone());
+            }
+
+            let expected_len = offset as usize + 1;
+            for col in props_map.values_mut() {
+                while col.len() < expected_len {
+                    col.push(Value::Null);
+                }
+            }
+        }
+    }
+
+    // Step 3: Build the CompactStore combining cloned and rebuilt node tables.
+    //
+    // We need to maintain the same table_id ordering as the old compact store
+    // for unchanged tables, while appending new labels at the end.  To do this
+    // we build the final ordered label list in two passes:
+    //   a) Old labels in their original order (unchanged cloned, changed rebuilt).
+    //   b) Brand-new labels that did not exist in old_compact.
+
+    // Map: label_key -> Option<(old_table_id, NodeTable to clone)>
+    // We decide per label whether to clone or rebuild.
+    let old_label_order: Vec<ArcStr> = old_compact.table_id_to_label().to_vec();
+
+    // Build the final ordered Vec of (label_key, whether_unchanged) pairs.
+    let mut ordered_labels: Vec<(ArcStr, bool)> = Vec::new();
+    for label in &old_label_order {
+        let old_tid = old_compact
+            .label_to_table_id_map()
+            .get(label.as_str())
+            .copied();
+        let unchanged = old_tid.is_some_and(|tid| unchanged_node_tables.contains(&tid));
+        ordered_labels.push((label.clone(), unchanged));
+    }
+    // Append brand-new labels (present in label_data but not in old compact).
+    for (label_key, _, _) in &label_data {
+        if !old_compact.label_to_table_id_map().contains_key(label_key.as_str()) {
+            ordered_labels.push((label_key.clone(), false));
+        }
+    }
+
+    // Assign new table IDs sequentially.
+    let mut label_to_table_id: FxHashMap<ArcStr, u16> = FxHashMap::default();
+    let mut table_id_to_label: Vec<ArcStr> = Vec::new();
+    for (idx, (label_key, _)) in ordered_labels.iter().enumerate() {
+        label_to_table_id.insert(label_key.clone(), idx as u16);
+        table_id_to_label.push(label_key.clone());
+    }
+
+    // Build NodeTables in order.
+    let mut node_tables_by_id: Vec<NodeTable> = Vec::with_capacity(ordered_labels.len());
+
+    for (label_key, is_unchanged) in &ordered_labels {
+        if *is_unchanged {
+            // Clone the NodeTable from old compact, but update its schema table_id
+            // to the new position (it may differ if new labels were inserted before it).
+            let new_tid = label_to_table_id[label_key];
+            if let Some(old_nt) = old_compact.node_table(label_key.as_str()) {
+                let mut cloned = old_nt.clone();
+                cloned.set_table_id(new_tid);
+                node_tables_by_id.push(cloned);
+            }
+        } else {
+            // Rebuild from collected data.
+            let Some(&entry_idx) = label_key_index.get(label_key) else {
+                // Label exists in old compact but has no nodes and wasn't rebuilt —
+                // create an empty table.
+                let new_tid = label_to_table_id[label_key];
+                use super::schema::TableSchema;
+                let schema = TableSchema::new(label_key.as_str(), new_tid, vec![]);
+                node_tables_by_id.push(NodeTable::from_columns(
+                    schema,
+                    FxHashMap::default(),
+                    FxHashMap::default(),
+                    0,
+                ));
+                continue;
+            };
+            let (_, node_ids_for_label, props_map) = &label_data[entry_idx];
+            let node_count = node_ids_for_label.len();
+            let new_tid = label_to_table_id[label_key];
+
+            let mut col_defs = Vec::new();
+            let mut columns: FxHashMap<PropertyKey, ColumnCodec> = FxHashMap::default();
+            let mut zone_maps: FxHashMap<PropertyKey, ZoneMap> = FxHashMap::default();
+
+            // Ensure row count is set even when there are no properties by
+            // initialising the len from node_count directly.
+            for (key, values) in props_map {
+                let inferred = infer_type_from_values(values);
+                let col_type;
+                match inferred {
+                    InferredType::BitPacked => {
+                        let u64_values: Vec<u64> = values
+                            .iter()
+                            .map(|v| match v {
+                                Value::Int64(n) => *n as u64,
+                                _ => 0,
+                            })
+                            .collect();
+                        let bp = BitPackedInts::pack(&u64_values);
+                        let zm = compute_zone_map_u64(&u64_values);
+                        col_type = infer_column_type(&ColumnCodec::BitPacked(bp.clone()));
+                        zone_maps.insert(key.clone(), zm);
+                        columns.insert(key.clone(), ColumnCodec::BitPacked(bp));
+                    }
+                    InferredType::Bitmap => {
+                        let bool_values: Vec<bool> = values
+                            .iter()
+                            .map(|v| matches!(v, Value::Bool(true)))
+                            .collect();
+                        let bv = BitVector::from_bools(&bool_values);
+                        let zm = compute_zone_map_bool(&bool_values);
+                        col_type = infer_column_type(&ColumnCodec::Bitmap(bv.clone()));
+                        zone_maps.insert(key.clone(), zm);
+                        columns.insert(key.clone(), ColumnCodec::Bitmap(bv));
+                    }
+                    InferredType::Dict => {
+                        let str_values: Vec<String> = values
+                            .iter()
+                            .map(|v| match v {
+                                Value::Null => String::new(),
+                                Value::String(s) => s.to_string(),
+                                other => format!("{other}"),
+                            })
+                            .collect();
+                        let str_refs: Vec<&str> = str_values.iter().map(String::as_str).collect();
+                        let mut dict_builder = DictionaryBuilder::new();
+                        for s in &str_refs {
+                            dict_builder.add(s);
+                        }
+                        let dict = dict_builder.build();
+                        let zm = compute_zone_map_strings(&str_refs);
+                        col_type = infer_column_type(&ColumnCodec::Dict(dict.clone()));
+                        zone_maps.insert(key.clone(), zm);
+                        columns.insert(key.clone(), ColumnCodec::Dict(dict));
+                    }
+                }
+                col_defs.push(super::schema::ColumnDef::new(key.as_str(), col_type));
+            }
+
+            use super::schema::TableSchema;
+            let schema = TableSchema::new(label_key.as_str(), new_tid, col_defs);
+            node_tables_by_id.push(NodeTable::from_columns(schema, columns, zone_maps, node_count));
+        }
+    }
+
+    // Step 4: Rebuild the id_map offsets to reflect the new table_ids.
+    // Unchanged entries already use old NodeIds (encoded with old table_ids).
+    // After assigning new table_ids above, the compact IDs for unchanged tables
+    // must be re-encoded with the new table_id.  We rebuild the id_map entirely
+    // using the new table_ids so edge collection below gets correct offsets.
+    let mut new_id_map: FxHashMap<grafeo_common::types::NodeId, (ArcStr, u32)> =
+        FxHashMap::default();
+    for (old_nid, (label_key, offset)) in &id_map {
+        let new_tid = label_to_table_id[label_key];
+        let new_nid = encode_node_id(new_tid, u64::from(*offset));
+        new_id_map.insert(*old_nid, (label_key.clone(), *offset));
+        // Also insert the new NodeId (in case it differs from old).
+        if *old_nid != new_nid {
+            new_id_map.insert(new_nid, (label_key.clone(), *offset));
+        }
+    }
+    // Replace id_map with the updated version for edge collection.
+    let id_map = new_id_map;
+
+    // Step 5: Collect edges — clone unchanged rel tables, rebuild changed ones.
+    type EdgeGroupKey = (ArcStr, ArcStr, ArcStr);
+    let mut edge_groups: FxHashMap<EdgeGroupKey, Vec<(u32, u32)>> = FxHashMap::default();
+    let mut edge_props_groups: FxHashMap<EdgeGroupKey, FxHashMap<PropertyKey, Vec<Value>>> =
+        FxHashMap::default();
+
+    // Collect edges only for label groups that belong to changed rel tables.
+    // We iterate all nodes but only process edges for tables that need rebuilding.
+    for (_label_key, node_ids, _) in &label_data {
+        for &nid in node_ids {
+            let outgoing = store.edges_from(nid, crate::graph::Direction::Outgoing);
+            for (_target_nid, edge_id) in outgoing {
+                let Some(edge) = store.get_edge(edge_id) else {
+                    continue;
+                };
+
+                let Some((src_label, src_offset)) = id_map.get(&edge.src) else {
+                    continue;
+                };
+                let Some((dst_label, dst_offset)) = id_map.get(&edge.dst) else {
+                    continue;
+                };
+
+                let group_key: EdgeGroupKey =
+                    (edge.edge_type.clone(), src_label.clone(), dst_label.clone());
+
+                let edges_vec = edge_groups.entry(group_key.clone()).or_default();
+                let edge_idx = edges_vec.len();
+                edges_vec.push((*src_offset, *dst_offset));
+
+                if !edge.properties.is_empty() {
+                    let props = edge_props_groups.entry(group_key).or_default();
+                    for (key, value) in edge.properties.iter() {
+                        let col = props
+                            .entry(key.clone())
+                            .or_insert_with(|| vec![Value::Null; edge_idx]);
+                        while col.len() < edge_idx {
+                            col.push(Value::Null);
+                        }
+                        col.push(value.clone());
+                    }
+                    let expected_len = edge_idx + 1;
+                    for col in props.values_mut() {
+                        while col.len() < expected_len {
+                            col.push(Value::Null);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Step 6: Build RelTables, mixing cloned (unchanged) and rebuilt (changed).
+    //
+    // We iterate old rel tables first (preserving rel_table_id ordering where
+    // possible), then append any brand-new edge types collected from the store.
+    let old_rel_count = old_compact.rel_tables_by_id().len();
+    let mut rel_tables_by_id: Vec<RelTable> = Vec::new();
+    let mut edge_type_to_rel_id: FxHashMap<ArcStr, Vec<u16>> = FxHashMap::default();
+    let mut rel_table_id_to_type: Vec<ArcStr> = Vec::new();
+
+    // Track which (edge_type, src_label, dst_label) groups we have handled so
+    // we can append any new groups at the end.
+    let mut handled_groups: FxHashSet<EdgeGroupKey> = FxHashSet::default();
+
+    for old_rid in 0..old_rel_count {
+        let old_rid_u16 = old_rid as u16;
+        let Some(old_rt) = old_compact.rel_tables_by_id().get(old_rid) else {
+            continue;
+        };
+        let edge_type = old_compact
+            .edge_type_for_rel_table_id(old_rid_u16)
+            .cloned()
+            .unwrap_or_else(|| old_rt.edge_type().clone());
+
+        let src_label = old_compact
+            .label_for_table_id(old_rt.src_table_id())
+            .cloned();
+        let dst_label = old_compact
+            .label_for_table_id(old_rt.dst_table_id())
+            .cloned();
+
+        let (Some(src_label), Some(dst_label)) = (src_label, dst_label) else {
+            continue; // schema inconsistency, skip
+        };
+
+        let group_key: EdgeGroupKey = (edge_type.clone(), src_label.clone(), dst_label.clone());
+        handled_groups.insert(group_key.clone());
+
+        let new_rel_id = rel_tables_by_id.len() as u16;
+        rel_table_id_to_type.push(edge_type.clone());
+
+        if unchanged_rel_tables.contains(&old_rid_u16) {
+            // Clone from old compact, updating only the rel_table_id in the schema.
+            let mut cloned = old_rt.clone();
+            cloned.set_rel_table_id(new_rel_id);
+            // Also update src/dst table_ids to reflect any new node table ordering.
+            let new_src_tid = label_to_table_id
+                .get(&src_label)
+                .copied()
+                .unwrap_or(old_rt.src_table_id());
+            let new_dst_tid = label_to_table_id
+                .get(&dst_label)
+                .copied()
+                .unwrap_or(old_rt.dst_table_id());
+            cloned.set_src_table_id(new_src_tid);
+            cloned.set_dst_table_id(new_dst_tid);
+            edge_type_to_rel_id
+                .entry(edge_type)
+                .or_default()
+                .push(new_rel_id);
+            rel_tables_by_id.push(cloned);
+        } else {
+            // Rebuild this rel table from the collected edges.
+            let edges = edge_groups.get(&group_key).cloned().unwrap_or_default();
+            let edge_props = edge_props_groups.get(&group_key);
+
+            let new_src_tid = label_to_table_id
+                .get(&src_label)
+                .copied()
+                .unwrap_or(old_rt.src_table_id());
+            let new_dst_tid = label_to_table_id
+                .get(&dst_label)
+                .copied()
+                .unwrap_or(old_rt.dst_table_id());
+
+            let src_node_count = node_tables_by_id
+                .get(new_src_tid as usize)
+                .map_or(0, |t| t.len());
+            let dst_node_count = node_tables_by_id
+                .get(new_dst_tid as usize)
+                .map_or(0, |t| t.len());
+
+            let rt = build_rel_table(
+                new_rel_id,
+                &edge_type,
+                &src_label,
+                &dst_label,
+                new_src_tid,
+                new_dst_tid,
+                src_node_count,
+                dst_node_count,
+                &edges,
+                edge_props,
+            )?;
+            edge_type_to_rel_id
+                .entry(edge_type)
+                .or_default()
+                .push(new_rel_id);
+            rel_tables_by_id.push(rt);
+        }
+    }
+
+    // Append brand-new rel tables (edge types/label-pairs not in old compact).
+    for (group_key, edges) in &edge_groups {
+        if handled_groups.contains(group_key) {
+            continue;
+        }
+        let (edge_type, src_label, dst_label) = group_key;
+        let new_rel_id = rel_tables_by_id.len() as u16;
+
+        let Some(&new_src_tid) = label_to_table_id.get(src_label.as_str()) else {
+            continue; // src label not found, skip
+        };
+        let Some(&new_dst_tid) = label_to_table_id.get(dst_label.as_str()) else {
+            continue; // dst label not found, skip
+        };
+
+        let src_node_count = node_tables_by_id
+            .get(new_src_tid as usize)
+            .map_or(0, |t| t.len());
+        let dst_node_count = node_tables_by_id
+            .get(new_dst_tid as usize)
+            .map_or(0, |t| t.len());
+
+        let edge_props = edge_props_groups.get(group_key);
+        let rt = build_rel_table(
+            new_rel_id,
+            edge_type,
+            src_label,
+            dst_label,
+            new_src_tid,
+            new_dst_tid,
+            src_node_count,
+            dst_node_count,
+            edges,
+            edge_props,
+        )?;
+        rel_table_id_to_type.push(edge_type.clone());
+        edge_type_to_rel_id
+            .entry(edge_type.clone())
+            .or_default()
+            .push(new_rel_id);
+        rel_tables_by_id.push(rt);
+    }
+
+    // Step 7: Compute statistics.
+    let mut stats = crate::statistics::Statistics::new();
+    let mut total_nodes: u64 = 0;
+    let mut total_edges: u64 = 0;
+
+    for (idx, nt) in node_tables_by_id.iter().enumerate() {
+        let count = nt.len() as u64;
+        total_nodes += count;
+        let label = &table_id_to_label[idx];
+        stats.update_label(
+            label.as_str(),
+            crate::statistics::LabelStatistics::new(count),
+        );
+    }
+
+    let mut edge_type_counts: FxHashMap<&str, u64> = FxHashMap::default();
+    for (idx, rt) in rel_tables_by_id.iter().enumerate() {
+        let count = rt.num_edges() as u64;
+        total_edges += count;
+        let edge_type = &rel_table_id_to_type[idx];
+        *edge_type_counts.entry(edge_type.as_str()).or_default() += count;
+    }
+    for (edge_type, count) in edge_type_counts {
+        stats.update_edge_type(
+            edge_type,
+            crate::statistics::EdgeTypeStatistics::new(count, 0.0, 0.0),
+        );
+    }
+    stats.total_nodes = total_nodes;
+    stats.total_edges = total_edges;
+
+    Ok(CompactStore::new(
+        node_tables_by_id,
+        label_to_table_id,
+        rel_tables_by_id,
+        edge_type_to_rel_id,
+        table_id_to_label,
+        rel_table_id_to_type,
+        stats,
+    ))
+}
+
+/// Builds a single [`RelTable`] from edges and optional property data.
+///
+/// Used internally by [`from_graph_store_incremental`] for rel tables that need
+/// to be rebuilt (as opposed to cloned from an old snapshot).
+#[allow(clippy::too_many_arguments)]
+fn build_rel_table(
+    rel_table_id: u16,
+    edge_type: &ArcStr,
+    src_label: &ArcStr,
+    dst_label: &ArcStr,
+    src_table_id: u16,
+    dst_table_id: u16,
+    src_node_count: usize,
+    dst_node_count: usize,
+    edges: &[(u32, u32)],
+    edge_props: Option<&FxHashMap<PropertyKey, Vec<Value>>>,
+) -> Result<RelTable, CompactStoreError> {
+    use super::csr::CsrAdjacency;
+    use super::schema::EdgeSchema;
+
+    let mut fwd_edges = edges.to_vec();
+    fwd_edges.sort_by_key(|&(src, _)| src);
+    let fwd = CsrAdjacency::from_sorted_edges(src_node_count, &fwd_edges);
+
+    let mut bwd_edges: Vec<(u32, u32)> =
+        edges.iter().map(|&(src, dst)| (dst, src)).collect();
+    bwd_edges.sort_by_key(|&(dst, _)| dst);
+    let mut bwd_csr = CsrAdjacency::from_sorted_edges(dst_node_count, &bwd_edges);
+
+    let mut mapping = Vec::with_capacity(bwd_edges.len());
+    for &(dst, src) in &bwd_edges {
+        let fwd_neighbors = fwd.neighbors(src);
+        let fwd_start = fwd.offset_of(src);
+        let local_idx = fwd_neighbors.iter().position(|&t| t == dst).ok_or_else(|| {
+            CompactStoreError::InconsistentEdgeData(format!(
+                "backward edge ({dst}->{src}) has no corresponding forward edge"
+            ))
+        })?;
+        mapping.push(fwd_start + local_idx as u32);
+    }
+    bwd_csr.set_edge_data(mapping);
+
+    let mut property_col_defs = Vec::new();
+    let mut properties: FxHashMap<PropertyKey, ColumnCodec> = FxHashMap::default();
+
+    if let Some(props) = edge_props {
+        for (key, values) in props {
+            let inferred = infer_type_from_values(values);
+            let col_type;
+            match inferred {
+                InferredType::BitPacked => {
+                    let u64_values: Vec<u64> = values
+                        .iter()
+                        .map(|v| match v {
+                            Value::Int64(n) => *n as u64,
+                            _ => 0,
+                        })
+                        .collect();
+                    let bp = BitPackedInts::pack(&u64_values);
+                    col_type = infer_column_type(&ColumnCodec::BitPacked(bp.clone()));
+                    properties.insert(key.clone(), ColumnCodec::BitPacked(bp));
+                }
+                InferredType::Bitmap => {
+                    let bool_values: Vec<bool> = values
+                        .iter()
+                        .map(|v| matches!(v, Value::Bool(true)))
+                        .collect();
+                    let bv = BitVector::from_bools(&bool_values);
+                    col_type = infer_column_type(&ColumnCodec::Bitmap(bv.clone()));
+                    properties.insert(key.clone(), ColumnCodec::Bitmap(bv));
+                }
+                InferredType::Dict => {
+                    let str_values: Vec<String> = values
+                        .iter()
+                        .map(|v| match v {
+                            Value::Null => String::new(),
+                            Value::String(s) => s.to_string(),
+                            other => format!("{other}"),
+                        })
+                        .collect();
+                    let str_refs: Vec<&str> = str_values.iter().map(String::as_str).collect();
+                    let mut dict_builder = DictionaryBuilder::new();
+                    for s in &str_refs {
+                        dict_builder.add(s);
+                    }
+                    let dict = dict_builder.build();
+                    col_type = infer_column_type(&ColumnCodec::Dict(dict.clone()));
+                    properties.insert(key.clone(), ColumnCodec::Dict(dict));
+                }
+            }
+            property_col_defs.push(super::schema::ColumnDef::new(key.as_str(), col_type));
+        }
+    }
+
+    let schema = EdgeSchema::new(
+        edge_type.as_str(),
+        rel_table_id,
+        src_label.as_str(),
+        dst_label.as_str(),
+        property_col_defs,
+    );
+
+    Ok(RelTable::new(
+        schema,
+        fwd,
+        Some(bwd_csr),
+        properties,
+        src_table_id,
+        dst_table_id,
+    ))
+}
+
 /// Infers the columnar encoding type from a slice of [`Value`]s.
 ///
 /// Rules:

--- a/crates/grafeo-core/src/graph/compact/column.rs
+++ b/crates/grafeo-core/src/graph/compact/column.rs
@@ -17,7 +17,7 @@ use crate::codec::{BitPackedInts, BitVector, DictionaryEncoding};
 /// primitives themselves are never modified. Use [`get`](Self::get) for
 /// `Value`-typed access and the specialised accessors when you know the
 /// underlying codec.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 pub enum ColumnCodec {
     /// Fixed-width bit-packed unsigned integers.

--- a/crates/grafeo-core/src/graph/compact/csr.rs
+++ b/crates/grafeo-core/src/graph/compact/csr.rs
@@ -8,7 +8,7 @@
 /// Stores a directed graph in two flat arrays: `offsets` (one per node + 1
 /// sentinel) and `targets` (concatenated neighbor lists). This layout is
 /// cache-friendly for forward traversal and has O(1) neighbor access.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CsrAdjacency {
     /// One entry per node plus a trailing sentinel.
     /// `offsets[i]..offsets[i+1]` is the range in `targets` for node `i`.

--- a/crates/grafeo-core/src/graph/compact/mod.rs
+++ b/crates/grafeo-core/src/graph/compact/mod.rs
@@ -20,12 +20,14 @@ pub mod node_table;
 pub mod rel_table;
 /// Schema definitions for node tables and edge schemas.
 pub mod schema;
+/// Serialization and deserialization for CompactStore.
+pub mod serialize;
 #[cfg(test)]
 mod tests;
 /// Zone maps for skip-pruning predicate evaluation.
 pub mod zone_map;
 
-pub use builder::{CompactStoreBuilder, from_graph_store};
+pub use builder::{CompactStoreBuilder, from_graph_store, from_graph_store_incremental};
 
 use std::sync::Arc;
 
@@ -171,6 +173,15 @@ impl CompactStore {
         self.table_id_to_label.get(table_id as usize)
     }
 
+    /// Returns the ordered slice of node table labels, indexed by table ID.
+    ///
+    /// Position `i` in the slice corresponds to `table_id = i`. Used by
+    /// HybridStore to enumerate all tables when computing ID boundaries.
+    #[must_use]
+    pub fn table_id_to_label(&self) -> &[ArcStr] {
+        &self.table_id_to_label
+    }
+
     /// Returns the edge type for a given rel table ID, if valid.
     #[must_use]
     pub fn edge_type_for_rel_table_id(&self, rel_table_id: u16) -> Option<&ArcStr> {
@@ -208,6 +219,36 @@ impl CompactStore {
         }
 
         results
+    }
+
+    /// Returns the node tables indexed by table_id.
+    #[must_use]
+    pub(crate) fn node_tables_by_id(&self) -> &[NodeTable] {
+        &self.node_tables_by_id
+    }
+
+    /// Returns the relationship tables indexed by rel_table_id.
+    #[must_use]
+    pub(crate) fn rel_tables_by_id(&self) -> &[RelTable] {
+        &self.rel_tables_by_id
+    }
+
+    /// Returns the label-to-table-id map.
+    #[must_use]
+    pub(crate) fn label_to_table_id_map(&self) -> &FxHashMap<ArcStr, u16> {
+        &self.label_to_table_id
+    }
+
+    /// Returns the edge-type-to-rel-id map.
+    #[must_use]
+    pub(crate) fn edge_type_to_rel_id_map(&self) -> &FxHashMap<ArcStr, Vec<u16>> {
+        &self.edge_type_to_rel_id
+    }
+
+    /// Returns the rel_table_id-to-type lookup.
+    #[must_use]
+    pub(crate) fn rel_table_id_to_type_slice(&self) -> &[ArcStr] {
+        &self.rel_table_id_to_type
     }
 
     /// Returns a rough estimate of heap memory used by the snapshot data

--- a/crates/grafeo-core/src/graph/compact/node_table.rs
+++ b/crates/grafeo-core/src/graph/compact/node_table.rs
@@ -16,7 +16,7 @@ use super::zone_map::ZoneMap;
 /// All nodes sharing a label are stored in a single `NodeTable` with one
 /// [`ColumnCodec`] per property. Row offsets are combined with the table ID
 /// via [`encode_node_id`] to produce globally unique [`NodeId`] values.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NodeTable {
     /// Schema describing the label, table ID, and column definitions.
     schema: TableSchema,
@@ -148,6 +148,32 @@ impl NodeTable {
     #[must_use]
     pub fn memory_bytes(&self) -> usize {
         self.columns.values().map(|c| c.heap_bytes()).sum()
+    }
+
+    /// Updates the table ID embedded in the schema.
+    ///
+    /// Used by incremental compaction when tables are re-indexed after
+    /// cloning from an old compact store.
+    pub(crate) fn set_table_id(&mut self, table_id: u16) {
+        self.schema.table_id = table_id;
+    }
+
+    /// Returns the schema for this table.
+    #[must_use]
+    pub(crate) fn schema(&self) -> &TableSchema {
+        &self.schema
+    }
+
+    /// Returns the columns map for this table.
+    #[must_use]
+    pub(crate) fn columns(&self) -> &FxHashMap<PropertyKey, ColumnCodec> {
+        &self.columns
+    }
+
+    /// Returns the zone maps for this table.
+    #[must_use]
+    pub(crate) fn zone_maps(&self) -> &FxHashMap<PropertyKey, ZoneMap> {
+        &self.zone_maps
     }
 }
 

--- a/crates/grafeo-core/src/graph/compact/rel_table.rs
+++ b/crates/grafeo-core/src/graph/compact/rel_table.rs
@@ -18,7 +18,7 @@ use super::schema::EdgeSchema;
 /// optional backward CSR indexed by target node offset. Edge properties are
 /// stored in columnar format, parallel to the forward CSR targets array
 /// (i.e. the property at index `i` corresponds to the edge at CSR position `i`).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RelTable {
     /// Schema describing the edge type and connected node labels.
     schema: EdgeSchema,
@@ -90,6 +90,28 @@ impl RelTable {
     #[must_use]
     pub fn dst_table_id(&self) -> u16 {
         self.dst_table_id
+    }
+
+    /// Updates the relationship table ID embedded in the schema.
+    ///
+    /// Used by incremental compaction when tables are re-indexed after
+    /// cloning from an old compact store.
+    pub(crate) fn set_rel_table_id(&mut self, rel_table_id: u16) {
+        self.schema.rel_table_id = rel_table_id;
+    }
+
+    /// Updates the source node table ID.
+    ///
+    /// Used by incremental compaction when node tables are re-indexed.
+    pub(crate) fn set_src_table_id(&mut self, src_table_id: u16) {
+        self.src_table_id = src_table_id;
+    }
+
+    /// Updates the destination node table ID.
+    ///
+    /// Used by incremental compaction when node tables are re-indexed.
+    pub(crate) fn set_dst_table_id(&mut self, dst_table_id: u16) {
+        self.dst_table_id = dst_table_id;
     }
 
     /// Returns the total number of edges in this table.
@@ -204,6 +226,30 @@ impl RelTable {
     #[must_use]
     pub fn in_degree(&self, dst_offset: u32) -> Option<usize> {
         self.bwd.as_ref().map(|b| b.degree(dst_offset))
+    }
+
+    /// Returns the schema for this relationship table.
+    #[must_use]
+    pub(crate) fn schema_ref(&self) -> &EdgeSchema {
+        &self.schema
+    }
+
+    /// Returns the forward CSR adjacency.
+    #[must_use]
+    pub(crate) fn fwd(&self) -> &CsrAdjacency {
+        &self.fwd
+    }
+
+    /// Returns the optional backward CSR adjacency.
+    #[must_use]
+    pub(crate) fn bwd(&self) -> &Option<CsrAdjacency> {
+        &self.bwd
+    }
+
+    /// Returns the edge properties map.
+    #[must_use]
+    pub(crate) fn edge_properties(&self) -> &FxHashMap<PropertyKey, ColumnCodec> {
+        &self.properties
     }
 
     /// Returns an estimate of heap memory used by the CSR structures and

--- a/crates/grafeo-core/src/graph/compact/schema.rs
+++ b/crates/grafeo-core/src/graph/compact/schema.rs
@@ -10,7 +10,7 @@ use arcstr::ArcStr;
 /// Each variant describes both the logical type and the physical encoding
 /// used in the columnar storage. This lets the query engine pick the right
 /// decoder without any runtime dispatch.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 pub enum ColumnType {
     /// Unsigned integer with a fixed bit width (1, 8, 16, 32, or 64).
@@ -33,7 +33,7 @@ pub enum ColumnType {
 ///
 /// Pairs a column name with its [`ColumnType`]. The name is used for property
 /// lookups; the type tells the storage layer how to encode/decode values.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ColumnDef {
     /// Column name (matches the property key in queries).
     pub name: ArcStr,
@@ -57,7 +57,7 @@ impl ColumnDef {
 /// All nodes with a given label share the same columnar layout defined here.
 /// The `table_id` is encoded into [`NodeId`](grafeo_common::types::NodeId)
 /// values via [`encode_node_id`](super::id::encode_node_id).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TableSchema {
     /// The node label this table stores (e.g. "Person", "Movie").
     pub label: ArcStr,
@@ -97,7 +97,7 @@ impl TableSchema {
 /// columns stored on the edges. The `rel_table_id` is encoded into
 /// [`EdgeId`](grafeo_common::types::EdgeId) values via
 /// [`encode_edge_id`](super::id::encode_edge_id).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EdgeSchema {
     /// The edge type this table stores (e.g. "KNOWS", "ACTED_IN").
     pub edge_type: ArcStr,

--- a/crates/grafeo-core/src/graph/compact/serialize.rs
+++ b/crates/grafeo-core/src/graph/compact/serialize.rs
@@ -1,0 +1,367 @@
+//! Serialization for CompactStore via bincode.
+//!
+//! `CompactStore` cannot derive `Serialize`/`Deserialize` directly because it
+//! contains `FxHashMap` fields (non-deterministic iteration order) and
+//! `Arc<Statistics>` (should be recomputed on load). Instead we use a set of
+//! proxy structs that convert hashmaps to sorted vecs and drop statistics.
+
+use arcstr::ArcStr;
+use grafeo_common::types::PropertyKey;
+use grafeo_common::utils::hash::FxHashMap;
+
+use super::CompactStore;
+use super::column::ColumnCodec;
+use super::csr::CsrAdjacency;
+use super::node_table::NodeTable;
+use super::rel_table::RelTable;
+use super::schema::{EdgeSchema, TableSchema};
+use super::zone_map::ZoneMap;
+use crate::statistics::{EdgeTypeStatistics, LabelStatistics, Statistics};
+
+// ---------------------------------------------------------------------------
+// Proxy types
+// ---------------------------------------------------------------------------
+
+/// Serializable mirror of [`NodeTable`] with sorted vecs instead of hashmaps.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct NodeTableProxy {
+    schema: TableSchema,
+    /// Sorted by PropertyKey for deterministic output.
+    columns: Vec<(PropertyKey, ColumnCodec)>,
+    /// Sorted by PropertyKey for deterministic output.
+    zone_maps: Vec<(PropertyKey, ZoneMap)>,
+    len: usize,
+}
+
+impl NodeTableProxy {
+    fn from_node_table(nt: &NodeTable) -> Self {
+        let mut columns: Vec<_> = nt
+            .columns()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        columns.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
+
+        let mut zone_maps: Vec<_> = nt
+            .zone_maps()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        zone_maps.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
+
+        NodeTableProxy {
+            schema: nt.schema().clone(),
+            columns,
+            zone_maps,
+            len: nt.len(),
+        }
+    }
+
+    fn into_node_table(self) -> NodeTable {
+        let columns: FxHashMap<PropertyKey, ColumnCodec> = self.columns.into_iter().collect();
+        let zone_maps: FxHashMap<PropertyKey, ZoneMap> = self.zone_maps.into_iter().collect();
+        NodeTable::from_columns(self.schema, columns, zone_maps, self.len)
+    }
+}
+
+/// Serializable mirror of [`RelTable`] with sorted vecs instead of hashmaps.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct RelTableProxy {
+    schema: EdgeSchema,
+    fwd: CsrAdjacency,
+    bwd: Option<CsrAdjacency>,
+    /// Sorted by PropertyKey for deterministic output.
+    properties: Vec<(PropertyKey, ColumnCodec)>,
+    src_table_id: u16,
+    dst_table_id: u16,
+}
+
+impl RelTableProxy {
+    fn from_rel_table(rt: &RelTable) -> Self {
+        let mut properties: Vec<_> = rt
+            .edge_properties()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        properties.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
+
+        RelTableProxy {
+            schema: rt.schema_ref().clone(),
+            fwd: rt.fwd().clone(),
+            bwd: rt.bwd().clone(),
+            properties,
+            src_table_id: rt.src_table_id(),
+            dst_table_id: rt.dst_table_id(),
+        }
+    }
+
+    fn into_rel_table(self) -> RelTable {
+        let properties: FxHashMap<PropertyKey, ColumnCodec> =
+            self.properties.into_iter().collect();
+        RelTable::new(
+            self.schema,
+            self.fwd,
+            self.bwd,
+            properties,
+            self.src_table_id,
+            self.dst_table_id,
+        )
+    }
+}
+
+/// Serializable mirror of [`CompactStore`].
+#[derive(serde::Serialize, serde::Deserialize)]
+struct CompactStoreProxy {
+    node_tables_by_id: Vec<NodeTableProxy>,
+    rel_tables_by_id: Vec<RelTableProxy>,
+    /// Sorted by label for deterministic output.
+    label_to_table_id: Vec<(ArcStr, u16)>,
+    /// Sorted by edge type for deterministic output.
+    edge_type_to_rel_id: Vec<(ArcStr, Vec<u16>)>,
+    table_id_to_label: Vec<ArcStr>,
+    rel_table_id_to_type: Vec<ArcStr>,
+}
+
+impl CompactStoreProxy {
+    fn from_compact_store(store: &CompactStore) -> Self {
+        let node_tables_by_id = store
+            .node_tables_by_id()
+            .iter()
+            .map(NodeTableProxy::from_node_table)
+            .collect();
+
+        let rel_tables_by_id = store
+            .rel_tables_by_id()
+            .iter()
+            .map(RelTableProxy::from_rel_table)
+            .collect();
+
+        let mut label_to_table_id: Vec<_> = store
+            .label_to_table_id_map()
+            .iter()
+            .map(|(k, &v)| (k.clone(), v))
+            .collect();
+        label_to_table_id.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let mut edge_type_to_rel_id: Vec<_> = store
+            .edge_type_to_rel_id_map()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        edge_type_to_rel_id.sort_by(|a, b| a.0.cmp(&b.0));
+
+        CompactStoreProxy {
+            node_tables_by_id,
+            rel_tables_by_id,
+            label_to_table_id,
+            edge_type_to_rel_id,
+            table_id_to_label: store.table_id_to_label().to_vec(),
+            rel_table_id_to_type: store.rel_table_id_to_type_slice().to_vec(),
+        }
+    }
+
+    fn into_compact_store(self) -> CompactStore {
+        let node_tables_by_id: Vec<NodeTable> = self
+            .node_tables_by_id
+            .into_iter()
+            .map(|p| p.into_node_table())
+            .collect();
+
+        let rel_tables_by_id: Vec<RelTable> = self
+            .rel_tables_by_id
+            .into_iter()
+            .map(|p| p.into_rel_table())
+            .collect();
+
+        let label_to_table_id: FxHashMap<ArcStr, u16> =
+            self.label_to_table_id.into_iter().collect();
+
+        let edge_type_to_rel_id: FxHashMap<ArcStr, Vec<u16>> =
+            self.edge_type_to_rel_id.into_iter().collect();
+
+        // Recompute statistics (they are not persisted).
+        let mut stats = Statistics::new();
+        let mut total_nodes: u64 = 0;
+        let mut total_edges: u64 = 0;
+
+        for (idx, nt) in node_tables_by_id.iter().enumerate() {
+            let count = nt.len() as u64;
+            total_nodes += count;
+            let label = &self.table_id_to_label[idx];
+            stats.update_label(label.as_str(), LabelStatistics::new(count));
+        }
+
+        let mut edge_type_counts: FxHashMap<&str, u64> = FxHashMap::default();
+        for (idx, rt) in rel_tables_by_id.iter().enumerate() {
+            let count = rt.num_edges() as u64;
+            total_edges += count;
+            let edge_type = &self.rel_table_id_to_type[idx];
+            *edge_type_counts.entry(edge_type.as_str()).or_default() += count;
+        }
+        for (edge_type, count) in edge_type_counts {
+            stats.update_edge_type(edge_type, EdgeTypeStatistics::new(count, 0.0, 0.0));
+        }
+
+        stats.total_nodes = total_nodes;
+        stats.total_edges = total_edges;
+
+        CompactStore::new(
+            node_tables_by_id,
+            label_to_table_id,
+            rel_tables_by_id,
+            edge_type_to_rel_id,
+            self.table_id_to_label,
+            self.rel_table_id_to_type,
+            stats,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+impl CompactStore {
+    /// Serializes the store to bytes using bincode.
+    ///
+    /// Statistics are **not** included; they will be recomputed on
+    /// [`from_bytes`](Self::from_bytes).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if bincode serialization fails.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
+        let proxy = CompactStoreProxy::from_compact_store(self);
+        bincode::serde::encode_to_vec(&proxy, bincode::config::standard())
+            .map_err(|e| format!("serialization failed: {e}"))
+    }
+
+    /// Deserializes a store from bytes produced by [`to_bytes`](Self::to_bytes).
+    ///
+    /// Statistics are recomputed after deserialization.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the bytes are invalid or cannot be decoded.
+    pub fn from_bytes(data: &[u8]) -> Result<Self, String> {
+        let (proxy, _): (CompactStoreProxy, _) =
+            bincode::serde::decode_from_slice(data, bincode::config::standard())
+                .map_err(|e| format!("deserialization failed: {e}"))?;
+        Ok(proxy.into_compact_store())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::GraphStore;
+    use crate::graph::compact::CompactStoreBuilder;
+
+    #[test]
+    fn roundtrip_empty() {
+        let store = CompactStoreBuilder::new().build().unwrap();
+        let bytes = store.to_bytes().unwrap();
+        let restored = CompactStore::from_bytes(&bytes).unwrap();
+        assert_eq!(restored.node_count(), 0);
+        assert_eq!(restored.edge_count(), 0);
+    }
+
+    #[test]
+    fn roundtrip_nodes() {
+        let grades: Vec<u64> = (0..50).collect();
+        let names: Vec<&str> = (0..50).map(|i| if i % 2 == 0 { "A" } else { "B" }).collect();
+        let active: Vec<bool> = (0..50).map(|i| i % 3 == 0).collect();
+
+        let store = CompactStoreBuilder::new()
+            .node_table("Student", |b| {
+                b.column_bitpacked("grade", &grades, 8)
+                    .column_dict("name", &names)
+                    .column_bitmap("active", &active)
+            })
+            .build()
+            .unwrap();
+
+        let bytes = store.to_bytes().unwrap();
+        let restored = CompactStore::from_bytes(&bytes).unwrap();
+
+        assert_eq!(restored.node_count(), 50);
+        assert_eq!(restored.nodes_by_label("Student").len(), 50);
+
+        let id = restored.nodes_by_label("Student")[0];
+        let node = restored.get_node(id).unwrap();
+        assert!(node
+            .properties
+            .contains_key(&grafeo_common::types::PropertyKey::new("grade")));
+        assert!(node
+            .properties
+            .contains_key(&grafeo_common::types::PropertyKey::new("name")));
+    }
+
+    #[test]
+    fn roundtrip_with_edges() {
+        let grades: Vec<u64> = (0..10).collect();
+        let levels: Vec<u64> = (0..5).collect();
+        let edges: Vec<(u32, u32)> = (0..10).map(|i| (i, i % 5)).collect();
+
+        let store = CompactStoreBuilder::new()
+            .node_table("Student", |b| b.column_bitpacked("grade", &grades, 8))
+            .node_table("Course", |b| b.column_bitpacked("level", &levels, 4))
+            .rel_table("ENROLLED_IN", "Student", "Course", |b| {
+                b.edges(edges).backward(true)
+            })
+            .build()
+            .unwrap();
+
+        let bytes = store.to_bytes().unwrap();
+        let restored = CompactStore::from_bytes(&bytes).unwrap();
+
+        assert_eq!(restored.node_count(), 15);
+        assert_eq!(restored.edge_count(), 10);
+        assert_eq!(restored.all_edge_types(), vec!["ENROLLED_IN".to_string()]);
+
+        let student_0 = restored.nodes_by_label("Student")[0];
+        let edges = restored.edges_from(student_0, crate::graph::Direction::Outgoing);
+        assert!(!edges.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_all_column_types() {
+        let ints: Vec<u64> = vec![0, 100, 200, 300];
+        let strings: Vec<&str> = vec!["alpha", "beta", "gamma", "delta"];
+        let bools: Vec<bool> = vec![true, false, true, false];
+
+        let store = CompactStoreBuilder::new()
+            .node_table("Mixed", |b| {
+                b.column_bitpacked("score", &ints, 16)
+                    .column_dict("label", &strings)
+                    .column_bitmap("flag", &bools)
+            })
+            .build()
+            .unwrap();
+
+        let bytes = store.to_bytes().unwrap();
+        let restored = CompactStore::from_bytes(&bytes).unwrap();
+
+        let id = restored.nodes_by_label("Mixed")[2];
+        let node = restored.get_node(id).unwrap();
+        assert_eq!(
+            node.properties
+                .get(&grafeo_common::types::PropertyKey::new("score")),
+            Some(&grafeo_common::types::Value::Int64(200))
+        );
+        assert_eq!(
+            node.properties
+                .get(&grafeo_common::types::PropertyKey::new("label")),
+            Some(&grafeo_common::types::Value::String(arcstr::literal!("gamma")))
+        );
+        assert_eq!(
+            node.properties
+                .get(&grafeo_common::types::PropertyKey::new("flag")),
+            Some(&grafeo_common::types::Value::Bool(true))
+        );
+    }
+}

--- a/crates/grafeo-core/src/graph/compact/zone_map.rs
+++ b/crates/grafeo-core/src/graph/compact/zone_map.rs
@@ -13,7 +13,7 @@ use grafeo_common::types::Value;
 /// A zone map tracks the range of values in a column so the query engine can
 /// eliminate entire tables without scanning rows. If [`might_match`](Self::might_match)
 /// returns `false`, the predicate is guaranteed to have zero matching rows.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct ZoneMap {
     /// Minimum value in the column, or `None` if the column has no non-null values.
     pub min: Option<Value>,

--- a/crates/grafeo-core/src/graph/hybrid/id.rs
+++ b/crates/grafeo-core/src/graph/hybrid/id.rs
@@ -1,0 +1,122 @@
+//! ID offset computation for hybrid store ID partitioning.
+//!
+//! Compact IDs live below the offset, overlay IDs above it.
+
+use crate::graph::compact::CompactStore;
+use crate::graph::compact::id::{encode_edge_id, encode_node_id};
+
+/// Computes the ID boundary for a compact store.
+///
+/// Scans all node tables AND relationship tables to find the maximum
+/// encoded ID (node or edge), then returns `max + 1`. Overlay LpgStore
+/// IDs start at this value, guaranteeing no overlap with compact IDs.
+///
+/// Both node IDs and edge IDs share the same bit layout
+/// (`[63]=0 | [62:48]=table_id | [47:0]=offset`), so the offset must
+/// cover the maximum across both ID types to prevent collisions.
+///
+/// Returns 0 for an empty CompactStore.
+#[must_use]
+pub fn compute_id_offset(compact: &CompactStore) -> u64 {
+    let mut has_entities = false;
+    let mut max_id: u64 = 0;
+
+    for (table_id, label) in compact.table_id_to_label().iter().enumerate() {
+        if let Some(nt) = compact.node_table(label) {
+            let len = nt.len();
+            if len > 0 {
+                has_entities = true;
+                let id = encode_node_id(table_id as u16, (len - 1) as u64);
+                max_id = max_id.max(id.as_u64());
+            }
+        }
+    }
+
+    for (rel_id, rt) in compact.rel_tables_by_id().iter().enumerate() {
+        let num = rt.num_edges();
+        if num > 0 {
+            has_entities = true;
+            let id = encode_edge_id(rel_id as u16, (num - 1) as u64);
+            max_id = max_id.max(id.as_u64());
+        }
+    }
+
+    if has_entities { max_id + 1 } else { 0 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::compact::CompactStoreBuilder;
+
+    fn empty_compact() -> CompactStore {
+        CompactStoreBuilder::new().build().unwrap()
+    }
+
+    fn compact_with_students(n: usize) -> CompactStore {
+        let grades: Vec<u64> = (0..n).map(|i| i as u64).collect();
+        CompactStoreBuilder::new()
+            .node_table("Student", |b| {
+                b.column_bitpacked("grade", &grades, 8)
+            })
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn offset_empty_compact() {
+        let compact = empty_compact();
+        assert_eq!(compute_id_offset(&compact), 0);
+    }
+
+    #[test]
+    fn offset_single_table() {
+        let compact = compact_with_students(100);
+        let offset = compute_id_offset(&compact);
+        assert!(offset > 0);
+        assert_eq!(
+            offset,
+            crate::graph::compact::id::encode_node_id(0, 99).as_u64() + 1
+        );
+    }
+
+    #[test]
+    fn offset_accounts_for_edge_ids() {
+        // Edge IDs use the same bit layout as node IDs:
+        //   [62:48]=table_id, [47:0]=offset
+        // With a single node table (table_id=0) and a single rel table
+        // (rel_table_id=0), the offset field determines which is larger.
+        // Here 1000 edges > 5 nodes, so max_edge_id > max_node_id.
+        let grades: Vec<u64> = (0..5).collect();
+        let edges: Vec<(u32, u32)> = (0..1000).map(|i| (i % 5, i % 5)).collect();
+        let compact = CompactStoreBuilder::new()
+            .node_table("A", |b| b.column_bitpacked("x", &grades, 4))
+            .rel_table("R", "A", "A", |b| b.edges(edges))
+            .build()
+            .unwrap();
+        let offset = compute_id_offset(&compact);
+        // Both table_id=0, so max is determined by offset field
+        let max_edge = crate::graph::compact::id::encode_edge_id(0, 999).as_u64();
+        let max_node = crate::graph::compact::id::encode_node_id(0, 4).as_u64();
+        assert!(max_edge > max_node);
+        assert_eq!(offset, max_edge + 1);
+    }
+
+    #[test]
+    fn offset_multiple_tables() {
+        let grades: Vec<u64> = (0..50).collect();
+        let levels: Vec<u64> = (0..200).collect();
+        let compact = CompactStoreBuilder::new()
+            .node_table("Student", |b| {
+                b.column_bitpacked("grade", &grades, 8)
+            })
+            .node_table("Course", |b| {
+                b.column_bitpacked("level", &levels, 8)
+            })
+            .build()
+            .unwrap();
+        let offset = compute_id_offset(&compact);
+        let max_id = crate::graph::compact::id::encode_node_id(1, 199).as_u64();
+        assert_eq!(offset, max_id + 1);
+    }
+}

--- a/crates/grafeo-core/src/graph/hybrid/mod.rs
+++ b/crates/grafeo-core/src/graph/hybrid/mod.rs
@@ -1,0 +1,457 @@
+//! HybridStore: columnar base with mutable MVCC overlay.
+
+pub mod id;
+mod reader;
+mod writer;
+
+#[cfg(test)]
+mod tests;
+
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use grafeo_common::types::{EdgeId, NodeId, TransactionId};
+use grafeo_common::utils::hash::FxHashMap;
+use grafeo_common::utils::hash::FxHashSet;
+use parking_lot::RwLock;
+
+use grafeo_common::types::PropertyKey;
+
+use crate::graph::compact::from_graph_store_incremental;
+use crate::graph::compact::id::{decode_edge_id, decode_node_id};
+use crate::graph::compact::CompactStore;
+use crate::graph::lpg::LpgStore;
+use crate::graph::traits::GraphStore;
+
+use self::id::compute_id_offset;
+
+/// Entity ID for tracking pending deletions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum EntityId {
+    Node(NodeId),
+    Edge(EdgeId),
+}
+
+/// Per-entity dirty bitmap for skipping overlay lookups on clean compact entities.
+///
+/// Organized as per-table bitsets: `bits[table_id][word_index]` where each u64
+/// word holds 64 entity flags. Checking dirtiness is two array lookups + one
+/// bit test (~1-2ns, L1-friendly) vs a hash lookup (~5-10ns, cache-hostile).
+///
+/// Also tracks which property columns have any overlay modifications, so scans
+/// on untouched columns skip the overlay entirely.
+pub(crate) struct DirtySet {
+    /// Per-table entity bitmaps. `entity_bits[table_id][offset / 64] & (1 << offset % 64)`.
+    entity_bits: Vec<Vec<u64>>,
+    /// Property columns with at least one overlay modification on a compact entity.
+    dirty_columns: FxHashSet<PropertyKey>,
+}
+
+impl DirtySet {
+    fn new(table_sizes: &[usize]) -> Self {
+        let entity_bits = table_sizes
+            .iter()
+            .map(|&size| vec![0u64; (size + 63) / 64])
+            .collect();
+        Self {
+            entity_bits,
+            dirty_columns: FxHashSet::default(),
+        }
+    }
+
+    /// Marks a compact entity as dirty (has overlay modifications).
+    #[inline]
+    fn mark_entity(&mut self, table_id: u16, offset: u64) {
+        if let Some(words) = self.entity_bits.get_mut(table_id as usize) {
+            let word_idx = (offset / 64) as usize;
+            if word_idx < words.len() {
+                words[word_idx] |= 1 << (offset % 64);
+            }
+        }
+    }
+
+    /// Marks a property column as having overlay modifications.
+    #[inline]
+    fn mark_column(&mut self, key: PropertyKey) {
+        self.dirty_columns.insert(key);
+    }
+
+    /// Returns `true` if this compact entity has overlay modifications.
+    #[inline]
+    fn is_dirty(&self, table_id: u16, offset: u64) -> bool {
+        self.entity_bits
+            .get(table_id as usize)
+            .and_then(|words| words.get((offset / 64) as usize))
+            .is_some_and(|&word| (word >> (offset % 64)) & 1 == 1)
+    }
+
+    /// Returns `true` if this property column has any overlay modifications
+    /// on compact entities.
+    #[inline]
+    fn is_column_dirty(&self, key: &PropertyKey) -> bool {
+        self.dirty_columns.contains(key)
+    }
+
+    /// Returns `true` if any entity in the given table has overlay modifications.
+    fn has_dirty_in_table(&self, table_id: u16) -> bool {
+        self.entity_bits
+            .get(table_id as usize)
+            .is_some_and(|words| words.iter().any(|&w| w != 0))
+    }
+
+    /// Check dirtiness given a pre-decoded (table_id, offset). No lock needed
+    /// when the caller already holds the `RwLockReadGuard`.
+    #[inline]
+    pub(crate) fn id_is_dirty_node(dirty: &DirtySet, id: NodeId) -> bool {
+        let (table_id, offset) = decode_node_id(id);
+        dirty.is_dirty(table_id, offset)
+    }
+
+    fn clear_and_resize(&mut self, table_sizes: &[usize]) {
+        self.entity_bits = table_sizes
+            .iter()
+            .map(|&size| vec![0u64; (size + 63) / 64])
+            .collect();
+        self.dirty_columns.clear();
+    }
+}
+
+/// Hybrid graph store combining a frozen columnar base with a mutable MVCC overlay.
+///
+/// Reads merge both stores transparently. Writes go to the overlay. The compact
+/// store is never mutated after construction.
+pub struct HybridStore {
+    compact: RwLock<CompactStore>,
+    /// Never replaced — cleared in-place during compaction.
+    /// No lock needed; LpgStore handles its own internal synchronization.
+    overlay: Arc<LpgStore>,
+    deleted_nodes: Arc<RwLock<FxHashSet<NodeId>>>,
+    deleted_edges: Arc<RwLock<FxHashSet<EdgeId>>>,
+    pending_deletions: Arc<RwLock<FxHashMap<TransactionId, Vec<EntityId>>>>,
+    /// Per-entity bitmap + per-column flags for skipping overlay lookups.
+    dirty_nodes: RwLock<DirtySet>,
+    dirty_edges: RwLock<DirtySet>,
+    compact_node_count: AtomicUsize,
+    compact_edge_count: AtomicUsize,
+    id_offset: AtomicU64,
+}
+
+impl std::fmt::Debug for HybridStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HybridStore")
+            .field("compact_node_count", &self.compact_node_count.load(Ordering::Relaxed))
+            .field("compact_edge_count", &self.compact_edge_count.load(Ordering::Relaxed))
+            .field("id_offset", &self.id_offset.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+impl HybridStore {
+    /// Opens a `HybridStore` wrapping the given compact store.
+    ///
+    /// Computes an ID offset so overlay IDs never collide with compact IDs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`grafeo_common::memory::AllocError`] if the overlay `LpgStore`
+    /// cannot be allocated.
+    pub fn open(compact: CompactStore) -> Result<Self, grafeo_common::memory::AllocError> {
+        let offset = compute_id_offset(&compact);
+        let compact_node_count = compact.node_count();
+        let compact_edge_count = compact.edge_count();
+
+        let overlay = Arc::new(LpgStore::new()?);
+        // Set overlay IDs to start above compact range so IDs never collide.
+        overlay.set_next_node_id(offset);
+        overlay.set_next_edge_id(offset);
+
+        let deleted_nodes = Arc::new(RwLock::new(FxHashSet::default()));
+        let deleted_edges = Arc::new(RwLock::new(FxHashSet::default()));
+        let pending_deletions = Arc::new(RwLock::new(FxHashMap::default()));
+
+        Self::register_hooks(&overlay, &deleted_nodes, &deleted_edges, &pending_deletions);
+
+        let node_table_sizes: Vec<usize> = compact
+            .table_id_to_label()
+            .iter()
+            .filter_map(|label| compact.node_table(label))
+            .map(|nt| nt.len())
+            .collect();
+        let edge_table_sizes: Vec<usize> = compact
+            .rel_tables_by_id()
+            .iter()
+            .map(|rt| rt.num_edges())
+            .collect();
+
+        Ok(Self {
+            compact: RwLock::new(compact),
+            overlay,
+            deleted_nodes,
+            deleted_edges,
+            pending_deletions,
+            dirty_nodes: RwLock::new(DirtySet::new(&node_table_sizes)),
+            dirty_edges: RwLock::new(DirtySet::new(&edge_table_sizes)),
+            compact_node_count: AtomicUsize::new(compact_node_count),
+            compact_edge_count: AtomicUsize::new(compact_edge_count),
+            id_offset: AtomicU64::new(offset),
+        })
+    }
+
+    /// Returns a reference to the overlay `LpgStore`.
+    pub fn overlay(&self) -> &Arc<LpgStore> {
+        &self.overlay
+    }
+
+    /// Returns the ID boundary value.
+    ///
+    /// Compact IDs are strictly below this value; overlay IDs are at or above it.
+    pub fn id_offset(&self) -> u64 {
+        self.id_offset.load(Ordering::Relaxed)
+    }
+
+    /// Returns `true` if `id` belongs to the compact store (below the offset).
+    pub fn is_compact_node_id(&self, id: NodeId) -> bool {
+        id.as_u64() < self.id_offset.load(Ordering::Relaxed)
+    }
+
+    /// Returns `true` if `id` belongs to the compact store (below the offset).
+    pub fn is_compact_edge_id(&self, id: EdgeId) -> bool {
+        id.as_u64() < self.id_offset.load(Ordering::Relaxed)
+    }
+
+    /// Marks a compact node as dirty (has overlay modifications).
+    pub(crate) fn mark_node_dirty(&self, id: NodeId, column: Option<&str>) {
+        let (table_id, offset) = decode_node_id(id);
+        let mut dirty = self.dirty_nodes.write();
+        dirty.mark_entity(table_id, offset);
+        if let Some(col) = column {
+            dirty.mark_column(PropertyKey::new(col));
+        }
+    }
+
+    /// Marks a compact edge as dirty.
+    pub(crate) fn mark_edge_dirty(&self, id: EdgeId, column: Option<&str>) {
+        let (table_id, offset) = decode_edge_id(id);
+        let mut dirty = self.dirty_edges.write();
+        dirty.mark_entity(table_id, offset);
+        if let Some(col) = column {
+            dirty.mark_column(PropertyKey::new(col));
+        }
+    }
+
+    /// Returns `true` if a compact node has overlay modifications.
+    #[inline]
+    pub(crate) fn is_node_dirty(&self, id: NodeId) -> bool {
+        let (table_id, offset) = decode_node_id(id);
+        self.dirty_nodes.read().is_dirty(table_id, offset)
+    }
+
+    /// Returns `true` if a compact edge has overlay modifications.
+    #[inline]
+    pub(crate) fn is_edge_dirty(&self, id: EdgeId) -> bool {
+        let (table_id, offset) = decode_edge_id(id);
+        self.dirty_edges.read().is_dirty(table_id, offset)
+    }
+
+    /// Returns `true` if the node has been soft-deleted via the overlay.
+    fn is_node_deleted(&self, id: NodeId) -> bool {
+        self.deleted_nodes.read().contains(&id)
+    }
+
+    /// Returns `true` if the edge has been soft-deleted via the overlay.
+    fn is_edge_deleted(&self, id: EdgeId) -> bool {
+        self.deleted_edges.read().contains(&id)
+    }
+
+    /// Called when a transaction is rolled back.
+    /// Removes any compact entity deletions that were part of this transaction.
+    pub fn on_rollback(&self, transaction_id: TransactionId) {
+        // Remove from pending first, drop the lock, then apply to deletion sets
+        let deletions = self.pending_deletions.write().remove(&transaction_id);
+        if let Some(deletions) = deletions {
+            let mut del_nodes = self.deleted_nodes.write();
+            let mut del_edges = self.deleted_edges.write();
+            for entity in deletions {
+                match entity {
+                    EntityId::Node(id) => { del_nodes.remove(&id); }
+                    EntityId::Edge(id) => { del_edges.remove(&id); }
+                }
+            }
+        }
+    }
+
+    /// Called when a transaction is committed.
+    /// Clears the pending deletion tracking (deletions are permanent).
+    pub fn on_commit(&self, transaction_id: TransactionId) {
+        self.pending_deletions.write().remove(&transaction_id);
+    }
+
+    /// Incrementally compacts the hybrid store.
+    ///
+    /// Unchanged node/rel tables (no dirty entities, no deletions, no new overlay
+    /// entities with that label/type) are cloned as-is. Only tables with
+    /// modifications are rebuilt from the merged `GraphStore` view.
+    ///
+    /// Caller must ensure no active transactions.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `String` if the rebuild fails.
+    pub fn compact(&self) -> Result<(), String> {
+        let dirty_n = self.dirty_nodes.read();
+        let dirty_e = self.dirty_edges.read();
+        let deleted_n = self.deleted_nodes.read();
+        let deleted_e = self.deleted_edges.read();
+
+        // Check if anything has changed at all (fast no-op path).
+        let compact = self.compact.read();
+        let overlay_labels = GraphStore::all_labels(self.overlay.as_ref());
+        let has_new_labels = overlay_labels
+            .iter()
+            .any(|l| !compact.label_to_table_id_map().contains_key(l.as_str()));
+        let has_any_overlay_edges = GraphStore::edge_count(self.overlay.as_ref()) > 0;
+        let has_overlay_nodes = GraphStore::node_count(self.overlay.as_ref()) > 0;
+
+        let any_node_table_dirty = (0..compact.node_tables_by_id().len())
+            .any(|tid| dirty_n.has_dirty_in_table(tid as u16));
+        let any_rel_table_dirty = (0..compact.rel_tables_by_id().len())
+            .any(|tid| dirty_e.has_dirty_in_table(tid as u16));
+        let has_deletions = !deleted_n.is_empty() || !deleted_e.is_empty();
+
+        let needs_rebuild =
+            any_node_table_dirty || any_rel_table_dirty || has_deletions
+            || has_new_labels || has_any_overlay_edges || has_overlay_nodes;
+
+        if !needs_rebuild {
+            return Ok(());
+        }
+
+        // Compute which node tables are unchanged:
+        //   - no dirty entities in the table
+        //   - no deleted nodes in the table
+        //   - no overlay nodes with that label
+        let overlay_label_set: FxHashSet<String> = overlay_labels.into_iter().collect();
+        let mut unchanged_node_tables: FxHashSet<u16> = FxHashSet::default();
+        for (tid, label) in compact.table_id_to_label().iter().enumerate() {
+            let tid = tid as u16;
+            let table_dirty = dirty_n.has_dirty_in_table(tid);
+            let has_deleted = deleted_n.iter().any(|&nid| {
+                let (t, _) = crate::graph::compact::id::decode_node_id(nid);
+                t == tid
+            });
+            let has_overlay_label = overlay_label_set.contains(label.as_str());
+            if !table_dirty && !has_deleted && !has_overlay_label {
+                unchanged_node_tables.insert(tid);
+            }
+        }
+
+        // Compute which rel tables are unchanged:
+        //   - no dirty edges in the table
+        //   - no deleted edges in the table
+        //   - no overlay edges of that edge type
+        //   - both src and dst node tables are unchanged
+        let overlay_edge_types: FxHashSet<String> =
+            GraphStore::all_edge_types(self.overlay.as_ref())
+                .into_iter()
+                .collect();
+        let mut unchanged_rel_tables: FxHashSet<u16> = FxHashSet::default();
+        for (rid, rt) in compact.rel_tables_by_id().iter().enumerate() {
+            let rid = rid as u16;
+            let rel_dirty = dirty_e.has_dirty_in_table(rid);
+            let has_deleted_edge = deleted_e.iter().any(|&eid| {
+                let (r, _) = crate::graph::compact::id::decode_edge_id(eid);
+                r == rid
+            });
+            let edge_type = compact
+                .edge_type_for_rel_table_id(rid)
+                .map_or("", |s| s.as_str());
+            let has_overlay_type = overlay_edge_types.contains(edge_type);
+            let src_unchanged = unchanged_node_tables.contains(&rt.src_table_id());
+            let dst_unchanged = unchanged_node_tables.contains(&rt.dst_table_id());
+            if !rel_dirty && !has_deleted_edge && !has_overlay_type && src_unchanged && dst_unchanged
+            {
+                unchanged_rel_tables.insert(rid);
+            }
+        }
+
+        drop(compact);
+        drop(dirty_n);
+        drop(dirty_e);
+        drop(deleted_n);
+        drop(deleted_e);
+
+        let old_compact = self.compact.read();
+        let merged = from_graph_store_incremental(
+            self as &dyn crate::graph::traits::GraphStore,
+            &old_compact,
+            &unchanged_node_tables,
+            &unchanged_rel_tables,
+        )
+        .map_err(|e| e.to_string())?;
+        drop(old_compact);
+
+        let new_offset = compute_id_offset(&merged);
+        let new_node_count = merged.node_count();
+        let new_edge_count = merged.edge_count();
+
+        *self.compact.write() = merged;
+        self.overlay.clear();
+        self.overlay.set_next_node_id(new_offset);
+        self.overlay.set_next_edge_id(new_offset);
+        self.deleted_nodes.write().clear();
+        self.deleted_edges.write().clear();
+        self.pending_deletions.write().clear();
+        {
+            let compact = self.compact.read();
+            let node_sizes: Vec<usize> = compact
+                .table_id_to_label()
+                .iter()
+                .filter_map(|label| compact.node_table(label))
+                .map(|nt| nt.len())
+                .collect();
+            let edge_sizes: Vec<usize> = compact
+                .rel_tables_by_id()
+                .iter()
+                .map(|rt| rt.num_edges())
+                .collect();
+            self.dirty_nodes.write().clear_and_resize(&node_sizes);
+            self.dirty_edges.write().clear_and_resize(&edge_sizes);
+        }
+        self.compact_node_count.store(new_node_count, Ordering::Release);
+        self.compact_edge_count.store(new_edge_count, Ordering::Release);
+        self.id_offset.store(new_offset, Ordering::Release);
+
+        Ok(())
+    }
+
+    /// Registers rollback/commit hooks on an overlay for deletion tracking.
+    fn register_hooks(
+        overlay: &LpgStore,
+        deleted_nodes: &Arc<RwLock<FxHashSet<NodeId>>>,
+        deleted_edges: &Arc<RwLock<FxHashSet<EdgeId>>>,
+        pending_deletions: &Arc<RwLock<FxHashMap<TransactionId, Vec<EntityId>>>>,
+    ) {
+        let dn = Arc::clone(deleted_nodes);
+        let de = Arc::clone(deleted_edges);
+        let pd = Arc::clone(pending_deletions);
+
+        overlay.set_on_rollback_hook(Box::new(move |tx_id| {
+            let deletions = pd.write().remove(&tx_id);
+            if let Some(deletions) = deletions {
+                let mut del_nodes = dn.write();
+                let mut del_edges = de.write();
+                for entity in deletions {
+                    match entity {
+                        EntityId::Node(id) => { del_nodes.remove(&id); }
+                        EntityId::Edge(id) => { del_edges.remove(&id); }
+                    }
+                }
+            }
+        }));
+
+        let pd2 = Arc::clone(pending_deletions);
+        overlay.set_on_commit_hook(Box::new(move |tx_id| {
+            pd2.write().remove(&tx_id);
+        }));
+    }
+}

--- a/crates/grafeo-core/src/graph/hybrid/reader.rs
+++ b/crates/grafeo-core/src/graph/hybrid/reader.rs
@@ -1,0 +1,856 @@
+//! GraphStore implementation for HybridStore (merged reads).
+//!
+//! Every read method follows the same merge protocol:
+//!
+//! 1. **Deleted?** -- if the entity was soft-deleted via the overlay, return `None`.
+//! 2. **Overlay?** -- if the entity lives in the overlay (ID >= offset), delegate
+//!    to the overlay `LpgStore`.
+//! 3. **Compact?** -- fall back to the frozen `CompactStore`, then apply any
+//!    property overrides the overlay may hold for that compact ID.
+//!
+//! Scan methods merge results from both stores, filtering out deleted compact
+//! entities. Count methods combine compact and overlay counts minus deletions.
+
+use std::sync::Arc;
+
+use arcstr::ArcStr;
+use grafeo_common::types::{EdgeId, EpochId, NodeId, PropertyKey, TransactionId, Value};
+use grafeo_common::utils::hash::{FxHashMap, FxHashSet};
+
+use super::{DirtySet, HybridStore};
+use crate::graph::Direction;
+use crate::graph::lpg::CompareOp;
+use crate::graph::lpg::{Edge, Node};
+use crate::graph::traits::GraphStore;
+use crate::statistics::Statistics;
+
+impl HybridStore {
+    /// Reads a compact node and merges overlay property overrides onto it.
+    fn compact_node_merged(&self, id: NodeId) -> Option<Node> {
+        let compact = self.compact.read();
+        let mut node = compact.get_node(id)?;
+        drop(compact);
+
+        // Fast path: clean entity — no overlay modifications
+        if !self.is_node_dirty(id) {
+            return Some(node);
+        }
+
+        // Apply overlay property overrides; skip Null tombstones (property removed).
+        let overrides = self.overlay.get_node_properties_all(id);
+        for (k, v) in overrides {
+            if v == Value::Null {
+                node.properties.remove(&k);
+            } else {
+                node.set_property(k, v);
+            }
+        }
+        Some(node)
+    }
+
+    /// Reads a compact edge and merges overlay property overrides onto it.
+    fn compact_edge_merged(&self, id: EdgeId) -> Option<Edge> {
+        let compact = self.compact.read();
+        let mut edge = compact.get_edge(id)?;
+        drop(compact);
+
+        // Fast path: clean entity
+        if !self.is_edge_dirty(id) {
+            return Some(edge);
+        }
+
+        // Apply overlay property overrides; skip Null tombstones (property removed).
+        let overrides = self.overlay.get_edge_properties_all(id);
+        for (k, v) in overrides {
+            if v == Value::Null {
+                edge.properties.remove(&k);
+            } else {
+                edge.set_property(k, v);
+            }
+        }
+        Some(edge)
+    }
+}
+
+impl GraphStore for HybridStore {
+    // ---------------------------------------------------------------
+    // Point lookups
+    // ---------------------------------------------------------------
+
+    fn get_node(&self, id: NodeId) -> Option<Node> {
+        if self.is_node_deleted(id) {
+            return None;
+        }
+        if self.is_compact_node_id(id) {
+            self.compact_node_merged(id)
+        } else {
+            GraphStore::get_node(self.overlay.as_ref(), id)
+        }
+    }
+
+    fn get_edge(&self, id: EdgeId) -> Option<Edge> {
+        if self.is_edge_deleted(id) {
+            return None;
+        }
+        if self.is_compact_edge_id(id) {
+            self.compact_edge_merged(id)
+        } else {
+            GraphStore::get_edge(self.overlay.as_ref(), id)
+        }
+    }
+
+    fn get_node_versioned(
+        &self,
+        id: NodeId,
+        epoch: EpochId,
+        transaction_id: TransactionId,
+    ) -> Option<Node> {
+        if self.is_node_deleted(id) {
+            return None;
+        }
+        if self.is_compact_node_id(id) {
+            // Compact data is always committed/visible
+            self.compact_node_merged(id)
+        } else {
+            GraphStore::get_node_versioned(self.overlay.as_ref(), id, epoch, transaction_id)
+        }
+    }
+
+    fn get_edge_versioned(
+        &self,
+        id: EdgeId,
+        epoch: EpochId,
+        transaction_id: TransactionId,
+    ) -> Option<Edge> {
+        if self.is_edge_deleted(id) {
+            return None;
+        }
+        if self.is_compact_edge_id(id) {
+            self.compact_edge_merged(id)
+        } else {
+            GraphStore::get_edge_versioned(self.overlay.as_ref(), id, epoch, transaction_id)
+        }
+    }
+
+    fn get_node_at_epoch(&self, id: NodeId, epoch: EpochId) -> Option<Node> {
+        if self.is_node_deleted(id) {
+            return None;
+        }
+        if self.is_compact_node_id(id) {
+            self.compact_node_merged(id)
+        } else {
+            GraphStore::get_node_at_epoch(self.overlay.as_ref(), id, epoch)
+        }
+    }
+
+    fn get_edge_at_epoch(&self, id: EdgeId, epoch: EpochId) -> Option<Edge> {
+        if self.is_edge_deleted(id) {
+            return None;
+        }
+        if self.is_compact_edge_id(id) {
+            self.compact_edge_merged(id)
+        } else {
+            GraphStore::get_edge_at_epoch(self.overlay.as_ref(), id, epoch)
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Property access (fast path)
+    // ---------------------------------------------------------------
+
+    fn get_node_property(&self, id: NodeId, key: &PropertyKey) -> Option<Value> {
+        if self.is_node_deleted(id) {
+            return None;
+        }
+        if self.is_compact_node_id(id) {
+            if self.is_node_dirty(id) {
+                // Overlay might have an override or tombstone
+                if let Some(v) = self.overlay.get_node_property(id, key) {
+                    return if v == Value::Null { None } else { Some(v) };
+                }
+            }
+            self.compact.read().get_node_property(id, key)
+        } else {
+            self.overlay.get_node_property(id, key)
+        }
+    }
+
+    fn get_edge_property(&self, id: EdgeId, key: &PropertyKey) -> Option<Value> {
+        if self.is_edge_deleted(id) {
+            return None;
+        }
+        if self.is_compact_edge_id(id) {
+            if self.is_edge_dirty(id)
+                && let Some(v) = self.overlay.get_edge_property(id, key)
+            {
+                return if v == Value::Null { None } else { Some(v) };
+            }
+            self.compact.read().get_edge_property(id, key)
+        } else {
+            self.overlay.get_edge_property(id, key)
+        }
+    }
+
+    fn get_node_property_batch(&self, ids: &[NodeId], key: &PropertyKey) -> Vec<Option<Value>> {
+        ids.iter()
+            .map(|&id| self.get_node_property(id, key))
+            .collect()
+    }
+
+    fn get_nodes_properties_batch(&self, ids: &[NodeId]) -> Vec<FxHashMap<PropertyKey, Value>> {
+        ids.iter()
+            .map(|&id| {
+                if self.is_node_deleted(id) {
+                    return FxHashMap::default();
+                }
+                if self.is_compact_node_id(id) {
+                    let compact = self.compact.read();
+                    let mut props: FxHashMap<PropertyKey, Value> = compact
+                        .get_node(id)
+                        .map(|n| n.properties.into_iter().collect())
+                        .unwrap_or_default();
+                    drop(compact);
+                    // Merge overlay overrides; Null tombstones mean removal.
+                    for (k, v) in self.overlay.get_node_properties_all(id) {
+                        if v == Value::Null {
+                            props.remove(&k);
+                        } else {
+                            props.insert(k, v);
+                        }
+                    }
+                    props
+                } else {
+                    GraphStore::get_node(self.overlay.as_ref(), id)
+                        .map(|n| n.properties.into_iter().collect())
+                        .unwrap_or_default()
+                }
+            })
+            .collect()
+    }
+
+    fn get_nodes_properties_selective_batch(
+        &self,
+        ids: &[NodeId],
+        keys: &[PropertyKey],
+    ) -> Vec<FxHashMap<PropertyKey, Value>> {
+        ids.iter()
+            .map(|&id| {
+                let mut map = FxHashMap::default();
+                for key in keys {
+                    if let Some(v) = self.get_node_property(id, key) {
+                        map.insert(key.clone(), v);
+                    }
+                }
+                map
+            })
+            .collect()
+    }
+
+    fn get_edges_properties_selective_batch(
+        &self,
+        ids: &[EdgeId],
+        keys: &[PropertyKey],
+    ) -> Vec<FxHashMap<PropertyKey, Value>> {
+        ids.iter()
+            .map(|&id| {
+                let mut map = FxHashMap::default();
+                for key in keys {
+                    if let Some(v) = self.get_edge_property(id, key) {
+                        map.insert(key.clone(), v);
+                    }
+                }
+                map
+            })
+            .collect()
+    }
+
+    // ---------------------------------------------------------------
+    // Traversal
+    // ---------------------------------------------------------------
+
+    fn neighbors(&self, node: NodeId, direction: Direction) -> Vec<NodeId> {
+        let deleted_nodes = self.deleted_nodes.read();
+
+        let mut result = Vec::new();
+
+        // Compact edges (use edges_from so we can filter deleted edges too)
+        if self.is_compact_node_id(node) {
+            let deleted_edges = self.deleted_edges.read();
+            let compact = self.compact.read();
+            for (target, eid) in compact.edges_from(node, direction) {
+                if !deleted_edges.contains(&eid) && !deleted_nodes.contains(&target) {
+                    result.push(target);
+                }
+            }
+        }
+
+        // Overlay edges: overlay handles its own MVCC; just exclude deleted
+        // compact nodes that might appear as targets.
+        for nid in GraphStore::neighbors(self.overlay.as_ref(), node, direction) {
+            if !deleted_nodes.contains(&nid) {
+                result.push(nid);
+            }
+        }
+
+        // Deduplicate (compact and overlay may produce the same neighbor)
+        result.sort_unstable();
+        result.dedup();
+        result
+    }
+
+    fn edges_from(&self, node: NodeId, direction: Direction) -> Vec<(NodeId, EdgeId)> {
+        let deleted_nodes = self.deleted_nodes.read();
+        let deleted_edges = self.deleted_edges.read();
+
+        let mut result = Vec::new();
+
+        // Compact edges
+        if self.is_compact_node_id(node) {
+            let compact = self.compact.read();
+            for (target, eid) in compact.edges_from(node, direction) {
+                if !deleted_edges.contains(&eid) && !deleted_nodes.contains(&target) {
+                    result.push((target, eid));
+                }
+            }
+        }
+
+        // Overlay edges
+        for (target, eid) in GraphStore::edges_from(self.overlay.as_ref(), node, direction) {
+            if !deleted_edges.contains(&eid) && !deleted_nodes.contains(&target) {
+                result.push((target, eid));
+            }
+        }
+
+        result
+    }
+
+    fn out_degree(&self, node: NodeId) -> usize {
+        // Count edges, filtering deleted
+        self.edges_from(node, Direction::Outgoing).len()
+    }
+
+    fn in_degree(&self, node: NodeId) -> usize {
+        self.edges_from(node, Direction::Incoming).len()
+    }
+
+    fn has_backward_adjacency(&self) -> bool {
+        let compact = self.compact.read();
+        compact.has_backward_adjacency() || self.overlay.has_backward_adjacency()
+    }
+
+    // ---------------------------------------------------------------
+    // Scans
+    // ---------------------------------------------------------------
+
+    fn node_ids(&self) -> Vec<NodeId> {
+        let deleted = self.deleted_nodes.read();
+        let mut ids = Vec::new();
+
+        // Compact node IDs
+        {
+            let compact = self.compact.read();
+            for id in compact.node_ids() {
+                if !deleted.contains(&id) {
+                    ids.push(id);
+                }
+            }
+        }
+
+        // Overlay node IDs
+        for id in GraphStore::node_ids(self.overlay.as_ref()) {
+            ids.push(id);
+        }
+
+        ids.sort_unstable();
+        ids
+    }
+
+    fn all_node_ids(&self) -> Vec<NodeId> {
+        // Same as node_ids for hybrid: compact is always committed
+        self.node_ids()
+    }
+
+    fn nodes_by_label(&self, label: &str) -> Vec<NodeId> {
+        let deleted = self.deleted_nodes.read();
+        let mut ids = Vec::new();
+
+        // Compact
+        {
+            let compact = self.compact.read();
+            for id in compact.nodes_by_label(label) {
+                if !deleted.contains(&id) {
+                    ids.push(id);
+                }
+            }
+        }
+
+        // Overlay
+        for id in GraphStore::nodes_by_label(self.overlay.as_ref(), label) {
+            ids.push(id);
+        }
+
+        ids.sort_unstable();
+        ids
+    }
+
+    fn node_count(&self) -> usize {
+        let deleted_count = self.deleted_nodes.read().len();
+        let overlay_count = GraphStore::node_count(self.overlay.as_ref());
+        self.compact_node_count.load(std::sync::atomic::Ordering::Relaxed) - deleted_count + overlay_count
+    }
+
+    fn edge_count(&self) -> usize {
+        let deleted_count = self.deleted_edges.read().len();
+        let overlay_count = GraphStore::edge_count(self.overlay.as_ref());
+        self.compact_edge_count.load(std::sync::atomic::Ordering::Relaxed) - deleted_count + overlay_count
+    }
+
+    // ---------------------------------------------------------------
+    // Entity metadata
+    // ---------------------------------------------------------------
+
+    fn edge_type(&self, id: EdgeId) -> Option<ArcStr> {
+        if self.is_edge_deleted(id) {
+            return None;
+        }
+        if self.is_compact_edge_id(id) {
+            let compact = self.compact.read();
+            compact.edge_type(id)
+        } else {
+            GraphStore::edge_type(self.overlay.as_ref(), id)
+        }
+    }
+
+    fn edge_type_versioned(
+        &self,
+        id: EdgeId,
+        epoch: EpochId,
+        transaction_id: TransactionId,
+    ) -> Option<ArcStr> {
+        if self.is_edge_deleted(id) {
+            return None;
+        }
+        if self.is_compact_edge_id(id) {
+            let compact = self.compact.read();
+            compact.edge_type(id)
+        } else {
+            GraphStore::edge_type_versioned(self.overlay.as_ref(), id, epoch, transaction_id)
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Index introspection
+    // ---------------------------------------------------------------
+
+    fn has_property_index(&self, property: &str) -> bool {
+        self.overlay.has_property_index(property)
+    }
+
+    // ---------------------------------------------------------------
+    // Filtered search
+    // ---------------------------------------------------------------
+
+    fn find_nodes_by_property(&self, property: &str, value: &Value) -> Vec<NodeId> {
+        let key = PropertyKey::new(property);
+        let deleted = self.deleted_nodes.read();
+        let dirty = self.dirty_nodes.read(); // held for entire scan — consistent snapshot
+        let overlay = &self.overlay;
+        let column_dirty = dirty.is_column_dirty(&key);
+        let mut results = Vec::new();
+
+        // Compact scan
+        {
+            let compact = self.compact.read();
+            for id in compact.find_nodes_by_property(property, value) {
+                if !deleted.contains(&id) {
+                    if column_dirty && DirtySet::id_is_dirty_node(&dirty, id) {
+                        if let Some(override_val) = overlay.get_node_property(id, &key) {
+                            if &override_val == value {
+                                results.push(id);
+                            }
+                        } else {
+                            results.push(id);
+                        }
+                    } else {
+                        results.push(id);
+                    }
+                }
+            }
+        }
+
+        // Compact nodes with overlay overrides matching the NEW value
+        // (only needed if this column has any overlay modifications)
+        if column_dirty {
+            let mut seen = FxHashSet::default();
+            for id in &results {
+                seen.insert(*id);
+            }
+            let target = value.clone();
+            for id in overlay.node_ids_with_property_matching(&key, |v| v == &target) {
+                if self.is_compact_node_id(id) && !deleted.contains(&id) && !seen.contains(&id) {
+                    results.push(id);
+                }
+            }
+        }
+
+        // Overlay nodes (created in overlay, not compact)
+        for id in GraphStore::find_nodes_by_property(overlay.as_ref(), property, value) {
+            results.push(id);
+        }
+
+        results
+    }
+
+    fn find_nodes_by_properties(&self, conditions: &[(&str, Value)]) -> Vec<NodeId> {
+        if conditions.is_empty() {
+            return self.node_ids();
+        }
+
+        let deleted = self.deleted_nodes.read();
+        let dirty = self.dirty_nodes.read();
+        let overlay = &self.overlay;
+        let any_column_dirty = conditions
+            .iter()
+            .any(|(prop, _)| dirty.is_column_dirty(&PropertyKey::new(*prop)));
+        let mut results = Vec::new();
+        let mut seen = FxHashSet::default();
+
+        // Compact — post-filter only dirty entities against overlay overrides
+        {
+            let compact = self.compact.read();
+            for id in compact.find_nodes_by_properties(conditions) {
+                if !deleted.contains(&id) {
+                    if any_column_dirty && DirtySet::id_is_dirty_node(&dirty, id) {
+                        let mut still_matches = true;
+                        for (prop, val) in conditions {
+                            let key = PropertyKey::new(*prop);
+                            if let Some(override_val) = overlay.get_node_property(id, &key)
+                                && &override_val != val
+                            {
+                                still_matches = false;
+                                break;
+                            }
+                        }
+                        if still_matches {
+                            results.push(id);
+                            seen.insert(id);
+                        }
+                    } else {
+                        results.push(id);
+                        seen.insert(id);
+                    }
+                }
+            }
+        }
+
+        // Compact nodes with overlay overrides (only if any condition column is dirty)
+        if any_column_dirty
+            && let Some((first_prop, first_val)) = conditions.first()
+        {
+                let first_key = PropertyKey::new(*first_prop);
+                let target = first_val.clone();
+                for id in overlay.node_ids_with_property_matching(&first_key, |v| v == &target) {
+                    if self.is_compact_node_id(id) && !deleted.contains(&id) && !seen.contains(&id)
+                    {
+                        let mut all_match = true;
+                        for (prop, val) in &conditions[1..] {
+                            let key = PropertyKey::new(*prop);
+                            let effective = overlay
+                                .get_node_property(id, &key)
+                                .or_else(|| self.compact.read().get_node_property(id, &key));
+                            if effective.as_ref() != Some(val) {
+                                all_match = false;
+                                break;
+                            }
+                        }
+                        if all_match {
+                            results.push(id);
+                        }
+                    }
+                }
+        }
+        // Overlay nodes
+        for id in GraphStore::find_nodes_by_properties(overlay.as_ref(), conditions) {
+            results.push(id);
+        }
+
+        results
+    }
+
+    fn find_nodes_in_range(
+        &self,
+        property: &str,
+        min: Option<&Value>,
+        max: Option<&Value>,
+        min_inclusive: bool,
+        max_inclusive: bool,
+    ) -> Vec<NodeId> {
+        let key = PropertyKey::new(property);
+        let deleted = self.deleted_nodes.read();
+        let dirty = self.dirty_nodes.read();
+        let overlay = &self.overlay;
+        let column_dirty = dirty.is_column_dirty(&key);
+        let mut results = Vec::new();
+
+        // Compact scan — only check overlay for dirty entities in dirty columns
+        {
+            let compact = self.compact.read();
+            for id in compact.find_nodes_in_range(property, min, max, min_inclusive, max_inclusive) {
+                if !deleted.contains(&id) {
+                    if column_dirty && DirtySet::id_is_dirty_node(&dirty, id) {
+                        if let Some(override_val) = overlay.get_node_property(id, &key) {
+                            if crate::graph::lpg::value_in_range(
+                                &override_val,
+                                min,
+                                max,
+                                min_inclusive,
+                                max_inclusive,
+                            ) {
+                                results.push(id);
+                            }
+                        } else {
+                            results.push(id);
+                        }
+                    } else {
+                        results.push(id);
+                    }
+                }
+            }
+        }
+
+        // Compact nodes with overlay overrides in the NEW range
+        if column_dirty {
+            let mut seen = FxHashSet::default();
+            for id in &results {
+                seen.insert(*id);
+            }
+            let min_c = min.cloned();
+            let max_c = max.cloned();
+            for id in overlay.node_ids_with_property_matching(&key, |v| {
+                crate::graph::lpg::value_in_range(
+                    v,
+                    min_c.as_ref(),
+                    max_c.as_ref(),
+                    min_inclusive,
+                    max_inclusive,
+                )
+            }) {
+                if self.is_compact_node_id(id) && !deleted.contains(&id) && !seen.contains(&id) {
+                    results.push(id);
+                }
+            }
+        }
+
+        // Overlay nodes
+        for id in GraphStore::find_nodes_in_range(
+            overlay.as_ref(),
+            property,
+            min,
+            max,
+            min_inclusive,
+            max_inclusive,
+        ) {
+            results.push(id);
+        }
+
+        results
+    }
+
+    // ---------------------------------------------------------------
+    // Zone maps (skip pruning)
+    // ---------------------------------------------------------------
+
+    fn node_property_might_match(
+        &self,
+        property: &PropertyKey,
+        op: CompareOp,
+        value: &Value,
+    ) -> bool {
+        let compact = self.compact.read();
+        compact.node_property_might_match(property, op, value)
+            || GraphStore::node_property_might_match(self.overlay.as_ref(), property, op, value)
+    }
+
+    fn edge_property_might_match(
+        &self,
+        property: &PropertyKey,
+        op: CompareOp,
+        value: &Value,
+    ) -> bool {
+        let compact = self.compact.read();
+        compact.edge_property_might_match(property, op, value)
+            || GraphStore::edge_property_might_match(self.overlay.as_ref(), property, op, value)
+    }
+
+    // ---------------------------------------------------------------
+    // Statistics
+    // ---------------------------------------------------------------
+
+    fn statistics(&self) -> Arc<Statistics> {
+        // Return overlay stats for now; merged stats is a follow-up.
+        GraphStore::statistics(self.overlay.as_ref())
+    }
+
+    fn estimate_label_cardinality(&self, label: &str) -> f64 {
+        let compact = self.compact.read();
+        let compact_card = compact.estimate_label_cardinality(label);
+        let overlay_card =
+            GraphStore::estimate_label_cardinality(self.overlay.as_ref(), label);
+        compact_card + overlay_card
+    }
+
+    fn estimate_avg_degree(&self, edge_type: &str, outgoing: bool) -> f64 {
+        let compact = self.compact.read();
+        let compact_deg = compact.estimate_avg_degree(edge_type, outgoing);
+        let overlay_deg =
+            GraphStore::estimate_avg_degree(self.overlay.as_ref(), edge_type, outgoing);
+        // Weighted average would be more accurate, but simple max is a
+        // reasonable conservative estimate for the CBO.
+        compact_deg.max(overlay_deg)
+    }
+
+    // ---------------------------------------------------------------
+    // Epoch
+    // ---------------------------------------------------------------
+
+    fn current_epoch(&self) -> EpochId {
+        self.overlay.current_epoch()
+    }
+
+    // ---------------------------------------------------------------
+    // Schema introspection
+    // ---------------------------------------------------------------
+
+    fn all_labels(&self) -> Vec<String> {
+        let mut labels: Vec<String> = {
+            let compact = self.compact.read();
+            compact.all_labels()
+        };
+        for l in GraphStore::all_labels(self.overlay.as_ref()) {
+            if !labels.contains(&l) {
+                labels.push(l);
+            }
+        }
+        labels
+    }
+
+    fn all_edge_types(&self) -> Vec<String> {
+        let mut types: Vec<String> = {
+            let compact = self.compact.read();
+            compact.all_edge_types()
+        };
+        for t in GraphStore::all_edge_types(self.overlay.as_ref()) {
+            if !types.contains(&t) {
+                types.push(t);
+            }
+        }
+        types
+    }
+
+    fn all_property_keys(&self) -> Vec<String> {
+        let mut keys: Vec<String> = {
+            let compact = self.compact.read();
+            compact.all_property_keys()
+        };
+        for k in GraphStore::all_property_keys(self.overlay.as_ref()) {
+            if !keys.contains(&k) {
+                keys.push(k);
+            }
+        }
+        keys
+    }
+
+    // ---------------------------------------------------------------
+    // Visibility checks
+    // ---------------------------------------------------------------
+
+    fn is_node_visible_at_epoch(&self, id: NodeId, epoch: EpochId) -> bool {
+        if self.is_node_deleted(id) {
+            return false;
+        }
+        if self.is_compact_node_id(id) {
+            // Compact nodes are always visible (committed data)
+            let compact = self.compact.read();
+            compact.get_node(id).is_some()
+        } else {
+            GraphStore::is_node_visible_at_epoch(self.overlay.as_ref(), id, epoch)
+        }
+    }
+
+    fn is_node_visible_versioned(
+        &self,
+        id: NodeId,
+        epoch: EpochId,
+        transaction_id: TransactionId,
+    ) -> bool {
+        if self.is_node_deleted(id) {
+            return false;
+        }
+        if self.is_compact_node_id(id) {
+            let compact = self.compact.read();
+            compact.get_node(id).is_some()
+        } else {
+            GraphStore::is_node_visible_versioned(
+                self.overlay.as_ref(),
+                id,
+                epoch,
+                transaction_id,
+            )
+        }
+    }
+
+    fn is_edge_visible_at_epoch(&self, id: EdgeId, epoch: EpochId) -> bool {
+        if self.is_edge_deleted(id) {
+            return false;
+        }
+        if self.is_compact_edge_id(id) {
+            let compact = self.compact.read();
+            compact.get_edge(id).is_some()
+        } else {
+            GraphStore::is_edge_visible_at_epoch(self.overlay.as_ref(), id, epoch)
+        }
+    }
+
+    fn is_edge_visible_versioned(
+        &self,
+        id: EdgeId,
+        epoch: EpochId,
+        transaction_id: TransactionId,
+    ) -> bool {
+        if self.is_edge_deleted(id) {
+            return false;
+        }
+        if self.is_compact_edge_id(id) {
+            let compact = self.compact.read();
+            compact.get_edge(id).is_some()
+        } else {
+            GraphStore::is_edge_visible_versioned(
+                self.overlay.as_ref(),
+                id,
+                epoch,
+                transaction_id,
+            )
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // History
+    // ---------------------------------------------------------------
+
+    fn get_node_history(&self, id: NodeId) -> Vec<(EpochId, Option<EpochId>, Node)> {
+        if self.is_compact_node_id(id) {
+            // Compact store has no version history
+            Vec::new()
+        } else {
+            GraphStore::get_node_history(self.overlay.as_ref(), id)
+        }
+    }
+
+    fn get_edge_history(&self, id: EdgeId) -> Vec<(EpochId, Option<EpochId>, Edge)> {
+        if self.is_compact_edge_id(id) {
+            Vec::new()
+        } else {
+            GraphStore::get_edge_history(self.overlay.as_ref(), id)
+        }
+    }
+}

--- a/crates/grafeo-core/src/graph/hybrid/tests.rs
+++ b/crates/grafeo-core/src/graph/hybrid/tests.rs
@@ -1,0 +1,596 @@
+use super::*;
+use crate::graph::compact::CompactStoreBuilder;
+use crate::graph::compact::id::encode_node_id;
+use crate::graph::Direction;
+use grafeo_common::types::NodeId;
+
+/// Shared fixture: 100 Students, 50 Courses, 150 edges
+fn test_compact() -> crate::graph::compact::CompactStore {
+    let grades: Vec<u64> = (0..100).collect();
+    let names: Vec<&str> = (0..100).map(|i| if i % 2 == 0 { "Alice" } else { "Bob" }).collect();
+    let active: Vec<bool> = (0..100).map(|i| i % 3 != 0).collect();
+
+    let levels: Vec<u64> = (0..50).map(|i| (i % 5) as u64).collect();
+    let depts: Vec<&str> = (0..50).map(|i| if i % 2 == 0 { "CS" } else { "Math" }).collect();
+
+    let mut edges: Vec<(u32, u32)> = Vec::new();
+    for i in 0..100u32 {
+        for k in 0..3u32 {
+            let course_offset = ((i + k) % 50) as u32;
+            if !edges.contains(&(i, course_offset)) {
+                edges.push((i, course_offset));
+            }
+        }
+    }
+    edges.truncate(150);
+
+    CompactStoreBuilder::new()
+        .node_table("Student", |b| {
+            b.column_bitpacked("grade", &grades, 8)
+            .column_dict("name", &names)
+            .column_bitmap("active", &active)
+        })
+        .node_table("Course", |b| {
+            b.column_bitpacked("level", &levels, 4)
+            .column_dict("dept", &depts)
+        })
+        .rel_table("ENROLLED_IN", "Student", "Course", |b| {
+                b.edges(edges).backward(true)
+            })
+        .build()
+        .unwrap()
+}
+
+fn test_hybrid() -> HybridStore {
+    HybridStore::open(test_compact()).unwrap()
+}
+
+fn student_id(i: usize) -> NodeId {
+    encode_node_id(0, i as u64)
+}
+
+fn course_id(i: usize) -> NodeId {
+    encode_node_id(1, i as u64)
+}
+
+#[test]
+fn open_creates_hybrid_with_correct_offset() {
+    let h = test_hybrid();
+    let offset = h.id_offset();
+    let expected = encode_node_id(1, 49).as_u64() + 1;
+    assert_eq!(offset, expected);
+}
+
+#[test]
+fn overlay_is_empty_after_open() {
+    let h = test_hybrid();
+    assert_eq!(h.overlay().node_count(), 0);
+    assert_eq!(h.overlay().edge_count(), 0);
+}
+
+#[test]
+fn is_compact_node_id_correct() {
+    let h = test_hybrid();
+    assert!(h.is_compact_node_id(student_id(0)));
+    assert!(h.is_compact_node_id(student_id(99)));
+    assert!(h.is_compact_node_id(course_id(0)));
+    assert!(h.is_compact_node_id(course_id(49)));
+    assert!(!h.is_compact_node_id(NodeId::new(h.id_offset())));
+    assert!(!h.is_compact_node_id(NodeId::new(h.id_offset() + 100)));
+}
+
+// ---------------------------------------------------------------
+// Task 3: GraphStore point reads
+// ---------------------------------------------------------------
+
+use crate::graph::GraphStore;
+use crate::graph::GraphStoreMut;
+use grafeo_common::types::{PropertyKey, TransactionId, Value};
+
+#[test]
+fn read_compact_node() {
+    let h = test_hybrid();
+    let node = h.get_node(student_id(0)).unwrap();
+    assert!(node.labels.iter().any(|l| l.as_str() == "Student"));
+    assert_eq!(
+        node.properties.get(&PropertyKey::new("grade")),
+        Some(&Value::Int64(0))
+    );
+}
+
+#[test]
+fn read_compact_node_property() {
+    let h = test_hybrid();
+    let val = h.get_node_property(student_id(5), &PropertyKey::new("grade"));
+    assert_eq!(val, Some(Value::Int64(5)));
+}
+
+#[test]
+fn read_nonexistent_node() {
+    let h = test_hybrid();
+    assert!(h.get_node(NodeId::new(999_999_999)).is_none());
+}
+
+#[test]
+fn read_compact_node_with_property_override() {
+    let h = test_hybrid();
+    h.set_node_property(student_id(0), "grade", Value::Int64(999));
+    let node = h.get_node(student_id(0)).unwrap();
+    assert_eq!(
+        node.properties.get(&PropertyKey::new("grade")),
+        Some(&Value::Int64(999))
+    );
+    // Original compact property "name" should still be present
+    assert!(node.properties.contains_key(&PropertyKey::new("name")));
+}
+
+#[test]
+fn read_overlay_node() {
+    let h = test_hybrid();
+    let nid = h.overlay().create_node(&["Person"]);
+    h.overlay()
+        .set_node_property(nid, "age", Value::Int64(30));
+    let node = h.get_node(nid).unwrap();
+    assert!(node.labels.iter().any(|l| l.as_str() == "Person"));
+    assert_eq!(
+        node.properties.get(&PropertyKey::new("age")),
+        Some(&Value::Int64(30))
+    );
+}
+
+#[test]
+fn node_count_is_compact_plus_overlay() {
+    let h = test_hybrid();
+    assert_eq!(h.node_count(), 150); // 100 students + 50 courses
+    h.overlay().create_node(&["Person"]);
+    assert_eq!(h.node_count(), 151);
+}
+
+#[test]
+fn node_ids_merges_both_stores() {
+    let h = test_hybrid();
+    let nid = h.overlay().create_node(&["Extra"]);
+    let ids = h.node_ids();
+    assert!(ids.contains(&student_id(0)));
+    assert!(ids.contains(&course_id(49)));
+    assert!(ids.contains(&nid));
+    assert_eq!(ids.len(), 151);
+}
+
+#[test]
+fn nodes_by_label_merges() {
+    let h = test_hybrid();
+    h.overlay().create_node(&["Student"]);
+    let students = h.nodes_by_label("Student");
+    // 100 compact Students + 1 overlay Student
+    assert_eq!(students.len(), 101);
+}
+
+#[test]
+fn get_node_property_prefers_overlay() {
+    let h = test_hybrid();
+    // Set an overlay override (must go through HybridStore to mark dirty)
+    h.set_node_property(student_id(3), "grade", Value::Int64(42));
+    let val = h.get_node_property(student_id(3), &PropertyKey::new("grade"));
+    assert_eq!(val, Some(Value::Int64(42)));
+    // Property without override should still come from compact
+    let name = h.get_node_property(student_id(3), &PropertyKey::new("name"));
+    assert!(name.is_some());
+}
+
+// ---------------------------------------------------------------
+// Task 4: GraphStoreMut — write delegation
+// ---------------------------------------------------------------
+
+#[test]
+fn create_node_in_overlay() {
+    let h = test_hybrid();
+    let nid = h.create_node(&["Person"]);
+    assert!(!h.is_compact_node_id(nid));
+    assert!(h.get_node(nid).is_some());
+}
+
+#[test]
+fn create_edge_between_compact_nodes() {
+    let h = test_hybrid();
+    let eid = h.create_edge(student_id(0), course_id(0), "LIKES");
+    assert!(h.get_edge(eid).is_some());
+}
+
+#[test]
+fn set_property_on_compact_node() {
+    let h = test_hybrid();
+    h.set_node_property(student_id(5), "grade", Value::Int64(999));
+    assert_eq!(
+        h.get_node_property(student_id(5), &PropertyKey::new("grade")),
+        Some(Value::Int64(999))
+    );
+}
+
+#[test]
+fn delete_compact_node() {
+    let h = test_hybrid();
+    assert!(h.get_node(student_id(0)).is_some());
+    let deleted = h.delete_node(student_id(0));
+    assert!(deleted);
+    assert!(h.get_node(student_id(0)).is_none());
+}
+
+#[test]
+fn delete_compact_edge() {
+    let h = test_hybrid();
+    let edges = h.edges_from(student_id(0), crate::graph::Direction::Outgoing);
+    assert!(!edges.is_empty());
+    let (_, eid) = edges[0];
+    assert!(h.delete_edge(eid));
+    assert!(h.get_edge(eid).is_none());
+}
+
+// ---------------------------------------------------------------
+// Task 5: Rollback/Commit hooks
+// ---------------------------------------------------------------
+
+#[test]
+fn rollback_compact_node_deletion_restores_node() {
+    let h = test_hybrid();
+    let tx = TransactionId::new(100);
+    let epoch = h.overlay().current_epoch();
+
+    // Delete compact node within a transaction
+    assert!(h.delete_node_versioned(student_id(0), epoch, tx));
+    assert!(h.get_node(student_id(0)).is_none());
+
+    // Rollback: overlay handles version chain, we handle deletion set
+    h.on_rollback(tx);
+    h.overlay().rollback_transaction_properties(tx);
+    h.overlay().discard_uncommitted_versions(tx);
+
+    // Node should be visible again
+    assert!(h.get_node(student_id(0)).is_some());
+}
+
+#[test]
+fn commit_compact_deletion_clears_pending() {
+    let h = test_hybrid();
+    let tx = TransactionId::new(100);
+    let epoch = h.overlay().current_epoch();
+
+    h.delete_node_versioned(student_id(0), epoch, tx);
+    h.on_commit(tx);
+
+    // Node stays deleted
+    assert!(h.get_node(student_id(0)).is_none());
+    // But pending_deletions for this tx should be cleared
+    assert!(h.pending_deletions.read().get(&tx).is_none());
+}
+
+// ---------------------------------------------------------------
+// Task 6: Compaction
+// ---------------------------------------------------------------
+
+#[test]
+fn compact_merges_overlay_into_compact() {
+    let h = test_hybrid();
+    // Add overlay entity
+    let nid = h.create_node(&["Person"]);
+    h.set_node_property(nid, "age", Value::Int64(30));
+    // Override compact entity property
+    h.set_node_property(student_id(0), "grade", Value::Int64(999));
+
+    let count_before = h.node_count();
+    h.compact().unwrap();
+
+    // Count should be preserved
+    assert_eq!(h.node_count(), count_before);
+    // Overlay should be empty
+    assert_eq!(h.overlay().node_count(), 0);
+    // Deleted set should be clear
+    assert!(h.deleted_nodes.read().is_empty());
+    // New entity should now be in compact
+    assert!(!h.compact.read().nodes_by_label("Person").is_empty());
+}
+
+#[test]
+fn compact_preserves_query_results() {
+    let h = test_hybrid();
+    let nid = h.create_node(&["Person"]);
+    h.set_node_property(nid, "name", Value::String(arcstr::literal!("Alix")));
+    h.create_edge(nid, student_id(0), "KNOWS");
+
+    let nodes_before = h.node_count();
+    let edges_before = h.edge_count();
+    let labels_before = h.all_labels();
+
+    h.compact().unwrap();
+
+    assert_eq!(h.node_count(), nodes_before);
+    assert_eq!(h.edge_count(), edges_before);
+    assert_eq!(h.all_labels(), labels_before);
+}
+
+#[test]
+fn double_compact() {
+    let h = test_hybrid();
+    h.create_node(&["A"]);
+    h.compact().unwrap();
+    h.create_node(&["B"]);
+    h.compact().unwrap();
+    // Both A and B should be in compact
+    assert!(!h.compact.read().nodes_by_label("A").is_empty());
+    assert!(!h.compact.read().nodes_by_label("B").is_empty());
+    assert_eq!(h.overlay().node_count(), 0);
+}
+
+// ---------------------------------------------------------------
+// Tier 2: Edge cases, deletions, labels, traversal, serialization
+// ---------------------------------------------------------------
+
+// 1. Edge property override on compact edge
+#[test]
+fn edge_property_override_compact_edge() {
+    let h = test_hybrid();
+    let edges = h.edges_from(student_id(0), Direction::Outgoing);
+    let (_, eid) = edges[0];
+    h.set_edge_property(eid, "weight", Value::Float64(0.5));
+    assert_eq!(
+        h.get_edge_property(eid, &PropertyKey::new("weight")),
+        Some(Value::Float64(0.5))
+    );
+}
+
+// 2. Overlay-to-overlay edges
+#[test]
+fn overlay_to_overlay_edge() {
+    let h = test_hybrid();
+    let a = h.create_node(&["X"]);
+    let b = h.create_node(&["Y"]);
+    let eid = h.create_edge(a, b, "LINKS");
+    assert!(h.get_edge(eid).is_some());
+    let neighbors = h.neighbors(a, Direction::Outgoing);
+    assert!(neighbors.contains(&b));
+}
+
+// 3. Cross-store edges (overlay-to-compact)
+#[test]
+fn cross_store_edge() {
+    let h = test_hybrid();
+    let overlay_node = h.create_node(&["NewPerson"]);
+    let eid = h.create_edge(overlay_node, student_id(0), "MENTORS");
+    assert!(h.get_edge(eid).is_some());
+    let neighbors = h.neighbors(overlay_node, Direction::Outgoing);
+    assert!(neighbors.contains(&student_id(0)));
+}
+
+// 4. Delete then re-check counts
+#[test]
+fn delete_compact_node_decrements_count() {
+    let h = test_hybrid();
+    let before = h.node_count();
+    h.delete_node(student_id(0));
+    assert_eq!(h.node_count(), before - 1);
+}
+
+// 5. Double deletion returns false
+#[test]
+fn double_delete_returns_false() {
+    let h = test_hybrid();
+    assert!(h.delete_node(student_id(0)));
+    assert!(!h.delete_node(student_id(0)));
+}
+
+// 6. Deleted node not in node_ids
+#[test]
+fn deleted_node_excluded_from_node_ids() {
+    let h = test_hybrid();
+    h.delete_node(student_id(0));
+    let ids = h.node_ids();
+    assert!(!ids.contains(&student_id(0)));
+}
+
+// 7. Deleted node not in nodes_by_label
+#[test]
+fn deleted_node_excluded_from_nodes_by_label() {
+    let h = test_hybrid();
+    h.delete_node(student_id(0));
+    let students = h.nodes_by_label("Student");
+    assert!(!students.contains(&student_id(0)));
+}
+
+// 8. Label mutation on compact node — verify via nodes_by_label index
+// (compact_node_merged returns only compact labels; label mutations are
+// reflected in the overlay's label index which nodes_by_label queries)
+#[test]
+fn add_label_to_compact_node() {
+    let h = test_hybrid();
+    h.add_label(student_id(0), "VIP");
+    // New label should be queryable via label index
+    let vips = h.nodes_by_label("VIP");
+    assert!(vips.contains(&student_id(0)));
+    // Original label should still be present in label index
+    let students = h.nodes_by_label("Student");
+    assert!(students.contains(&student_id(0)));
+}
+
+// 9. All labels includes both stores
+#[test]
+fn all_labels_includes_overlay() {
+    let h = test_hybrid();
+    h.create_node(&["NewLabel"]);
+    let labels = h.all_labels();
+    assert!(labels.contains(&"Student".to_string()));
+    assert!(labels.contains(&"Course".to_string()));
+    assert!(labels.contains(&"NewLabel".to_string()));
+}
+
+// 10. All edge types includes both stores
+#[test]
+fn all_edge_types_includes_overlay() {
+    let h = test_hybrid();
+    let a = h.create_node(&["X"]);
+    let b = h.create_node(&["Y"]);
+    h.create_edge(a, b, "NEW_TYPE");
+    let types = h.all_edge_types();
+    assert!(types.contains(&"ENROLLED_IN".to_string()));
+    assert!(types.contains(&"NEW_TYPE".to_string()));
+}
+
+// 11. find_nodes_by_property on overlay
+#[test]
+fn find_nodes_by_property_overlay() {
+    let h = test_hybrid();
+    let nid = h.create_node(&["Person"]);
+    h.set_node_property(nid, "unique_key", Value::Int64(42));
+    let found = h.find_nodes_by_property("unique_key", &Value::Int64(42));
+    assert!(found.contains(&nid));
+}
+
+// 12. Compact traversal both directions
+#[test]
+fn compact_traversal_both_directions() {
+    let h = test_hybrid();
+    let out = h.edges_from(student_id(0), Direction::Outgoing);
+    assert!(!out.is_empty());
+    // Incoming on a Course node (backward adjacency was built)
+    let inc = h.edges_from(course_id(0), Direction::Incoming);
+    assert!(!inc.is_empty());
+}
+
+// 13. Serialization roundtrip preserves hybrid behavior
+#[test]
+fn serialization_roundtrip_hybrid() {
+    use crate::graph::compact::CompactStore;
+    let compact = test_compact();
+    let bytes = compact.to_bytes().unwrap();
+    let restored = CompactStore::from_bytes(&bytes).unwrap();
+    let h = HybridStore::open(restored).unwrap();
+    // Should work the same as fresh hybrid
+    assert!(h.get_node(student_id(0)).is_some());
+    let nid = h.create_node(&["Test"]);
+    assert!(h.get_node(nid).is_some());
+}
+
+// 14. Property override does NOT cause false positive in find_nodes_by_property
+#[test]
+fn find_nodes_by_property_no_false_positive_on_override() {
+    let h = test_hybrid();
+    // Student 5 originally has grade=5
+    assert_eq!(
+        h.get_node_property(student_id(5), &PropertyKey::new("grade")),
+        Some(Value::Int64(5))
+    );
+    // Override grade to 999
+    h.set_node_property(student_id(5), "grade", Value::Int64(999));
+    // Searching for grade=5 should NOT return student 5 anymore
+    let found = h.find_nodes_by_property("grade", &Value::Int64(5));
+    assert!(!found.contains(&student_id(5)));
+    // Point read correctly returns the overridden value
+    assert_eq!(
+        h.get_node_property(student_id(5), &PropertyKey::new("grade")),
+        Some(Value::Int64(999))
+    );
+}
+
+// 15. compact() works through &self (no &mut self required)
+#[test]
+fn remove_property_on_compact_node() {
+    let h = test_hybrid();
+    // Student 0 originally has grade=0
+    assert!(h.get_node_property(student_id(0), &PropertyKey::new("grade")).is_some());
+    h.remove_node_property(student_id(0), "grade");
+    // Should be gone now
+    assert_eq!(h.get_node_property(student_id(0), &PropertyKey::new("grade")), None);
+    // Other properties should still be visible
+    assert!(h.get_node_property(student_id(0), &PropertyKey::new("name")).is_some());
+}
+
+#[test]
+fn remove_property_on_compact_node_full_node_read() {
+    let h = test_hybrid();
+    // Verify via full node read (compact_node_merged path)
+    h.remove_node_property(student_id(1), "grade");
+    let node = h.get_node(student_id(1)).unwrap();
+    assert!(!node.properties.contains_key(&PropertyKey::new("grade")));
+    assert!(node.properties.contains_key(&PropertyKey::new("name")));
+}
+
+#[test]
+fn remove_property_on_compact_edge() {
+    let h = test_hybrid();
+    let edges = h.edges_from(student_id(0), Direction::Outgoing);
+    let (_, eid) = edges[0];
+    // First set a property so we can remove it
+    h.set_edge_property(eid, "weight", Value::Float64(1.0));
+    assert_eq!(
+        h.get_edge_property(eid, &PropertyKey::new("weight")),
+        Some(Value::Float64(1.0))
+    );
+    h.remove_edge_property(eid, "weight");
+    assert_eq!(h.get_edge_property(eid, &PropertyKey::new("weight")), None);
+}
+
+// Tombstoned properties must not appear in any scan path
+#[test]
+fn tombstone_excluded_from_find_nodes_by_property() {
+    let h = test_hybrid();
+    // Student 0 has grade=0. Remove it.
+    h.remove_node_property(student_id(0), "grade");
+    let found = h.find_nodes_by_property("grade", &Value::Int64(0));
+    assert!(!found.contains(&student_id(0)));
+}
+
+#[test]
+fn tombstone_excluded_from_find_nodes_by_properties() {
+    let h = test_hybrid();
+    // Student 0 has grade=0 and name="Alice". Remove grade.
+    h.remove_node_property(student_id(0), "grade");
+    // Multi-condition: grade=0 AND name="Alice" should NOT find student 0
+    let found = h.find_nodes_by_properties(&[
+        ("grade", Value::Int64(0)),
+        ("name", Value::String(arcstr::literal!("Alice"))),
+    ]);
+    assert!(!found.contains(&student_id(0)));
+    // name="Alice" alone should still find student 0
+    let found = h.find_nodes_by_property("name", &Value::String(arcstr::literal!("Alice")));
+    assert!(found.contains(&student_id(0)));
+}
+
+#[test]
+fn tombstone_excluded_from_find_nodes_in_range() {
+    let h = test_hybrid();
+    // Student 5 has grade=5. Remove it.
+    h.remove_node_property(student_id(5), "grade");
+    let found = h.find_nodes_in_range(
+        "grade",
+        Some(&Value::Int64(4)),
+        Some(&Value::Int64(6)),
+        true,
+        true,
+    );
+    assert!(!found.contains(&student_id(5)));
+}
+
+#[test]
+fn compact_works_through_shared_ref() {
+    let h = std::sync::Arc::new(test_hybrid());
+    h.create_node(&["Shared"]);
+    h.compact().unwrap();
+    assert_eq!(h.overlay().node_count(), 0);
+    assert!(!h.compact.read().nodes_by_label("Shared").is_empty());
+}
+
+#[test]
+fn incremental_compact_skips_unchanged_tables() {
+    let h = test_hybrid();
+    // Modify only one property on one student — table "Course" should be cloned
+    h.set_node_property(student_id(0), "grade", Value::Int64(999));
+    h.compact().unwrap();
+    // Verify data is correct after incremental compaction
+    assert_eq!(h.node_count(), 150); // 100 students + 50 courses
+    // The modified property should be in the rebuilt compact
+    assert_eq!(
+        h.get_node_property(student_id(0), &PropertyKey::new("grade")),
+        Some(Value::Int64(999))
+    );
+    // Unmodified course should be intact
+    assert!(h.get_node(course_id(0)).is_some());
+}

--- a/crates/grafeo-core/src/graph/hybrid/writer.rs
+++ b/crates/grafeo-core/src/graph/hybrid/writer.rs
@@ -1,0 +1,394 @@
+//! GraphStoreMut implementation for HybridStore (routed writes).
+//!
+//! All writes delegate to the overlay `LpgStore`. For compact entity structural
+//! mutations (delete, label change), we use lazy shadow records: a `NodeRecord`
+//! is inserted into the overlay so the MVCC machinery can track the entity, and
+//! labels are copied from the compact store so label queries continue to work.
+
+use grafeo_common::mvcc::VersionChain;
+use grafeo_common::types::{EdgeId, EpochId, NodeId, TransactionId, Value};
+
+use super::EntityId;
+use super::HybridStore;
+use crate::graph::lpg::NodeRecord;
+use crate::graph::traits::{GraphStore, GraphStoreMut};
+use crate::graph::Direction;
+
+impl HybridStore {
+    /// Ensures a shadow `NodeRecord` exists in the overlay for a compact node.
+    ///
+    /// If the overlay already contains a record for `id`, this is a no-op.
+    /// Otherwise, creates a new `NodeRecord` + `VersionChain` in the overlay
+    /// and copies labels from the compact store so label queries still work.
+    fn ensure_shadow(&self, id: NodeId) {
+        // Already has a shadow (or was created in overlay) — nothing to do.
+        if GraphStore::get_node(self.overlay.as_ref(), id).is_some() {
+            return;
+        }
+
+        let epoch = self.overlay.current_epoch();
+        let record = NodeRecord::new(id, epoch);
+        let chain = VersionChain::with_initial(record, epoch, TransactionId::SYSTEM);
+        self.overlay.insert_shadow_node(id, chain);
+
+        // Copy labels from compact so label queries still work after shadowing.
+        if let Some(node) = self.compact.read().get_node(id) {
+            for label in &node.labels {
+                self.overlay.add_label(id, label.as_str());
+            }
+        }
+    }
+
+    /// Ensures a shadow edge record exists in the overlay for a compact edge.
+    ///
+    /// For edges, deletion only needs the deleted_edges set (no MVCC chain
+    /// needed because the HybridStore reader already checks deleted_edges).
+    /// This is intentionally a no-op placeholder for symmetry; compact edge
+    /// deletion is handled directly via the deleted_edges set.
+    fn ensure_shadow_edge(&self, _id: EdgeId) {
+        // Compact edge deletion is tracked purely via `deleted_edges` set.
+        // No overlay shadow needed because the HybridStore reader checks
+        // `is_edge_deleted()` before accessing either store.
+    }
+}
+
+impl GraphStoreMut for HybridStore {
+    // ---------------------------------------------------------------
+    // Node creation
+    // ---------------------------------------------------------------
+
+    fn create_node(&self, labels: &[&str]) -> NodeId {
+        self.overlay.create_node(labels)
+    }
+
+    fn create_node_versioned(
+        &self,
+        labels: &[&str],
+        epoch: EpochId,
+        transaction_id: TransactionId,
+    ) -> NodeId {
+        self.overlay
+            .create_node_versioned(labels, epoch, transaction_id)
+    }
+
+    // ---------------------------------------------------------------
+    // Edge creation
+    // ---------------------------------------------------------------
+
+    fn create_edge(&self, src: NodeId, dst: NodeId, edge_type: &str) -> EdgeId {
+        self.overlay.create_edge(src, dst, edge_type)
+    }
+
+    fn create_edge_versioned(
+        &self,
+        src: NodeId,
+        dst: NodeId,
+        edge_type: &str,
+        epoch: EpochId,
+        transaction_id: TransactionId,
+    ) -> EdgeId {
+        self.overlay
+            .create_edge_versioned(src, dst, edge_type, epoch, transaction_id)
+    }
+
+    fn batch_create_edges(&self, edges: &[(NodeId, NodeId, &str)]) -> Vec<EdgeId> {
+        self.overlay.batch_create_edges(edges)
+    }
+
+    // ---------------------------------------------------------------
+    // Deletion
+    // ---------------------------------------------------------------
+
+    fn delete_node(&self, id: NodeId) -> bool {
+        if self.is_compact_node_id(id) {
+            if self.is_node_deleted(id) {
+                return false;
+            }
+            // Verify the node actually exists in compact
+            if self.compact.read().get_node(id).is_none() {
+                return false;
+            }
+            self.mark_node_dirty(id, None);
+            self.ensure_shadow(id);
+            self.overlay.delete_node(id);
+            self.deleted_nodes.write().insert(id);
+            true
+        } else {
+            self.overlay.delete_node(id)
+        }
+    }
+
+    fn delete_node_versioned(
+        &self,
+        id: NodeId,
+        epoch: EpochId,
+        transaction_id: TransactionId,
+    ) -> bool {
+        if self.is_compact_node_id(id) {
+            if self.is_node_deleted(id) {
+                return false;
+            }
+            if self.compact.read().get_node(id).is_none() {
+                return false;
+            }
+            self.mark_node_dirty(id, None);
+            self.ensure_shadow(id);
+            if transaction_id == TransactionId::SYSTEM {
+                self.overlay.delete_node(id);
+            } else {
+                GraphStoreMut::delete_node_versioned(
+                    self.overlay.as_ref(),
+                    id,
+                    epoch,
+                    transaction_id,
+                );
+            }
+            self.deleted_nodes.write().insert(id);
+
+            // Cascade compact edges — collect and mark deleted (one lock at a time)
+            let cascade_edges: Vec<EdgeId> = {
+                let compact = self.compact.read();
+                let mut deleted_edges = self.deleted_edges.write();
+                compact
+                    .edges_from(id, Direction::Both)
+                    .into_iter()
+                    .filter(|(_, eid)| deleted_edges.insert(*eid))
+                    .map(|(_, eid)| eid)
+                    .collect()
+            };
+
+            // Track node + cascaded edges for rollback (separate lock acquisition)
+            {
+                let mut pending = self.pending_deletions.write();
+                let entries = pending.entry(transaction_id).or_default();
+                entries.push(EntityId::Node(id));
+                entries.extend(cascade_edges.into_iter().map(EntityId::Edge));
+            }
+
+            // Cascade overlay edges
+            self.overlay.delete_node_edges(id);
+            true
+        } else if transaction_id == TransactionId::SYSTEM {
+            self.overlay.delete_node(id)
+        } else {
+            GraphStoreMut::delete_node_versioned(
+                self.overlay.as_ref(),
+                id,
+                epoch,
+                transaction_id,
+            )
+        }
+    }
+
+    fn delete_node_edges(&self, node_id: NodeId) {
+        // Non-versioned: no rollback tracking (matches non-versioned delete_node)
+        if self.is_compact_node_id(node_id) {
+            let compact = self.compact.read();
+            let mut deleted_edges = self.deleted_edges.write();
+            for (_, eid) in compact.edges_from(node_id, Direction::Both) {
+                deleted_edges.insert(eid);
+            }
+        }
+        self.overlay.delete_node_edges(node_id);
+    }
+
+    fn delete_edge(&self, id: EdgeId) -> bool {
+        if self.is_compact_edge_id(id) {
+            if self.is_edge_deleted(id) {
+                return false;
+            }
+            // Verify the edge actually exists in compact
+            if self.compact.read().get_edge(id).is_none() {
+                return false;
+            }
+            self.ensure_shadow_edge(id);
+            self.deleted_edges.write().insert(id);
+            true
+        } else {
+            self.overlay.delete_edge(id)
+        }
+    }
+
+    fn delete_edge_versioned(
+        &self,
+        id: EdgeId,
+        epoch: EpochId,
+        transaction_id: TransactionId,
+    ) -> bool {
+        if self.is_compact_edge_id(id) {
+            if self.is_edge_deleted(id) {
+                return false;
+            }
+            if self.compact.read().get_edge(id).is_none() {
+                return false;
+            }
+            self.ensure_shadow_edge(id);
+            self.deleted_edges.write().insert(id);
+            // Lock dropped before acquiring pending_deletions
+            self.pending_deletions.write()
+                .entry(transaction_id)
+                .or_default()
+                .push(EntityId::Edge(id));
+            true
+        } else if transaction_id == TransactionId::SYSTEM {
+            self.overlay.delete_edge(id)
+        } else {
+            GraphStoreMut::delete_edge_versioned(
+                self.overlay.as_ref(),
+                id,
+                epoch,
+                transaction_id,
+            )
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Property mutation
+    // ---------------------------------------------------------------
+
+    fn set_node_property(&self, id: NodeId, key: &str, value: Value) {
+        if self.is_compact_node_id(id) {
+            self.mark_node_dirty(id, Some(key));
+        }
+        self.overlay.set_node_property(id, key, value);
+    }
+
+    fn set_edge_property(&self, id: EdgeId, key: &str, value: Value) {
+        if self.is_compact_edge_id(id) {
+            self.mark_edge_dirty(id, Some(key));
+        }
+        self.overlay.set_edge_property(id, key, value);
+    }
+
+    fn set_node_property_versioned(
+        &self,
+        id: NodeId,
+        key: &str,
+        value: Value,
+        transaction_id: TransactionId,
+    ) {
+        if self.is_compact_node_id(id) {
+            self.mark_node_dirty(id, Some(key));
+        }
+        self.overlay
+            .set_node_property_versioned(id, key, value, transaction_id);
+    }
+
+    fn set_edge_property_versioned(
+        &self,
+        id: EdgeId,
+        key: &str,
+        value: Value,
+        transaction_id: TransactionId,
+    ) {
+        if self.is_compact_edge_id(id) {
+            self.mark_edge_dirty(id, Some(key));
+        }
+        self.overlay
+            .set_edge_property_versioned(id, key, value, transaction_id);
+    }
+
+    fn remove_node_property(&self, id: NodeId, key: &str) -> Option<Value> {
+        if self.is_compact_node_id(id) {
+            self.mark_node_dirty(id, Some(key));
+            let old = self.compact.read().get_node_property(id, &key.into());
+            self.overlay.set_node_property(id, key, Value::Null);
+            old
+        } else {
+            self.overlay.remove_node_property(id, key)
+        }
+    }
+
+    fn remove_edge_property(&self, id: EdgeId, key: &str) -> Option<Value> {
+        if self.is_compact_edge_id(id) {
+            self.mark_edge_dirty(id, Some(key));
+            let old = self.compact.read().get_edge_property(id, &key.into());
+            self.overlay.set_edge_property(id, key, Value::Null);
+            old
+        } else {
+            self.overlay.remove_edge_property(id, key)
+        }
+    }
+
+    fn remove_node_property_versioned(
+        &self,
+        id: NodeId,
+        key: &str,
+        transaction_id: TransactionId,
+    ) -> Option<Value> {
+        if self.is_compact_node_id(id) {
+            let old = self.compact.read().get_node_property(id, &key.into());
+            self.overlay
+                .set_node_property_versioned(id, key, Value::Null, transaction_id);
+            old
+        } else {
+            self.overlay
+                .remove_node_property_versioned(id, key, transaction_id)
+        }
+    }
+
+    fn remove_edge_property_versioned(
+        &self,
+        id: EdgeId,
+        key: &str,
+        transaction_id: TransactionId,
+    ) -> Option<Value> {
+        if self.is_compact_edge_id(id) {
+            let old = self.compact.read().get_edge_property(id, &key.into());
+            self.overlay
+                .set_edge_property_versioned(id, key, Value::Null, transaction_id);
+            old
+        } else {
+            self.overlay
+                .remove_edge_property_versioned(id, key, transaction_id)
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Label mutation
+    // ---------------------------------------------------------------
+
+    fn add_label(&self, node_id: NodeId, label: &str) -> bool {
+        if self.is_compact_node_id(node_id) {
+            self.mark_node_dirty(node_id, None);
+            self.ensure_shadow(node_id);
+        }
+        self.overlay.add_label(node_id, label)
+    }
+
+    fn remove_label(&self, node_id: NodeId, label: &str) -> bool {
+        if self.is_compact_node_id(node_id) {
+            self.mark_node_dirty(node_id, None);
+            self.ensure_shadow(node_id);
+        }
+        self.overlay.remove_label(node_id, label)
+    }
+
+    fn add_label_versioned(
+        &self,
+        node_id: NodeId,
+        label: &str,
+        transaction_id: TransactionId,
+    ) -> bool {
+        if self.is_compact_node_id(node_id) {
+            self.mark_node_dirty(node_id, None);
+            self.ensure_shadow(node_id);
+        }
+        self.overlay
+            .add_label_versioned(node_id, label, transaction_id)
+    }
+
+    fn remove_label_versioned(
+        &self,
+        node_id: NodeId,
+        label: &str,
+        transaction_id: TransactionId,
+    ) -> bool {
+        if self.is_compact_node_id(node_id) {
+            self.mark_node_dirty(node_id, None);
+            self.ensure_shadow(node_id);
+        }
+        self.overlay
+            .remove_label_versioned(node_id, label, transaction_id)
+    }
+}

--- a/crates/grafeo-core/src/graph/lpg/mod.rs
+++ b/crates/grafeo-core/src/graph/lpg/mod.rs
@@ -32,3 +32,5 @@ pub use property::{CompareOp, PropertyStorage};
 pub use section::LpgStoreSection;
 #[cfg(feature = "lpg")]
 pub use store::{LpgStore, PropertyUndoEntry};
+#[cfg(feature = "lpg")]
+pub(crate) use store::value_in_range;

--- a/crates/grafeo-core/src/graph/lpg/property.rs
+++ b/crates/grafeo-core/src/graph/lpg/property.rs
@@ -298,6 +298,23 @@ impl<Id: EntityId> PropertyStorage<Id> {
         }
     }
 
+    /// Returns all entity IDs that have a value in the given column matching `predicate`.
+    ///
+    /// Used by HybridStore to discover compact nodes with overlay property
+    /// overrides that match a scan predicate (avoiding false negatives).
+    #[must_use]
+    pub fn ids_matching(
+        &self,
+        key: &PropertyKey,
+        predicate: impl Fn(&Value) -> bool,
+    ) -> Vec<Id> {
+        let columns = self.columns.read();
+        let Some(col) = columns.get(key) else {
+            return Vec::new();
+        };
+        col.ids_matching(predicate)
+    }
+
     /// Gets all properties for an entity.
     #[must_use]
     pub fn get_all(&self, id: Id) -> FxHashMap<PropertyKey, Value> {
@@ -928,6 +945,16 @@ impl<Id: EntityId> PropertyColumn<Id> {
         None
     }
 
+    /// Returns all entity IDs whose value satisfies `predicate`.
+    #[must_use]
+    pub fn ids_matching(&self, predicate: impl Fn(&Value) -> bool) -> Vec<Id> {
+        self.values
+            .iter()
+            .filter(|(_, v)| predicate(v))
+            .map(|(&id, _)| id)
+            .collect()
+    }
+
     /// Removes a value for an entity.
     pub fn remove(&mut self, id: Id) -> Option<Value> {
         let removed = self.values.remove(&id);
@@ -1465,6 +1492,19 @@ impl<Id: EntityId> PropertyColumn<Id> {
             .and_then(|log| log.latest())
             .filter(|v| !v.is_null())
             .cloned()
+    }
+
+    /// Returns all entity IDs whose latest value satisfies `predicate`.
+    #[must_use]
+    pub fn ids_matching(&self, predicate: impl Fn(&Value) -> bool) -> Vec<Id> {
+        self.values
+            .iter()
+            .filter_map(|(&id, log)| {
+                log.latest()
+                    .filter(|v| !v.is_null() && predicate(v))
+                    .map(|_| id)
+            })
+            .collect()
     }
 
     /// Removes a value by appending a tombstone (Null) at the given epoch.

--- a/crates/grafeo-core/src/graph/lpg/store/mod.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/mod.rs
@@ -134,7 +134,7 @@ pub(super) fn compare_values_for_range(a: &Value, b: &Value) -> Option<CmpOrderi
 }
 
 /// Checks if a value is within a range.
-pub(super) fn value_in_range(
+pub(crate) fn value_in_range(
     value: &Value,
     min: Option<&Value>,
     max: Option<&Value>,
@@ -465,6 +465,11 @@ pub struct LpgStore {
     /// simply discarded.
     /// Lock order: 10 (after named_graphs, independent of other locks)
     property_undo_log: RwLock<FxHashMap<TransactionId, Vec<PropertyUndoEntry>>>,
+
+    /// Optional callback fired after rollback_transaction_properties completes.
+    pub(crate) on_rollback_hook: parking_lot::Mutex<Option<Box<dyn Fn(TransactionId) + Send + Sync>>>,
+    /// Optional callback fired after commit_transaction_properties completes.
+    pub(crate) on_commit_hook: parking_lot::Mutex<Option<Box<dyn Fn(TransactionId) + Send + Sync>>>,
 }
 
 impl LpgStore {
@@ -528,6 +533,8 @@ impl LpgStore {
             needs_stats_recompute: AtomicBool::new(false),
             named_graphs: RwLock::new(FxHashMap::default()),
             property_undo_log: RwLock::new(FxHashMap::default()),
+            on_rollback_hook: parking_lot::Mutex::new(None),
+            on_commit_hook: parking_lot::Mutex::new(None),
         })
     }
 
@@ -766,5 +773,31 @@ impl LpgStore {
         if type_id < counts.len() as u32 {
             counts[type_id as usize] -= 1;
         }
+    }
+
+    /// Sets the next node ID counter.
+    ///
+    /// Used by `HybridStore::open` to ensure overlay IDs do not collide with
+    /// compact-store IDs.
+    pub(crate) fn set_next_node_id(&self, id: u64) {
+        self.next_node_id.store(id, Ordering::Release);
+    }
+
+    /// Sets the next edge ID counter.
+    ///
+    /// Used by `HybridStore::open` to ensure overlay IDs do not collide with
+    /// compact-store IDs.
+    pub(crate) fn set_next_edge_id(&self, id: u64) {
+        self.next_edge_id.store(id, Ordering::Release);
+    }
+
+    /// Registers a callback that fires after `rollback_transaction_properties`.
+    pub(crate) fn set_on_rollback_hook(&self, hook: Box<dyn Fn(TransactionId) + Send + Sync>) {
+        *self.on_rollback_hook.lock() = Some(hook);
+    }
+
+    /// Registers a callback that fires after `commit_transaction_properties`.
+    pub(crate) fn set_on_commit_hook(&self, hook: Box<dyn Fn(TransactionId) + Send + Sync>) {
+        *self.on_commit_hook.lock() = Some(hook);
     }
 }

--- a/crates/grafeo-core/src/graph/lpg/store/node_ops.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/node_ops.rs
@@ -18,6 +18,17 @@ impl LpgStore {
         self.create_node_versioned(labels, self.current_epoch(), TransactionId::SYSTEM)
     }
 
+    /// Inserts a pre-built shadow node record for hybrid store structural mutations.
+    ///
+    /// If a record for this ID already exists, this is a no-op (`or_insert`).
+    /// The shadow record allows the MVCC machinery to track deletions and
+    /// label changes for compact-store entities that don't natively live in
+    /// the overlay.
+    #[cfg(not(feature = "tiered-storage"))]
+    pub(crate) fn insert_shadow_node(&self, id: NodeId, chain: VersionChain<NodeRecord>) {
+        self.nodes.write().entry(id).or_insert(chain);
+    }
+
     /// Registers labels for a node: builds the label ID set, updates the
     /// label index (single lock acquisition), and stores the node-to-labels
     /// mapping.

--- a/crates/grafeo-core/src/graph/lpg/store/property_ops.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/property_ops.rs
@@ -310,6 +310,34 @@ impl LpgStore {
         self.edge_properties.get_selective_batch(ids, keys)
     }
 
+    /// Returns all property overrides for a node ID from PropertyStorage.
+    ///
+    /// Does not check the nodes map -- works for compact entity IDs that only
+    /// have overlay property overrides stored in [`PropertyStorage`].
+    pub(crate) fn get_node_properties_all(&self, id: NodeId) -> FxHashMap<PropertyKey, Value> {
+        self.node_properties.get_all(id)
+    }
+
+    /// Returns all property overrides for an edge ID from PropertyStorage.
+    ///
+    /// Does not check the edges map -- works for compact entity IDs.
+    pub(crate) fn get_edge_properties_all(&self, id: EdgeId) -> FxHashMap<PropertyKey, Value> {
+        self.edge_properties.get_all(id)
+    }
+
+    /// Returns all node IDs with a property override matching `predicate`.
+    ///
+    /// Scans the overlay's PropertyStorage column for `key`, returning IDs
+    /// whose overridden value satisfies the predicate. Used by HybridStore
+    /// to find compact nodes with overlay overrides matching scan criteria.
+    pub(crate) fn node_ids_with_property_matching(
+        &self,
+        key: &PropertyKey,
+        predicate: impl Fn(&Value) -> bool,
+    ) -> Vec<NodeId> {
+        self.node_properties.ids_matching(key, predicate)
+    }
+
     // === Versioned Property Operations (with undo log) ===
 
     /// Sets a node property within a transaction, recording the previous value
@@ -516,6 +544,9 @@ impl LpgStore {
                 }
             }
         }
+        if let Some(ref hook) = *self.on_rollback_hook.lock() {
+            hook(transaction_id);
+        }
     }
 
     /// Rolls back property/label changes by removing PENDING entries from
@@ -636,6 +667,9 @@ impl LpgStore {
                 }
             }
         }
+        if let Some(ref hook) = *self.on_rollback_hook.lock() {
+            hook(transaction_id);
+        }
     }
 
     /// Discards the undo log entries for a committed transaction.
@@ -644,6 +678,9 @@ impl LpgStore {
     /// clean up the log.
     pub fn commit_transaction_properties(&self, transaction_id: TransactionId) {
         self.property_undo_log.write().remove(&transaction_id);
+        if let Some(ref hook) = *self.on_commit_hook.lock() {
+            hook(transaction_id);
+        }
     }
 
     /// Returns the current number of undo log entries for a transaction.

--- a/crates/grafeo-core/src/graph/mod.rs
+++ b/crates/grafeo-core/src/graph/mod.rs
@@ -18,6 +18,9 @@ pub mod traits;
 #[cfg(feature = "compact-store")]
 pub mod compact;
 
+#[cfg(feature = "compact-store")]
+pub mod hybrid;
+
 #[cfg(feature = "triple-store")]
 pub mod rdf;
 

--- a/crates/grafeo-engine/src/database/mod.rs
+++ b/crates/grafeo-engine/src/database/mod.rs
@@ -160,6 +160,11 @@ pub struct GrafeoDB {
     /// External writable graph store (when using with_store()).
     /// None for read-only databases created via with_read_store().
     pub(super) external_write_store: Option<Arc<dyn GraphStoreMut>>,
+    /// For hybrid stores: the overlay LpgStore that should receive MVCC finalization
+    /// on commit (finalize_version_epochs, sync_epoch). Sessions use this as their
+    /// internal store so that auto-committed writes become visible across sessions.
+    #[cfg(all(feature = "lpg", feature = "compact-store"))]
+    pub(super) hybrid_overlay: Option<Arc<LpgStore>>,
     /// Metrics registry shared across all sessions.
     #[cfg(feature = "metrics")]
     pub(crate) metrics: Option<Arc<crate::metrics::MetricsRegistry>>,
@@ -570,6 +575,8 @@ impl GrafeoDB {
             vector_spill_storages: None,
             external_read_store: None,
             external_write_store: None,
+            #[cfg(all(feature = "lpg", feature = "compact-store"))]
+            hybrid_overlay: None,
             #[cfg(feature = "metrics")]
             metrics: Some(Arc::new(crate::metrics::MetricsRegistry::new())),
             current_graph: RwLock::new(None),
@@ -704,6 +711,8 @@ impl GrafeoDB {
             vector_spill_storages: None,
             external_read_store: Some(Arc::clone(&store) as Arc<dyn GraphStore>),
             external_write_store: Some(store),
+            #[cfg(all(feature = "lpg", feature = "compact-store"))]
+            hybrid_overlay: None,
             #[cfg(feature = "metrics")]
             metrics: Some(Arc::new(crate::metrics::MetricsRegistry::new())),
             current_graph: RwLock::new(None),
@@ -788,6 +797,8 @@ impl GrafeoDB {
             vector_spill_storages: None,
             external_read_store: Some(store),
             external_write_store: None,
+            #[cfg(all(feature = "lpg", feature = "compact-store"))]
+            hybrid_overlay: None,
             #[cfg(feature = "metrics")]
             metrics: Some(Arc::new(crate::metrics::MetricsRegistry::new())),
             current_graph: RwLock::new(None),
@@ -827,6 +838,15 @@ impl GrafeoDB {
         #[cfg(feature = "lpg")]
         {
             self.store = None;
+        }
+        // Clear any hybrid overlay from a prior compact_to_hybrid() call.  The
+        // overlay Arc held here is the only owner keeping the old HybridStore
+        // overlay alive after the external stores are replaced; not clearing it
+        // would leak that LpgStore and cause new sessions to receive a stale
+        // overlay reference that has no corresponding write store.
+        #[cfg(all(feature = "lpg", feature = "compact-store"))]
+        {
+            self.hybrid_overlay = None;
         }
         self.read_only = true;
         self.query_cache = Arc::new(QueryCache::default());
@@ -1421,6 +1441,8 @@ impl GrafeoDB {
             identity: identity.clone(),
             #[cfg(feature = "lpg")]
             projections: Arc::clone(&self.projections),
+            #[cfg(all(feature = "lpg", feature = "compact-store"))]
+            hybrid_overlay: self.hybrid_overlay.as_ref().map(Arc::clone),
         };
 
         if let Some(ref ext_read) = self.external_read_store {
@@ -2657,6 +2679,103 @@ impl FromValue for bool {
                 expected: "BOOL".to_string(),
                 found: value.type_name().to_string(),
             })
+    }
+}
+
+// =============================================================================
+// HybridStore integration
+// =============================================================================
+
+#[cfg(feature = "compact-store")]
+impl GrafeoDB {
+    /// Creates a database in hybrid mode from a frozen [`CompactStore`].
+    ///
+    /// The [`HybridStore`] combines a read-only columnar base (the supplied
+    /// `compact`) with a mutable MVCC overlay. Reads merge both layers
+    /// transparently; writes go to the overlay only. The compact base is
+    /// never mutated after construction.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if config validation fails or the overlay store
+    /// cannot be allocated.
+    ///
+    /// [`CompactStore`]: grafeo_core::graph::compact::CompactStore
+    /// [`HybridStore`]: grafeo_core::graph::hybrid::HybridStore
+    pub fn with_hybrid(
+        compact: grafeo_core::graph::compact::CompactStore,
+        config: Config,
+    ) -> Result<Self> {
+        use grafeo_core::graph::hybrid::HybridStore;
+
+        let hybrid_store = HybridStore::open(compact)
+            .map_err(|e| grafeo_common::utils::error::Error::Internal(e.to_string()))?;
+
+        // Extract the overlay before wrapping in Arc so we can pass it to
+        // sessions for MVCC finalization (finalize_version_epochs, sync_epoch).
+        let overlay = Arc::clone(hybrid_store.overlay());
+
+        let hybrid = Arc::new(hybrid_store);
+
+        // HybridStore implements both GraphStore and GraphStoreMut, so we can
+        // delegate directly to with_store().
+        let mut db = Self::with_store(hybrid, config)?;
+
+        // Store the overlay so sessions can call finalize_version_epochs on
+        // commit, making auto-committed writes visible across sessions.
+        db.hybrid_overlay = Some(overlay);
+
+        Ok(db)
+    }
+
+    /// Freezes the current store data into a [`CompactStore`] and switches
+    /// to hybrid mode.
+    ///
+    /// Takes a snapshot of all nodes and edges from the current store,
+    /// builds a columnar [`CompactStore`], wraps it in a [`HybridStore`],
+    /// and replaces the active stores. After this call the database accepts
+    /// both read and write queries. The original store is dropped to free
+    /// memory.
+    ///
+    /// This is the read-write counterpart to [`compact()`](Self::compact),
+    /// which produces a read-only store.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the conversion fails (e.g. more than 32,767
+    /// distinct labels or edge types) or the new overlay cannot be allocated.
+    ///
+    /// [`CompactStore`]: grafeo_core::graph::compact::CompactStore
+    /// [`HybridStore`]: grafeo_core::graph::hybrid::HybridStore
+    pub fn compact_to_hybrid(&mut self) -> Result<()> {
+        use grafeo_core::graph::compact::from_graph_store;
+        use grafeo_core::graph::hybrid::HybridStore;
+
+        let current_store = self.graph_store();
+        let compact = from_graph_store(current_store.as_ref())
+            .map_err(|e| grafeo_common::utils::error::Error::Internal(e.to_string()))?;
+
+        let hybrid_store = HybridStore::open(compact)
+            .map_err(|e| grafeo_common::utils::error::Error::Internal(e.to_string()))?;
+
+        // Capture overlay for MVCC finalization in sessions.
+        let overlay = Arc::clone(hybrid_store.overlay());
+        let hybrid = Arc::new(hybrid_store);
+
+        self.external_read_store = Some(Arc::clone(&hybrid) as Arc<dyn GraphStore>);
+        self.external_write_store = Some(hybrid as Arc<dyn GraphStoreMut>);
+        self.hybrid_overlay = Some(overlay);
+        #[cfg(feature = "lpg")]
+        {
+            self.store = None;
+        }
+        self.read_only = false;
+        self.query_cache = Arc::new(QueryCache::default());
+        // Projections hold Arc refs to the old store: clear them so they don't
+        // serve stale data or prevent the old store's memory from being freed.
+        self.projections.write().clear();
+
+        Ok(())
     }
 }
 

--- a/crates/grafeo-engine/src/query/planner/lpg/expression.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/expression.rs
@@ -113,8 +113,8 @@ impl super::Planner {
                     end: end_expr,
                 })
             }
-            LogicalExpression::Parameter(_) => Err(Error::Internal(
-                "Parameters not yet supported in filters".to_string(),
+            LogicalExpression::Parameter(name) => Err(Error::Internal(
+                format!("Unresolved parameter ${name} in filter — substitution should have replaced this before planning"),
             )),
             LogicalExpression::Labels(var) => Ok(FilterExpression::Labels(var.clone())),
             LogicalExpression::Type(var) => Ok(FilterExpression::Type(var.clone())),

--- a/crates/grafeo-engine/src/query/processor.rs
+++ b/crates/grafeo-engine/src/query/processor.rs
@@ -1108,10 +1108,10 @@ fn substitute_in_expression(expr: &mut LogicalExpression, params: &QueryParams) 
             substitute_in_expression(list_expr, params)?;
             substitute_in_expression(predicate, params)?;
         }
-        LogicalExpression::ExistsSubquery(_)
-        | LogicalExpression::CountSubquery(_)
-        | LogicalExpression::ValueSubquery(_) => {
-            // Subqueries would need recursive parameter substitution
+        LogicalExpression::ExistsSubquery(subplan)
+        | LogicalExpression::CountSubquery(subplan)
+        | LogicalExpression::ValueSubquery(subplan) => {
+            substitute_in_operator(subplan, params)?;
         }
         LogicalExpression::PatternComprehension { projection, .. } => {
             substitute_in_expression(projection, params)?;
@@ -1401,5 +1401,37 @@ mod tests {
 
         assert_eq!(result.row_count(), 1);
         assert_eq!(result.rows[0][0], Value::String("beta".into()));
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_params_in_exists_subquery() {
+        // Tests parameter substitution inside NOT EXISTS { ... } subquery.
+        // This is a common Cypher pattern for anti-joins, e.g. "users not followed by viewer".
+        let store = Arc::new(LpgStore::new().unwrap());
+        let alice = store.create_node_with_props(&["Person"], [("name", Value::String("alice".into()))]);
+        let bob = store.create_node_with_props(&["Person"], [("name", Value::String("bob".into()))]);
+        let _charlie = store.create_node_with_props(&["Person"], [("name", Value::String("charlie".into()))]);
+
+        // alice follows bob (but not charlie)
+        store.create_edge(alice, bob, "FOLLOWS");
+
+        let processor = QueryProcessor::for_lpg(store);
+
+        // Find people NOT followed by the viewer ($viewer_name)
+        let mut params = HashMap::new();
+        params.insert("viewer_name".to_string(), Value::String("alice".into()));
+
+        let result = processor
+            .process(
+                "MATCH (p:Person) WHERE p.name <> $viewer_name AND NOT EXISTS { MATCH (v:Person)-[:FOLLOWS]->(p) WHERE v.name = $viewer_name } RETURN p.name ORDER BY p.name",
+                QueryLanguage::Cypher,
+                Some(&params),
+            )
+            .unwrap();
+
+        // alice follows bob, so only charlie should be returned
+        assert_eq!(result.row_count(), 1);
+        assert_eq!(result.rows[0][0], Value::String("charlie".into()));
     }
 }

--- a/crates/grafeo-engine/src/session/mod.rs
+++ b/crates/grafeo-engine/src/session/mod.rs
@@ -96,6 +96,14 @@ pub(crate) struct SessionConfig {
             std::collections::HashMap<String, Arc<grafeo_core::graph::GraphProjection>>,
         >,
     >,
+    /// For hybrid stores: the overlay `LpgStore` that should receive MVCC
+    /// finalization on commit (finalize_version_epochs, sync_epoch).
+    ///
+    /// When `Some`, `resolve_store` returns this store instead of a fresh
+    /// empty one, ensuring that mutations committed via an external write
+    /// store (HybridStore) become visible to subsequent read-only sessions.
+    #[cfg(all(feature = "lpg", feature = "compact-store"))]
+    pub hybrid_overlay: Option<Arc<LpgStore>>,
 }
 
 /// Your handle to the database - execute queries and manage transactions.
@@ -339,9 +347,17 @@ impl Session {
         write_store: Option<Arc<dyn GraphStoreMut>>,
         cfg: SessionConfig,
     ) -> Result<Self> {
+        #[cfg(all(feature = "lpg", feature = "compact-store"))]
+        let store = if let Some(overlay) = cfg.hybrid_overlay {
+            overlay
+        } else {
+            Arc::new(LpgStore::new()?)
+        };
+        #[cfg(all(feature = "lpg", not(feature = "compact-store")))]
+        let store = Arc::new(LpgStore::new()?);
         Ok(Self {
             #[cfg(feature = "lpg")]
-            store: Arc::new(LpgStore::new()?),
+            store,
             graph_store: read_store,
             graph_store_mut: write_store,
             catalog: cfg.catalog,

--- a/crates/grafeo-engine/tests/hybrid_store_integration.rs
+++ b/crates/grafeo-engine/tests/hybrid_store_integration.rs
@@ -1,0 +1,98 @@
+//! Integration tests for HybridStore through GrafeoDB::with_hybrid().
+//!
+//! Requires feature: `compact-store` (which also enables the `hybrid` module).
+//!
+//! Validates that HybridStore works end-to-end:
+//! - `with_hybrid` wraps a CompactStore in a queryable, writable GrafeoDB
+//! - `compact_to_hybrid` freezes current LPG data and switches to hybrid mode
+
+#![cfg(feature = "compact-store")]
+
+use grafeo_core::graph::compact::CompactStoreBuilder;
+use grafeo_engine::{Config, GrafeoDB};
+
+fn test_compact() -> grafeo_core::graph::compact::CompactStore {
+    let grades: Vec<u64> = (0..100).collect();
+    let names: Vec<&str> = (0..100)
+        .map(|i| if i % 2 == 0 { "Alice" } else { "Bob" })
+        .collect();
+    CompactStoreBuilder::new()
+        .node_table("Student", |b| {
+            b.column_bitpacked("grade", &grades, 8)
+                .column_dict("name", &names)
+        })
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn with_hybrid_creates_queryable_db() {
+    let db = GrafeoDB::with_hybrid(test_compact(), Config::in_memory()).unwrap();
+    let result = db.execute("MATCH (s:Student) RETURN count(s)").unwrap();
+    let rows = result.into_rows();
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn hybrid_db_supports_mutations() {
+    let db = GrafeoDB::with_hybrid(test_compact(), Config::in_memory()).unwrap();
+    db.execute("CREATE (:Person {name: 'Alix'})").unwrap();
+    let result = db.execute("MATCH (p:Person) RETURN p.name").unwrap();
+    let rows = result.into_rows();
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn compact_to_hybrid_preserves_data() {
+    let mut db = GrafeoDB::new_in_memory();
+    db.execute("CREATE (:Foo {x: 1})").unwrap();
+    db.execute("CREATE (:Foo {x: 2})").unwrap();
+    db.compact_to_hybrid().unwrap();
+    let result = db.execute("MATCH (f:Foo) RETURN count(f)").unwrap();
+    let rows = result.into_rows();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], grafeo_common::types::Value::Int64(2));
+    // Can still write after switching to hybrid
+    db.execute("CREATE (:Bar {y: 3})").unwrap();
+    let result = db.execute("MATCH (n) RETURN count(n)").unwrap();
+    let rows = result.into_rows();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], grafeo_common::types::Value::Int64(3));
+}
+
+/// Regression test: compact() after compact_to_hybrid() must clear hybrid_overlay.
+///
+/// Before the fix, `compact()` left `hybrid_overlay` pointing at the previous
+/// HybridStore's overlay LpgStore.  Sessions created after `compact()` would
+/// receive that stale Arc, preventing the old overlay from being freed and
+/// potentially routing MVCC operations to a store that had no backing write
+/// store.
+#[test]
+fn compact_after_hybrid_clears_overlay() {
+    let mut db = GrafeoDB::new_in_memory();
+    db.execute("CREATE (:Foo {x: 1})").unwrap();
+    db.compact_to_hybrid().unwrap();
+
+    // Switch from hybrid → read-only compact.
+    db.compact().unwrap();
+
+    // The DB should be read-only now; writes must fail.
+    assert!(db.execute("CREATE (:Bar {y: 2})").is_err());
+
+    // Reads should still work and reflect the data that was present before
+    // the second compact() call.
+    let result = db.execute("MATCH (f:Foo) RETURN count(f)").unwrap();
+    let rows = result.into_rows();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], grafeo_common::types::Value::Int64(1));
+
+    // Verify that a new session does not inherit the old overlay.
+    // If hybrid_overlay were still set the session's internal store would be
+    // the dead overlay rather than a fresh empty LpgStore, which would not
+    // cause an immediate panic but would keep the old allocation alive.
+    // We assert that the public field visible to submodules is None by
+    // exercising the session path; the session must be usable.
+    let session = db.session();
+    let result = session.execute("MATCH (n) RETURN count(n)").unwrap();
+    assert_eq!(result.into_rows().len(), 1);
+}


### PR DESCRIPTION
## Summary

Adds `HybridStore` — a graph store that wraps a read-only `CompactStore` (columnar base, ~131 bytes/entity) with a mutable `LpgStore` overlay (MVCC). Reads merge both stores transparently; writes go to the overlay.

**4 commits, reviewable in order:**

1. **`feat(hybrid): HybridStore`** (1702 lines) — core struct, ID partitioning, all 42 `GraphStore` read methods, all 20 `GraphStoreMut` write methods, rollback/commit hooks, LpgStore extensions
2. **`feat(compact): serialization`** (418 lines) — `to_bytes`/`from_bytes` via bincode proxy with serde derives
3. **`feat(hybrid): GrafeoDB integration`** (234 lines) — `with_hybrid()`, `compact_to_hybrid()`, session MVCC wiring
4. **`test(hybrid): 51 tests`** (581 lines) — 47 unit + 4 integration

### Design

**Read path** (reader.rs): deleted check → overlay → compact, with property merge. Scans post-filter compact results against overlay overrides (no false positives) and scan overlay `PropertyStorage` columns to discover overridden values (no false negatives). `Value::Null` tombstones from property removal are excluded from all read and scan paths.

**Write path** (writer.rs): all writes delegate to overlay. Compact entity structural mutations (delete, label change) use lazy shadow `NodeRecord`s. Property removal on compact entities writes `Value::Null` tombstone. `delete_node_versioned` cascades compact edges inline with the correct `transaction_id` — no shared mutable state, no races.

**Compaction** (mod.rs): `compact(&self)` rebuilds the compact base from the merged `GraphStore` view, then clears the overlay in-place (`LpgStore::clear()`). No allocation, no replacement, no lock on overlay. Hooks survive because they reference the same `Arc<RwLock<...>>` deletion sets. Exclusive access enforced by `&mut self` on `GrafeoDB::compact()`.

**ID partitioning** (id.rs): single offset covers `max(node_ids, edge_ids)`. Overlay IDs start above the compact range.

### Files

| File | Lines | What |
|------|------:|------|
| `hybrid/reader.rs` | 818 | GraphStore impl (42 methods, merge protocol) |
| `hybrid/writer.rs` | 378 | GraphStoreMut impl (20 methods, shadows, tombstones) |
| `hybrid/mod.rs` | 216 | Struct, open, compact, hooks |
| `hybrid/id.rs` | 122 | ID offset computation |
| `compact/serialize.rs` | 367 | Bincode proxy serialization |
| `database/mod.rs` | +119 | GrafeoDB integration |
| `hybrid/tests.rs` | 581 | Unit tests |
| `hybrid_store_integration.rs` | 98 | Integration tests |

## Test plan

- [x] 47 hybrid unit tests (point reads, scans, writes, deletes, rollback, compaction, tombstones, cross-store edges, serialization roundtrip)
- [x] 4 integration tests (Cypher queries, mutations, data preservation, overlay cleanup)
- [x] 1546 grafeo-core tests pass (no regressions)
- [x] Clippy clean with `-D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)