### PR TITLE
fix(layered): hold dirty_node_ids lock once in nodes_by_label

### DIFF
--- a/crates/grafeo-core/src/graph/compact/layered.rs
+++ b/crates/grafeo-core/src/graph/compact/layered.rs
@@ -385,12 +385,13 @@ impl GraphStore for LayeredStore {
 
     fn nodes_by_label(&self, label: &str) -> Vec<NodeId> {
         let deleted = self.deleted_from_base_nodes.read();
+        let dirty = self.dirty_node_ids.read();
 
         let mut ids: Vec<NodeId> = self
             .base
             .nodes_by_label(label)
             .into_iter()
-            .filter(|id| !deleted.contains(id) && !self.is_node_dirty(*id))
+            .filter(|id| !deleted.contains(id) && !dirty.contains(id))
             .collect();
         ids.extend(
             self.overlay


### PR DESCRIPTION
## Summary

`nodes_by_label` calls `self.is_node_dirty()` per entity in a filter loop, re-acquiring the `dirty_node_ids` RwLock on every iteration. The other three scan methods in the same impl block (`find_nodes_by_property`, `find_nodes_by_properties`, `find_nodes_in_range`) already hold the read guard once. This PR makes `nodes_by_label` consistent with them.

## Change

```diff
 fn nodes_by_label(&self, label: &str) -> Vec<NodeId> {
     let deleted = self.deleted_from_base_nodes.read();
+    let dirty = self.dirty_node_ids.read();

     let mut ids: Vec<NodeId> = self
         .base
         .nodes_by_label(label)
         .into_iter()
-        .filter(|id| !deleted.contains(id) && !self.is_node_dirty(*id))
+        .filter(|id| !deleted.contains(id) && !dirty.contains(id))
         .collect();
```

## Benchmark (10K nodes, Apple M3 Pro)

`nodes_by_label` at 0% dirty (pure base read, no overlay mutations):

| | Before | After |
|--|--------|-------|
| per-call | 46 µs | 27 µs |
| per-row | 4.6 ns | 2.7 ns |

42% improvement from eliminating ~10K RwLock read-guard acquisitions per call. At higher dirty ratios the lock overhead is masked by the hash lookups.

## Test plan

All 53 LayeredStore tests pass unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hold the `dirty_node_ids` read lock once in `nodes_by_label` to avoid per-item lock acquisition and match other scan methods. Improves scan performance on large label lookups.

- **Refactors**
  - Acquire the `dirty_node_ids` read guard once and use `dirty.contains(id)` in the filter instead of calling `self.is_node_dirty` per item.
  - Aligns behavior with `find_nodes_by_property`, `find_nodes_by_properties`, and `find_nodes_in_range`.
  - Benchmark (10K nodes, 0% dirty): 46 µs → 27 µs per call (~42% faster).

<sup>Written for commit 05b8cf127907f9ee479ccc8f89abfeffded16453. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

