### PR TITLE
fix: index/search operations after compact() panic or return empty

### DIFF
--- a/crates/grafeo-core/src/execution/operators/filter.rs
+++ b/crates/grafeo-core/src/execution/operators/filter.rs
@@ -1664,6 +1664,7 @@ impl ExpressionPredicate {
             .or_else(|| self.eval_temporal_fn(name, args, chunk, row))
             .or_else(|| self.eval_path_fn(name, args, chunk, row))
             .or_else(|| self.eval_vector_fn(name, args, chunk, row))
+            .or_else(|| self.eval_text_fn(name, args, chunk, row))
             .or_else(|| self.eval_session_fn(name, args, chunk, row))
     }
 
@@ -3385,6 +3386,28 @@ impl ExpressionPredicate {
         }
     }
 
+    /// Coerces a `Value` to a borrowed or owned float slice for vector math.
+    ///
+    /// Handles both `Value::Vector` (native) and `Value::List` (GQL inline literal
+    /// form `[0.9, 0.1, 0.0]` which the parser translates to a list of Float64/Int64).
+    fn coerce_to_float_vec(val: &Value) -> Option<std::borrow::Cow<[f32]>> {
+        match val {
+            Value::Vector(v) => Some(std::borrow::Cow::Borrowed(v.as_ref())),
+            Value::List(list) => {
+                let mut vec = Vec::with_capacity(list.len());
+                for item in list.iter() {
+                    match item {
+                        Value::Float64(f) => vec.push(*f as f32),
+                        Value::Int64(i) => vec.push(*i as f32),
+                        _ => return None,
+                    }
+                }
+                Some(std::borrow::Cow::Owned(vec))
+            }
+            _ => None,
+        }
+    }
+
     fn eval_vector_fn(
         &self,
         name: &str,
@@ -3399,13 +3422,13 @@ impl ExpressionPredicate {
                 }
                 let a_val = self.eval_expr(&args[0], chunk, row)?;
                 let b_val = self.eval_expr(&args[1], chunk, row)?;
-                let a = a_val.as_vector()?;
-                let b = b_val.as_vector()?;
+                let a = Self::coerce_to_float_vec(&a_val)?;
+                let b = Self::coerce_to_float_vec(&b_val)?;
                 if a.len() != b.len() {
                     return None;
                 }
                 Some(Value::Float64(
-                    crate::index::vector::cosine_similarity(a, b) as f64,
+                    crate::index::vector::cosine_similarity(&a, &b) as f64,
                 ))
             }
             "euclidean_distance" => {
@@ -3414,13 +3437,13 @@ impl ExpressionPredicate {
                 }
                 let a_val = self.eval_expr(&args[0], chunk, row)?;
                 let b_val = self.eval_expr(&args[1], chunk, row)?;
-                let a = a_val.as_vector()?;
-                let b = b_val.as_vector()?;
+                let a = Self::coerce_to_float_vec(&a_val)?;
+                let b = Self::coerce_to_float_vec(&b_val)?;
                 if a.len() != b.len() {
                     return None;
                 }
                 Some(Value::Float64(
-                    crate::index::vector::euclidean_distance(a, b) as f64,
+                    crate::index::vector::euclidean_distance(&a, &b) as f64,
                 ))
             }
             "dot_product" => {
@@ -3429,13 +3452,13 @@ impl ExpressionPredicate {
                 }
                 let a_val = self.eval_expr(&args[0], chunk, row)?;
                 let b_val = self.eval_expr(&args[1], chunk, row)?;
-                let a = a_val.as_vector()?;
-                let b = b_val.as_vector()?;
+                let a = Self::coerce_to_float_vec(&a_val)?;
+                let b = Self::coerce_to_float_vec(&b_val)?;
                 if a.len() != b.len() {
                     return None;
                 }
                 Some(Value::Float64(
-                    crate::index::vector::dot_product(a, b) as f64
+                    crate::index::vector::dot_product(&a, &b) as f64
                 ))
             }
             "manhattan_distance" => {
@@ -3444,17 +3467,75 @@ impl ExpressionPredicate {
                 }
                 let a_val = self.eval_expr(&args[0], chunk, row)?;
                 let b_val = self.eval_expr(&args[1], chunk, row)?;
-                let a = a_val.as_vector()?;
-                let b = b_val.as_vector()?;
+                let a = Self::coerce_to_float_vec(&a_val)?;
+                let b = Self::coerce_to_float_vec(&b_val)?;
                 if a.len() != b.len() {
                     return None;
                 }
                 Some(Value::Float64(
-                    crate::index::vector::manhattan_distance(a, b) as f64,
+                    crate::index::vector::manhattan_distance(&a, &b) as f64,
                 ))
             }
             _ => None,
         }
+    }
+
+    #[cfg(feature = "text-index")]
+    fn eval_text_fn(
+        &self,
+        name: &str,
+        args: &[FilterExpression],
+        chunk: &DataChunk,
+        row: usize,
+    ) -> Option<Value> {
+        match name {
+            "text_score" | "text_match" => {
+                if args.len() != 2 {
+                    return None;
+                }
+
+                // First arg must be a property access (e.g., n.body)
+                let FilterExpression::Property { variable, property } = &args[0] else {
+                    return None;
+                };
+
+                // Get node_id from the chunk
+                let col_idx = *self.variable_columns.get(variable.as_str())?;
+                let col = chunk.column(col_idx)?;
+                let node_id = col.get_node_id(row)?;
+
+                // Second arg: query string
+                let query_val = self.eval_expr(&args[1], chunk, row)?;
+                let Value::String(query_str) = &query_val else {
+                    return None;
+                };
+
+                // Get the node's labels to look up the text index
+                let node = self.resolve_node(node_id)?;
+                let label = node.labels.first()?;
+
+                // Score using the store's text index
+                let score = self.store.score_text(node_id, label, property, query_str)?;
+
+                if name == "text_match" {
+                    Some(Value::Bool(score > 0.0))
+                } else {
+                    Some(Value::Float64(score))
+                }
+            }
+            _ => None,
+        }
+    }
+
+    #[cfg(not(feature = "text-index"))]
+    fn eval_text_fn(
+        &self,
+        _name: &str,
+        _args: &[FilterExpression],
+        _chunk: &DataChunk,
+        _row: usize,
+    ) -> Option<Value> {
+        None
     }
 
     fn eval_session_fn(
@@ -6460,5 +6541,167 @@ mod tests {
         let op = FilterOperator::new(Box::new(mock), Box::new(predicate));
         let (mut child, _predicate) = op.into_parts();
         assert!(child.next().unwrap().is_none());
+    }
+}
+
+#[cfg(all(test, feature = "text-index", feature = "lpg"))]
+mod text_fn_tests {
+    use super::*;
+    use crate::execution::chunk::DataChunkBuilder;
+    use crate::graph::GraphStore;
+    use crate::graph::lpg::LpgStore;
+    use crate::index::text::{BM25Config, InvertedIndex};
+    use grafeo_common::types::LogicalType;
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn setup_store_with_text_index() -> (Arc<LpgStore>, grafeo_common::types::NodeId, grafeo_common::types::NodeId) {
+        let store = Arc::new(LpgStore::new().unwrap());
+
+        // Create nodes with text properties
+        let n1 = store.create_node(&["Article"]);
+        store.set_node_property(n1, "body", Value::String("rust graph database engine".into()));
+        let n2 = store.create_node(&["Article"]);
+        store.set_node_property(n2, "body", Value::String("python web framework".into()));
+
+        // Create and populate text index
+        let mut index = InvertedIndex::new(BM25Config::default());
+        index.insert(n1, "rust graph database engine");
+        index.insert(n2, "python web framework");
+        store.add_text_index("Article", "body", Arc::new(RwLock::new(index)));
+
+        (store, n1, n2)
+    }
+
+    #[test]
+    fn test_text_score_function() {
+        let (store, n1, n2) = setup_store_with_text_index();
+
+        // Build a chunk with two rows: n1 in row 0, n2 in row 1
+        let mut builder = DataChunkBuilder::new(&[LogicalType::Node]);
+        builder.column_mut(0).unwrap().push_node_id(n1);
+        builder.advance_row();
+        builder.column_mut(0).unwrap().push_node_id(n2);
+        builder.advance_row();
+        let chunk = builder.finish();
+
+        let mut variable_columns = HashMap::new();
+        variable_columns.insert("doc".to_string(), 0);
+
+        // text_score(doc.body, "rust database") > 0.0
+        let predicate = ExpressionPredicate::new(
+            FilterExpression::Binary {
+                left: Box::new(FilterExpression::FunctionCall {
+                    name: "text_score".to_string(),
+                    args: vec![
+                        FilterExpression::Property {
+                            variable: "doc".to_string(),
+                            property: "body".to_string(),
+                        },
+                        FilterExpression::Literal(Value::String("rust database".into())),
+                    ],
+                }),
+                op: BinaryFilterOp::Gt,
+                right: Box::new(FilterExpression::Literal(Value::Float64(0.0))),
+            },
+            variable_columns,
+            store as Arc<dyn GraphStore>,
+        );
+
+        // n1 matches "rust database" — should pass
+        assert!(predicate.evaluate(&chunk, 0), "n1 should score > 0 for 'rust database'");
+        // n2 does not match — should fail
+        assert!(!predicate.evaluate(&chunk, 1), "n2 should score 0 for 'rust database'");
+    }
+
+    #[test]
+    fn test_text_match_function() {
+        let (store, n1, n2) = setup_store_with_text_index();
+
+        // Build a chunk with two rows
+        let mut builder = DataChunkBuilder::new(&[LogicalType::Node]);
+        builder.column_mut(0).unwrap().push_node_id(n1);
+        builder.advance_row();
+        builder.column_mut(0).unwrap().push_node_id(n2);
+        builder.advance_row();
+        let chunk = builder.finish();
+
+        let mut variable_columns = HashMap::new();
+        variable_columns.insert("doc".to_string(), 0);
+
+        // text_match(doc.body, "rust") = true/false
+        let predicate = ExpressionPredicate::new(
+            FilterExpression::FunctionCall {
+                name: "text_match".to_string(),
+                args: vec![
+                    FilterExpression::Property {
+                        variable: "doc".to_string(),
+                        property: "body".to_string(),
+                    },
+                    FilterExpression::Literal(Value::String("rust".into())),
+                ],
+            },
+            variable_columns,
+            store as Arc<dyn GraphStore>,
+        );
+
+        // n1 contains "rust" — text_match should return Bool(true) → evaluates to true
+        assert!(predicate.evaluate(&chunk, 0), "n1 should match 'rust'");
+        // n2 does not contain "rust" — text_match should return Bool(false)
+        assert!(!predicate.evaluate(&chunk, 1), "n2 should not match 'rust'");
+    }
+
+    #[test]
+    fn test_text_score_wrong_arg_count_returns_none() {
+        let store = Arc::new(LpgStore::new().unwrap());
+        let builder = DataChunkBuilder::new(&[LogicalType::Node]);
+        let chunk = builder.finish();
+        let variable_columns = HashMap::new();
+
+        // text_score with wrong number of args should return None (evaluate = false)
+        let predicate = ExpressionPredicate::new(
+            FilterExpression::FunctionCall {
+                name: "text_score".to_string(),
+                args: vec![FilterExpression::Literal(Value::String("only_one".into()))],
+            },
+            variable_columns,
+            store as Arc<dyn GraphStore>,
+        );
+        assert!(!predicate.evaluate(&chunk, 0));
+    }
+
+    #[test]
+    fn test_text_score_no_index_returns_none() {
+        // Node has a label but no text index for that label+property
+        let store = Arc::new(LpgStore::new().unwrap());
+        let n1 = store.create_node(&["Article"]);
+        store.set_node_property(n1, "body", Value::String("rust graph database".into()));
+        // No text index added
+
+        let mut builder = DataChunkBuilder::new(&[LogicalType::Node]);
+        builder.column_mut(0).unwrap().push_node_id(n1);
+        builder.advance_row();
+        let chunk = builder.finish();
+
+        let mut variable_columns = HashMap::new();
+        variable_columns.insert("doc".to_string(), 0);
+
+        let predicate = ExpressionPredicate::new(
+            FilterExpression::FunctionCall {
+                name: "text_score".to_string(),
+                args: vec![
+                    FilterExpression::Property {
+                        variable: "doc".to_string(),
+                        property: "body".to_string(),
+                    },
+                    FilterExpression::Literal(Value::String("rust".into())),
+                ],
+            },
+            variable_columns,
+            store as Arc<dyn GraphStore>,
+        );
+        // No index → score_text returns None → eval returns None → evaluate returns false
+        assert!(!predicate.evaluate(&chunk, 0));
     }
 }

--- a/crates/grafeo-core/src/execution/operators/filter.rs
+++ b/crates/grafeo-core/src/execution/operators/filter.rs
@@ -3510,12 +3510,12 @@ impl ExpressionPredicate {
                     return None;
                 };
 
-                // Get the node's labels to look up the text index
+                // Get the node's labels and try each for a text index match
                 let node = self.resolve_node(node_id)?;
-                let label = node.labels.first()?;
-
-                // Score using the store's text index
-                let score = self.store.score_text(node_id, label, property, query_str)?;
+                let score = node
+                    .labels
+                    .iter()
+                    .find_map(|label| self.store.score_text(node_id, label, property, query_str))?;
 
                 if name == "text_match" {
                     Some(Value::Bool(score > 0.0))

--- a/crates/grafeo-core/src/execution/operators/mod.rs
+++ b/crates/grafeo-core/src/execution/operators/mod.rs
@@ -41,6 +41,8 @@ mod project;
 pub mod push;
 mod scan;
 mod scan_vector;
+#[cfg(feature = "text-index")]
+mod scan_text;
 mod set_ops;
 mod shortest_path;
 pub mod single_row;
@@ -96,6 +98,8 @@ pub use push::{
 pub use push::{SpillableAggregatePushOperator, SpillableSortPushOperator};
 pub use scan::ScanOperator;
 pub use scan_vector::VectorScanOperator;
+#[cfg(feature = "text-index")]
+pub use scan_text::TextScanOperator;
 pub use set_ops::{ExceptOperator, IntersectOperator, OtherwiseOperator};
 pub use shortest_path::ShortestPathOperator;
 pub use single_row::{EmptyOperator, NodeListOperator, SingleRowOperator};

--- a/crates/grafeo-core/src/execution/operators/scan_text.rs
+++ b/crates/grafeo-core/src/execution/operators/scan_text.rs
@@ -1,0 +1,318 @@
+//! BM25 text scan operator.
+//!
+//! Performs full-text search using an inverted index with BM25 scoring.
+//! Supports top-k and score-threshold modes.
+
+use super::{Operator, OperatorError, OperatorResult};
+use crate::execution::DataChunk;
+use crate::graph::traits::GraphStore;
+use grafeo_common::types::{LogicalType, NodeId};
+use std::sync::Arc;
+
+/// A scan operator that retrieves nodes by BM25 text relevance.
+///
+/// This operator executes a full-text search against a store's text index
+/// and returns results as `(NodeId, Float64)` DataChunk batches, where the
+/// second column holds the BM25 score.
+///
+/// # Modes
+///
+/// - **Top-k**: return the `k` highest-scoring documents.
+/// - **Threshold**: return all documents scoring at or above a threshold.
+///
+/// # Output Schema
+///
+/// Returns a DataChunk with two columns:
+/// 1. `Node`    — The matched node ID
+/// 2. `Float64` — The BM25 relevance score
+pub struct TextScanOperator {
+    /// The graph store to search.
+    store: Arc<dyn GraphStore>,
+    /// Label to search within.
+    label: String,
+    /// Property holding the text to search.
+    property: String,
+    /// Search query string.
+    query: String,
+    /// Top-k limit (None = threshold mode).
+    k: Option<usize>,
+    /// Minimum score threshold (None = top-k mode).
+    threshold: Option<f64>,
+    /// Cached search results after first execution.
+    results: Vec<(NodeId, f64)>,
+    /// Current read position in `results`.
+    position: usize,
+    /// Whether the search has already been executed.
+    executed: bool,
+    /// Rows per output DataChunk (default 2048).
+    chunk_capacity: usize,
+}
+
+impl TextScanOperator {
+    /// Creates a top-k text scan operator.
+    ///
+    /// Returns the `k` highest-scoring nodes for the given query.
+    #[must_use]
+    pub fn top_k(
+        store: Arc<dyn GraphStore>,
+        label: impl Into<String>,
+        property: impl Into<String>,
+        query: impl Into<String>,
+        k: usize,
+    ) -> Self {
+        Self {
+            store,
+            label: label.into(),
+            property: property.into(),
+            query: query.into(),
+            k: Some(k),
+            threshold: None,
+            results: Vec::new(),
+            position: 0,
+            executed: false,
+            chunk_capacity: 2048,
+        }
+    }
+
+    /// Creates a threshold-based text scan operator.
+    ///
+    /// Returns all nodes with a BM25 score ≥ `threshold`.
+    #[must_use]
+    pub fn with_threshold(
+        store: Arc<dyn GraphStore>,
+        label: impl Into<String>,
+        property: impl Into<String>,
+        query: impl Into<String>,
+        threshold: f64,
+    ) -> Self {
+        Self {
+            store,
+            label: label.into(),
+            property: property.into(),
+            query: query.into(),
+            k: None,
+            threshold: Some(threshold),
+            results: Vec::new(),
+            position: 0,
+            executed: false,
+            chunk_capacity: 2048,
+        }
+    }
+
+    /// Sets the chunk capacity (rows per output batch).
+    #[must_use]
+    pub fn with_chunk_capacity(mut self, capacity: usize) -> Self {
+        self.chunk_capacity = capacity;
+        self
+    }
+
+    /// Executes the search on first call and caches the results.
+    fn execute_search(&mut self) {
+        if self.executed {
+            return;
+        }
+        self.executed = true;
+
+        self.results = if let Some(k) = self.k {
+            self.store
+                .text_search(&self.label, &self.property, &self.query, k)
+        } else if let Some(threshold) = self.threshold {
+            self.store
+                .text_search_with_threshold(&self.label, &self.property, &self.query, threshold)
+        } else {
+            Vec::new()
+        };
+    }
+}
+
+impl Operator for TextScanOperator {
+    fn next(&mut self) -> OperatorResult {
+        // Lazy execution on first call.
+        self.execute_search();
+
+        if self.position >= self.results.len() {
+            return Ok(None);
+        }
+
+        let schema = [LogicalType::Node, LogicalType::Float64];
+        let mut chunk = DataChunk::with_capacity(&schema, self.chunk_capacity);
+
+        let end = (self.position + self.chunk_capacity).min(self.results.len());
+        let count = end - self.position;
+
+        // Fill node ID column.
+        {
+            let node_col = chunk
+                .column_mut(0)
+                .ok_or_else(|| OperatorError::ColumnNotFound("node column".into()))?;
+
+            for i in self.position..end {
+                let (node_id, _) = self.results[i];
+                node_col.push_node_id(node_id);
+            }
+        }
+
+        // Fill BM25 score column.
+        {
+            let score_col = chunk
+                .column_mut(1)
+                .ok_or_else(|| OperatorError::ColumnNotFound("score column".into()))?;
+
+            for i in self.position..end {
+                let (_, score) = self.results[i];
+                score_col.push_float64(score);
+            }
+        }
+
+        chunk.set_count(count);
+        self.position = end;
+
+        Ok(Some(chunk))
+    }
+
+    fn reset(&mut self) {
+        self.position = 0;
+        self.results.clear();
+        self.executed = false;
+    }
+
+    fn name(&self) -> &'static str {
+        "TextScan(BM25)"
+    }
+}
+
+#[cfg(all(test, feature = "text-index", feature = "lpg"))]
+mod tests {
+    use super::*;
+    use crate::graph::lpg::LpgStore;
+    use crate::graph::traits::GraphStore;
+    use crate::index::text::{BM25Config, InvertedIndex};
+    use grafeo_common::types::Value;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn make_store() -> Arc<LpgStore> {
+        let store = Arc::new(LpgStore::new().expect("arena allocation"));
+
+        // Create nodes
+        let n1 = store.create_node(&["Doc"]);
+        store.set_node_property(n1, "body", Value::String("rust graph database engine".into()));
+        let n2 = store.create_node(&["Doc"]);
+        store.set_node_property(n2, "body", Value::String("python web framework".into()));
+        let n3 = store.create_node(&["Doc"]);
+        store.set_node_property(
+            n3,
+            "body",
+            Value::String("rust systems programming language".into()),
+        );
+
+        // Build and add text index
+        let mut index = InvertedIndex::new(BM25Config::default());
+        index.insert(n1, "rust graph database engine");
+        index.insert(n2, "python web framework");
+        index.insert(n3, "rust systems programming language");
+        store.add_text_index("Doc", "body", Arc::new(RwLock::new(index)));
+
+        store
+    }
+
+    #[test]
+    fn test_text_scan_top_k() {
+        let store = make_store();
+        let mut scan = TextScanOperator::top_k(
+            store.clone() as Arc<dyn GraphStore>,
+            "Doc",
+            "body",
+            "rust",
+            2,
+        );
+        let chunk = scan.next().unwrap().unwrap();
+        assert_eq!(chunk.row_count(), 2);
+        let n1 = chunk.column(0).unwrap().get_node_id(0);
+        let score1 = chunk.column(1).unwrap().get_float64(0);
+        assert!(n1.is_some());
+        assert!(score1.unwrap() > 0.0);
+        assert!(scan.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_text_scan_with_threshold() {
+        let store = make_store();
+        let all = store.text_search("Doc", "body", "rust database", 10);
+        assert_eq!(all.len(), 2);
+        let mid = (all[0].1 + all[1].1) / 2.0;
+        let mut scan = TextScanOperator::with_threshold(
+            store.clone() as Arc<dyn GraphStore>,
+            "Doc",
+            "body",
+            "rust database",
+            mid,
+        );
+        let chunk = scan.next().unwrap().unwrap();
+        assert_eq!(chunk.row_count(), 1);
+        assert_eq!(chunk.column(0).unwrap().get_node_id(0), Some(all[0].0));
+        assert!(scan.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_text_scan_no_matches() {
+        let store = make_store();
+        let mut scan = TextScanOperator::top_k(
+            store.clone() as Arc<dyn GraphStore>,
+            "Doc",
+            "body",
+            "nonexistent",
+            10,
+        );
+        assert!(scan.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_text_scan_reset() {
+        let store = make_store();
+        let mut scan = TextScanOperator::top_k(
+            store.clone() as Arc<dyn GraphStore>,
+            "Doc",
+            "body",
+            "rust",
+            10,
+        );
+        let chunk1 = scan.next().unwrap().unwrap();
+        assert_eq!(chunk1.row_count(), 2);
+        assert!(scan.next().unwrap().is_none());
+        scan.reset();
+        let chunk2 = scan.next().unwrap().unwrap();
+        assert_eq!(chunk2.row_count(), 2);
+    }
+
+    #[test]
+    fn test_text_scan_name() {
+        let store = make_store();
+        let scan = TextScanOperator::top_k(
+            store.clone() as Arc<dyn GraphStore>,
+            "Doc",
+            "body",
+            "rust",
+            10,
+        );
+        assert_eq!(scan.name(), "TextScan(BM25)");
+    }
+
+    #[test]
+    fn test_text_scan_chunk_capacity() {
+        let store = make_store();
+        let mut scan = TextScanOperator::top_k(
+            store.clone() as Arc<dyn GraphStore>,
+            "Doc",
+            "body",
+            "rust",
+            10,
+        )
+        .with_chunk_capacity(1);
+        let chunk1 = scan.next().unwrap().unwrap();
+        assert_eq!(chunk1.row_count(), 1);
+        let chunk2 = scan.next().unwrap().unwrap();
+        assert_eq!(chunk2.row_count(), 1);
+        assert!(scan.next().unwrap().is_none());
+    }
+}

--- a/crates/grafeo-core/src/execution/operators/scan_text.rs
+++ b/crates/grafeo-core/src/execution/operators/scan_text.rs
@@ -179,6 +179,10 @@ impl Operator for TextScanOperator {
     fn name(&self) -> &'static str {
         "TextScan(BM25)"
     }
+
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any + Send> {
+        self
+    }
 }
 
 #[cfg(all(test, feature = "text-index", feature = "lpg"))]

--- a/crates/grafeo-core/src/execution/operators/scan_text.rs
+++ b/crates/grafeo-core/src/execution/operators/scan_text.rs
@@ -102,7 +102,7 @@ impl TextScanOperator {
     /// Sets the chunk capacity (rows per output batch).
     #[must_use]
     pub fn with_chunk_capacity(mut self, capacity: usize) -> Self {
-        self.chunk_capacity = capacity;
+        self.chunk_capacity = capacity.max(1);
         self
     }
 

--- a/crates/grafeo-core/src/execution/operators/scan_vector.rs
+++ b/crates/grafeo-core/src/execution/operators/scan_vector.rs
@@ -203,6 +203,17 @@ impl VectorScanOperator {
         self
     }
 
+    /// Overrides the distance metric.
+    ///
+    /// When using `with_index`, the default metric is Cosine. Use this to
+    /// match the HNSW index's actual metric so that threshold comparisons
+    /// (min_similarity, max_distance) use the correct distance scale.
+    #[must_use]
+    pub fn with_metric(mut self, metric: DistanceMetric) -> Self {
+        self.metric = metric;
+        self
+    }
+
     /// Sets the chunk capacity for output batches.
     #[must_use]
     pub fn with_chunk_capacity(mut self, capacity: usize) -> Self {

--- a/crates/grafeo-core/src/execution/operators/scan_vector.rs
+++ b/crates/grafeo-core/src/execution/operators/scan_vector.rs
@@ -217,7 +217,7 @@ impl VectorScanOperator {
     /// Sets the chunk capacity for output batches.
     #[must_use]
     pub fn with_chunk_capacity(mut self, capacity: usize) -> Self {
-        self.chunk_capacity = capacity;
+        self.chunk_capacity = capacity.max(1);
         self
     }
 

--- a/crates/grafeo-core/src/graph/compact/builder.rs
+++ b/crates/grafeo-core/src/graph/compact/builder.rs
@@ -578,6 +578,7 @@ fn infer_column_type(codec: &ColumnCodec) -> ColumnType {
         ColumnCodec::Int8Vector { dimensions, .. } => ColumnType::Int8Vector {
             dimensions: *dimensions,
         },
+        ColumnCodec::Float64(_) => ColumnType::Float64,
     }
 }
 
@@ -649,6 +650,8 @@ fn compute_zone_map_bool(values: &[bool]) -> ZoneMap {
 enum InferredType {
     /// All non-null values are `Value::Int64` with value >= 0.
     BitPacked,
+    /// All non-null values are `Value::Float64`, or mixed `Int64`+`Float64`.
+    Float64,
     /// All non-null values are `Value::Bool`.
     Bitmap,
     /// All non-null values are `Value::String`, or mixed/unsupported types.
@@ -789,6 +792,19 @@ pub fn from_graph_store(
                         t.columns.push((key.clone(), ColumnCodec::BitPacked(bp)));
                         t.record_len(u64_values.len());
                     }
+                    InferredType::Float64 => {
+                        let f64_values: Vec<f64> = values
+                            .iter()
+                            .map(|v| match v {
+                                Value::Float64(f) => *f,
+                                Value::Int64(n) => *n as f64,
+                                _ => 0.0,
+                            })
+                            .collect();
+                        t.columns
+                            .push((key.clone(), ColumnCodec::Float64(f64_values)));
+                        t.record_len(values.len());
+                    }
                     InferredType::Bitmap => {
                         let bool_values: Vec<bool> = values
                             .iter()
@@ -908,6 +924,18 @@ pub fn from_graph_store(
                                     .collect();
                                 let bp = BitPackedInts::pack(&u64_values);
                                 r.properties.push((key.clone(), ColumnCodec::BitPacked(bp)));
+                            }
+                            InferredType::Float64 => {
+                                let f64_values: Vec<f64> = values
+                                    .iter()
+                                    .map(|v| match v {
+                                        Value::Float64(f) => *f,
+                                        Value::Int64(n) => *n as f64,
+                                        _ => 0.0,
+                                    })
+                                    .collect();
+                                r.properties
+                                    .push((key.clone(), ColumnCodec::Float64(f64_values)));
                             }
                             InferredType::Bitmap => {
                                 let bool_values: Vec<bool> = values
@@ -1102,6 +1130,7 @@ pub fn from_graph_store_preserving_ids(
 /// - Otherwise returns `Dict` (string fallback).
 fn infer_type_from_values(values: &[Value]) -> InferredType {
     let mut saw_int = false;
+    let mut saw_float = false;
     let mut saw_bool = false;
     let mut saw_other = false;
 
@@ -1109,13 +1138,17 @@ fn infer_type_from_values(values: &[Value]) -> InferredType {
         match v {
             Value::Null => {} // skip nulls
             Value::Int64(n) if *n >= 0 => saw_int = true,
+            Value::Float64(_) => saw_float = true,
             Value::Bool(_) => saw_bool = true,
             _ => saw_other = true,
         }
     }
 
-    if saw_other || (saw_int && saw_bool) {
+    // Mixed Int64+Float64 coalesces to Float64.
+    if saw_other || ((saw_int || saw_float) && saw_bool) {
         InferredType::Dict
+    } else if saw_float {
+        InferredType::Float64
     } else if saw_int {
         InferredType::BitPacked
     } else if saw_bool {
@@ -1421,7 +1454,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_graph_store_float_falls_back_to_dict() {
+    fn test_from_graph_store_float64_column() {
         use crate::graph::lpg::LpgStore;
 
         let store = LpgStore::new().unwrap();
@@ -1434,14 +1467,11 @@ mod tests {
         let ids = compact.nodes_by_label("Sensor");
         assert_eq!(ids.len(), 1);
 
-        // Float64 falls back to Dict, serialized as string.
+        // Float64 values are stored natively.
         let val = compact
             .get_node_property(ids[0], &PropertyKey::new("reading"))
             .unwrap();
-        match val {
-            Value::String(s) => assert!(s.contains("98.6"), "expected '98.6' in '{s}'"),
-            other => panic!("expected String (Dict fallback), got {other:?}"),
-        }
+        assert_eq!(val, Value::Float64(98.6));
     }
 
     #[test]
@@ -1616,7 +1646,15 @@ mod tests {
     fn test_infer_type_float() {
         assert_eq!(
             infer_type_from_values(&[Value::Float64(1.5)]),
-            InferredType::Dict
+            InferredType::Float64
+        );
+    }
+
+    #[test]
+    fn test_infer_type_mixed_int_float_coalesces_to_float() {
+        assert_eq!(
+            infer_type_from_values(&[Value::Int64(1), Value::Float64(2.5)]),
+            InferredType::Float64
         );
     }
 

--- a/crates/grafeo-core/src/graph/compact/builder.rs
+++ b/crates/grafeo-core/src/graph/compact/builder.rs
@@ -579,6 +579,9 @@ fn infer_column_type(codec: &ColumnCodec) -> ColumnType {
             dimensions: *dimensions,
         },
         ColumnCodec::Float64(_) => ColumnType::Float64,
+        ColumnCodec::Float32Vector { dimensions, .. } => ColumnType::Float32Vector {
+            dimensions: *dimensions,
+        },
     }
 }
 
@@ -654,6 +657,8 @@ enum InferredType {
     Float64,
     /// All non-null values are `Value::Bool`.
     Bitmap,
+    /// All non-null values are `Value::Vector` with consistent dimensions.
+    Float32Vector { dimensions: u16 },
     /// All non-null values are `Value::String`, or mixed/unsupported types.
     Dict,
 }
@@ -805,6 +810,20 @@ pub fn from_graph_store(
                             .push((key.clone(), ColumnCodec::Float64(f64_values)));
                         t.record_len(values.len());
                     }
+                    InferredType::Float32Vector { dimensions } => {
+                        let mut flat: Vec<f32> = Vec::with_capacity(values.len() * dimensions as usize);
+                        for v in values {
+                            match v {
+                                Value::Vector(vec) => flat.extend_from_slice(vec),
+                                _ => flat.extend(std::iter::repeat(0.0f32).take(dimensions as usize)),
+                            }
+                        }
+                        t.columns.push((
+                            key.clone(),
+                            ColumnCodec::Float32Vector { data: flat, dimensions },
+                        ));
+                        t.record_len(values.len());
+                    }
                     InferredType::Bitmap => {
                         let bool_values: Vec<bool> = values
                             .iter()
@@ -936,6 +955,19 @@ pub fn from_graph_store(
                                     .collect();
                                 r.properties
                                     .push((key.clone(), ColumnCodec::Float64(f64_values)));
+                            }
+                            InferredType::Float32Vector { dimensions } => {
+                                let mut flat: Vec<f32> = Vec::with_capacity(values.len() * dimensions as usize);
+                                for v in values {
+                                    match v {
+                                        Value::Vector(vec) => flat.extend_from_slice(vec),
+                                        _ => flat.extend(std::iter::repeat(0.0f32).take(dimensions as usize)),
+                                    }
+                                }
+                                r.properties.push((
+                                    key.clone(),
+                                    ColumnCodec::Float32Vector { data: flat, dimensions },
+                                ));
                             }
                             InferredType::Bitmap => {
                                 let bool_values: Vec<bool> = values
@@ -1132,7 +1164,9 @@ fn infer_type_from_values(values: &[Value]) -> InferredType {
     let mut saw_int = false;
     let mut saw_float = false;
     let mut saw_bool = false;
+    let mut saw_vector = false;
     let mut saw_other = false;
+    let mut vector_dims: Option<u16> = None;
 
     for v in values {
         match v {
@@ -1140,7 +1174,26 @@ fn infer_type_from_values(values: &[Value]) -> InferredType {
             Value::Int64(n) if *n >= 0 => saw_int = true,
             Value::Float64(_) => saw_float = true,
             Value::Bool(_) => saw_bool = true,
+            Value::Vector(vec) => {
+                saw_vector = true;
+                #[allow(clippy::cast_possible_truncation)]
+                let dims = vec.len() as u16;
+                if let Some(prev) = vector_dims {
+                    if prev != dims {
+                        saw_other = true; // mixed dimensions → fallback
+                    }
+                } else {
+                    vector_dims = Some(dims);
+                }
+            }
             _ => saw_other = true,
+        }
+    }
+
+    // Vectors are exclusive — mixed with other types falls back to Dict.
+    if saw_vector && !saw_other && !saw_int && !saw_float && !saw_bool {
+        if let Some(dims) = vector_dims {
+            return InferredType::Float32Vector { dimensions: dims };
         }
     }
 

--- a/crates/grafeo-core/src/graph/compact/builder.rs
+++ b/crates/grafeo-core/src/graph/compact/builder.rs
@@ -1176,8 +1176,10 @@ fn infer_type_from_values(values: &[Value]) -> InferredType {
             Value::Bool(_) => saw_bool = true,
             Value::Vector(vec) => {
                 saw_vector = true;
-                #[allow(clippy::cast_possible_truncation)]
-                let dims = vec.len() as u16;
+                let Ok(dims) = u16::try_from(vec.len()) else {
+                    saw_other = true; // too many dimensions for columnar storage
+                    continue;
+                };
                 if let Some(prev) = vector_dims {
                     if prev != dims {
                         saw_other = true; // mixed dimensions → fallback
@@ -1198,7 +1200,8 @@ fn infer_type_from_values(values: &[Value]) -> InferredType {
     }
 
     // Mixed Int64+Float64 coalesces to Float64.
-    if saw_other || ((saw_int || saw_float) && saw_bool) {
+    // Vectors mixed with any other type fall back to Dict.
+    if saw_other || saw_vector || ((saw_int || saw_float) && saw_bool) {
         InferredType::Dict
     } else if saw_float {
         InferredType::Float64

--- a/crates/grafeo-core/src/graph/compact/column.rs
+++ b/crates/grafeo-core/src/graph/compact/column.rs
@@ -450,6 +450,10 @@ impl ColumnCodec {
                 // Float32Vector
                 let dimensions = read_u16_le(data, pos)?;
                 let data_len = read_u32_le(data, pos)? as usize;
+                let byte_need = data_len.checked_mul(4).ok_or("Float32Vector length overflow")?;
+                if *pos + byte_need > data.len() {
+                    return Err("truncated Float32Vector data");
+                }
                 let mut f32_data = Vec::with_capacity(data_len);
                 for _ in 0..data_len {
                     f32_data.push(read_f32_le(data, pos)?);

--- a/crates/grafeo-core/src/graph/compact/column.rs
+++ b/crates/grafeo-core/src/graph/compact/column.rs
@@ -35,6 +35,13 @@ pub enum ColumnCodec {
     },
     /// Native IEEE 754 double-precision floats.
     Float64(Vec<f64>),
+    /// Float32 vectors (flat array with stride), for embedding / vector search.
+    Float32Vector {
+        /// Flat array of f32 components.
+        data: Vec<f32>,
+        /// Number of dimensions per vector.
+        dimensions: u16,
+    },
 }
 
 impl ColumnCodec {
@@ -78,6 +85,18 @@ impl ColumnCodec {
                 Some(Value::List(Arc::from(values)))
             }
             Self::Float64(vec) => vec.get(index).copied().map(Value::Float64),
+            Self::Float32Vector { data, dimensions } => {
+                let dims = *dimensions as usize;
+                if dims == 0 {
+                    return None;
+                }
+                let start = index.checked_mul(dims)?;
+                let end = start.checked_add(dims)?;
+                if end > data.len() {
+                    return None;
+                }
+                Some(Value::Vector(Arc::from(&data[start..end])))
+            }
         }
     }
 
@@ -129,6 +148,10 @@ impl ColumnCodec {
                 data.len().checked_div(dims).unwrap_or(0)
             }
             Self::Float64(vec) => vec.len(),
+            Self::Float32Vector { data, dimensions } => {
+                let dims = *dimensions as usize;
+                if dims == 0 { 0 } else { data.len() / dims }
+            }
         }
     }
 
@@ -327,6 +350,14 @@ impl ColumnCodec {
                     buf.extend_from_slice(&v.to_le_bytes());
                 }
             }
+            Self::Float32Vector { data, dimensions } => {
+                buf.push(5); // discriminant
+                buf.extend_from_slice(&dimensions.to_le_bytes());
+                write_usize_as_u32(buf, data.len());
+                for &v in data {
+                    buf.extend_from_slice(&v.to_le_bytes());
+                }
+            }
         }
     }
 
@@ -415,6 +446,19 @@ impl ColumnCodec {
                 }
                 Ok(Self::Float64(vec))
             }
+            5 => {
+                // Float32Vector
+                let dimensions = read_u16_le(data, pos)?;
+                let data_len = read_u32_le(data, pos)? as usize;
+                let mut f32_data = Vec::with_capacity(data_len);
+                for _ in 0..data_len {
+                    f32_data.push(read_f32_le(data, pos)?);
+                }
+                Ok(Self::Float32Vector {
+                    data: f32_data,
+                    dimensions,
+                })
+            }
             _ => Err("unknown codec discriminant"),
         }
     }
@@ -432,6 +476,7 @@ impl ColumnCodec {
             Self::Bitmap(bv) => bv.data().len() * std::mem::size_of::<u64>(),
             Self::Int8Vector { data, .. } => data.len(),
             Self::Float64(vec) => vec.len() * std::mem::size_of::<f64>(),
+            Self::Float32Vector { data, .. } => data.len() * std::mem::size_of::<f32>(),
         }
     }
 }
@@ -477,6 +522,15 @@ fn read_f64_le(data: &[u8], pos: &mut usize) -> Result<f64, &'static str> {
     }
     let v = f64::from_le_bytes(data[*pos..*pos + 8].try_into().unwrap());
     *pos += 8;
+    Ok(v)
+}
+
+fn read_f32_le(data: &[u8], pos: &mut usize) -> Result<f32, &'static str> {
+    if *pos + 4 > data.len() {
+        return Err("truncated f32");
+    }
+    let v = f32::from_le_bytes(data[*pos..*pos + 4].try_into().unwrap());
+    *pos += 4;
     Ok(v)
 }
 

--- a/crates/grafeo-core/src/graph/compact/column.rs
+++ b/crates/grafeo-core/src/graph/compact/column.rs
@@ -33,6 +33,8 @@ pub enum ColumnCodec {
         /// Number of dimensions per vector.
         dimensions: u16,
     },
+    /// Native IEEE 754 double-precision floats.
+    Float64(Vec<f64>),
 }
 
 impl ColumnCodec {
@@ -42,6 +44,7 @@ impl ColumnCodec {
     /// - [`Dict`](Self::Dict) → `Value::String(ArcStr::from(s))`
     /// - [`Bitmap`](Self::Bitmap) → `Value::Bool(b)`
     /// - [`Int8Vector`](Self::Int8Vector) → `Value::List(...)` of `Int64` values
+    /// - [`Float64`](Self::Float64) → `Value::Float64(f)`
     ///
     /// Returns `None` when `index` is out of bounds.
     #[inline]
@@ -74,6 +77,7 @@ impl ColumnCodec {
                     .collect();
                 Some(Value::List(Arc::from(values)))
             }
+            Self::Float64(vec) => vec.get(index).copied().map(Value::Float64),
         }
     }
 
@@ -124,6 +128,7 @@ impl ColumnCodec {
                 let dims = *dimensions as usize;
                 data.len().checked_div(dims).unwrap_or(0)
             }
+            Self::Float64(vec) => vec.len(),
         }
     }
 
@@ -164,6 +169,12 @@ impl ColumnCodec {
             },
             (Self::Bitmap(bv), &Value::Bool(target_bool)) => (0..bv.len())
                 .filter(|&i| bv.get(i) == Some(target_bool))
+                .collect(),
+            (Self::Float64(vec), &Value::Float64(target)) => vec
+                .iter()
+                .enumerate()
+                .filter(|&(_, v)| *v == target)
+                .map(|(i, _)| i)
                 .collect(),
             _ => (0..self.len())
                 .filter(|&i| self.get(i).as_ref() == Some(target))
@@ -309,6 +320,13 @@ impl ColumnCodec {
                     buf.push(v.to_le_bytes()[0]);
                 }
             }
+            Self::Float64(vec) => {
+                buf.push(4); // discriminant
+                write_usize_as_u32(buf, vec.len());
+                for &v in vec {
+                    buf.extend_from_slice(&v.to_le_bytes());
+                }
+            }
         }
     }
 
@@ -388,6 +406,15 @@ impl ColumnCodec {
                     dimensions,
                 })
             }
+            4 => {
+                // Float64
+                let count = read_u32_le(data, pos)? as usize;
+                let mut vec = Vec::with_capacity(count);
+                for _ in 0..count {
+                    vec.push(read_f64_le(data, pos)?);
+                }
+                Ok(Self::Float64(vec))
+            }
             _ => Err("unknown codec discriminant"),
         }
     }
@@ -404,6 +431,7 @@ impl ColumnCodec {
             }
             Self::Bitmap(bv) => bv.data().len() * std::mem::size_of::<u64>(),
             Self::Int8Vector { data, .. } => data.len(),
+            Self::Float64(vec) => vec.len() * std::mem::size_of::<f64>(),
         }
     }
 }
@@ -439,6 +467,15 @@ fn read_u64_le(data: &[u8], pos: &mut usize) -> Result<u64, &'static str> {
         return Err("truncated u64");
     }
     let v = u64::from_le_bytes(data[*pos..*pos + 8].try_into().unwrap());
+    *pos += 8;
+    Ok(v)
+}
+
+fn read_f64_le(data: &[u8], pos: &mut usize) -> Result<f64, &'static str> {
+    if *pos + 8 > data.len() {
+        return Err("truncated f64");
+    }
+    let v = f64::from_le_bytes(data[*pos..*pos + 8].try_into().unwrap());
     *pos += 8;
     Ok(v)
 }

--- a/crates/grafeo-core/src/graph/compact/layered.rs
+++ b/crates/grafeo-core/src/graph/compact/layered.rs
@@ -683,17 +683,27 @@ impl GraphStore for LayeredStore {
         property: &str,
         query: &str,
     ) -> Option<f64> {
+        if self.is_node_deleted_from_base(node_id) {
+            return None;
+        }
         self.overlay.score_text(node_id, label, property, query)
     }
 
     #[cfg(feature = "text-index")]
     fn text_search(&self, label: &str, property: &str, query: &str, k: usize) -> Vec<(NodeId, f64)> {
-        self.overlay.text_search(label, property, query, k)
+        let deleted = self.deleted_from_base_nodes.read();
+        let mut results = self.overlay.text_search(label, property, query, k + deleted.len());
+        results.retain(|(id, _)| !deleted.contains(id));
+        results.truncate(k);
+        results
     }
 
     #[cfg(feature = "text-index")]
     fn text_search_with_threshold(&self, label: &str, property: &str, query: &str, threshold: f64) -> Vec<(NodeId, f64)> {
-        self.overlay.text_search_with_threshold(label, property, query, threshold)
+        let deleted = self.deleted_from_base_nodes.read();
+        let mut results = self.overlay.text_search_with_threshold(label, property, query, threshold);
+        results.retain(|(id, _)| !deleted.contains(id));
+        results
     }
 
     #[cfg(feature = "text-index")]

--- a/crates/grafeo-core/src/graph/compact/layered.rs
+++ b/crates/grafeo-core/src/graph/compact/layered.rs
@@ -674,6 +674,46 @@ impl GraphStore for LayeredStore {
         }
         Vec::new()
     }
+
+    #[cfg(feature = "text-index")]
+    fn score_text(
+        &self,
+        node_id: NodeId,
+        label: &str,
+        property: &str,
+        query: &str,
+    ) -> Option<f64> {
+        self.overlay.score_text(node_id, label, property, query)
+    }
+
+    #[cfg(feature = "text-index")]
+    fn text_search(&self, label: &str, property: &str, query: &str, k: usize) -> Vec<(NodeId, f64)> {
+        self.overlay.text_search(label, property, query, k)
+    }
+
+    #[cfg(feature = "text-index")]
+    fn text_search_with_threshold(&self, label: &str, property: &str, query: &str, threshold: f64) -> Vec<(NodeId, f64)> {
+        self.overlay.text_search_with_threshold(label, property, query, threshold)
+    }
+
+    #[cfg(feature = "text-index")]
+    fn has_text_index(&self, label: &str, property: &str) -> bool {
+        self.overlay.has_text_index(label, property)
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn has_vector_index(&self, label: &str, property: &str) -> bool {
+        self.overlay.has_vector_index(label, property)
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn get_vector_index_handle(
+        &self,
+        label: &str,
+        property: &str,
+    ) -> Option<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
+        self.overlay.get_vector_index_handle(label, property)
+    }
 }
 
 // ── GraphStoreMut implementation ───────────────────────────────────

--- a/crates/grafeo-core/src/graph/compact/schema.rs
+++ b/crates/grafeo-core/src/graph/compact/schema.rs
@@ -27,6 +27,8 @@ pub enum ColumnType {
         /// Number of dimensions in each vector.
         dimensions: u16,
     },
+    /// IEEE 754 double-precision floating-point values.
+    Float64,
 }
 
 /// A single column within a table schema.

--- a/crates/grafeo-core/src/graph/compact/schema.rs
+++ b/crates/grafeo-core/src/graph/compact/schema.rs
@@ -29,6 +29,11 @@ pub enum ColumnType {
     },
     /// IEEE 754 double-precision floating-point values.
     Float64,
+    /// Fixed-dimension 32-bit float vector (for embeddings / vector search).
+    Float32Vector {
+        /// Number of dimensions in each vector.
+        dimensions: u16,
+    },
 }
 
 /// A single column within a table schema.

--- a/crates/grafeo-core/src/graph/compact/section.rs
+++ b/crates/grafeo-core/src/graph/compact/section.rs
@@ -551,6 +551,7 @@ fn infer_column_type_from_codec(codec: &ColumnCodec) -> ColumnType {
         ColumnCodec::Int8Vector { dimensions, .. } => ColumnType::Int8Vector {
             dimensions: *dimensions,
         },
+        ColumnCodec::Float64(_) => ColumnType::Float64,
     }
 }
 

--- a/crates/grafeo-core/src/graph/compact/section.rs
+++ b/crates/grafeo-core/src/graph/compact/section.rs
@@ -552,6 +552,9 @@ fn infer_column_type_from_codec(codec: &ColumnCodec) -> ColumnType {
             dimensions: *dimensions,
         },
         ColumnCodec::Float64(_) => ColumnType::Float64,
+        ColumnCodec::Float32Vector { dimensions, .. } => ColumnType::Float32Vector {
+            dimensions: *dimensions,
+        },
     }
 }
 

--- a/crates/grafeo-core/src/graph/lpg/store/graph_store_impl.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/graph_store_impl.rs
@@ -250,6 +250,58 @@ impl GraphStore for LpgStore {
     fn get_edge_history(&self, id: EdgeId) -> Vec<(EpochId, Option<EpochId>, Edge)> {
         LpgStore::get_edge_history(self, id)
     }
+
+    #[cfg(feature = "text-index")]
+    fn score_text(
+        &self,
+        node_id: NodeId,
+        label: &str,
+        property: &str,
+        query: &str,
+    ) -> Option<f64> {
+        let index = self.get_text_index(label, property)?;
+        let guard = index.read();
+        let score = guard.score_document(node_id, query);
+        Some(score)
+    }
+
+    #[cfg(feature = "text-index")]
+    fn text_search(&self, label: &str, property: &str, query: &str, k: usize) -> Vec<(NodeId, f64)> {
+        if let Some(index) = self.get_text_index(label, property) {
+            index.read().search(query, k)
+        } else {
+            Vec::new()
+        }
+    }
+
+    #[cfg(feature = "text-index")]
+    fn text_search_with_threshold(&self, label: &str, property: &str, query: &str, threshold: f64) -> Vec<(NodeId, f64)> {
+        if let Some(index) = self.get_text_index(label, property) {
+            index.read().search_with_threshold(query, threshold)
+        } else {
+            Vec::new()
+        }
+    }
+
+    #[cfg(feature = "text-index")]
+    fn has_text_index(&self, label: &str, property: &str) -> bool {
+        self.get_text_index(label, property).is_some()
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn has_vector_index(&self, label: &str, property: &str) -> bool {
+        self.get_vector_index(label, property).is_some()
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn get_vector_index_handle(
+        &self,
+        label: &str,
+        property: &str,
+    ) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
+        let index = self.get_vector_index(label, property)?;
+        Some(index as Arc<dyn std::any::Any + Send + Sync>)
+    }
 }
 
 impl GraphStoreMut for LpgStore {

--- a/crates/grafeo-core/src/graph/traits.rs
+++ b/crates/grafeo-core/src/graph/traits.rs
@@ -330,6 +330,62 @@ pub trait GraphStore: Send + Sync {
     fn get_edge_history(&self, _id: EdgeId) -> Vec<(EpochId, Option<EpochId>, Edge)> {
         Vec::new()
     }
+
+    // --- Text search (for per-row BM25 evaluation) ---
+
+    /// Scores a document against a text query using the store's text index.
+    ///
+    /// Returns `None` if no text index exists for the given (label, property) pair.
+    /// Used by filter evaluation for per-row BM25 scoring when planner pushdown
+    /// doesn't fire.
+    fn score_text(
+        &self,
+        _node_id: NodeId,
+        _label: &str,
+        _property: &str,
+        _query: &str,
+    ) -> Option<f64> {
+        None
+    }
+
+    /// Performs a full-text search using the store's text index, returning top-k results.
+    ///
+    /// Results are sorted by BM25 score descending.
+    /// Returns empty vec if no text index exists for the (label, property) pair.
+    fn text_search(&self, _label: &str, _property: &str, _query: &str, _k: usize) -> Vec<(NodeId, f64)> {
+        Vec::new()
+    }
+
+    /// Performs a full-text search returning all results above a threshold.
+    ///
+    /// Results are sorted by BM25 score descending.
+    /// Returns empty vec if no text index exists.
+    fn text_search_with_threshold(&self, _label: &str, _property: &str, _query: &str, _threshold: f64) -> Vec<(NodeId, f64)> {
+        Vec::new()
+    }
+
+    /// Returns true if a text index exists for the given (label, property).
+    fn has_text_index(&self, _label: &str, _property: &str) -> bool {
+        false
+    }
+
+    /// Returns true if a vector index exists for the given (label, property).
+    fn has_vector_index(&self, _label: &str, _property: &str) -> bool {
+        false
+    }
+
+    /// Returns a type-erased handle to the vector index for a (label, property) pair.
+    ///
+    /// The returned `Arc<dyn Any>` can be downcast to `Arc<VectorIndexKind>` when
+    /// the `vector-index` feature is enabled. This allows the planner to use
+    /// HNSW-accelerated search without leaking feature-gated types into the trait.
+    fn get_vector_index_handle(
+        &self,
+        _label: &str,
+        _property: &str,
+    ) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
+        None
+    }
 }
 
 /// Write operations for graph mutation.

--- a/crates/grafeo-core/src/index/text/inverted_index.rs
+++ b/crates/grafeo-core/src/index/text/inverted_index.rs
@@ -153,6 +153,19 @@ impl InvertedIndex {
         true
     }
 
+    /// BM25 term score: IDF * TF-component for a single term occurrence.
+    ///
+    /// `df` is the document frequency (number of documents containing the term),
+    /// `tf` is the term frequency in this document, `dl` is the document length,
+    /// `n` is the corpus size, and `avg_dl` is the average document length.
+    #[inline]
+    fn bm25_term_score(&self, df: f64, tf: f64, dl: f64, n: f64, avg_dl: f64) -> f64 {
+        let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+        let tf_component = (tf * (self.config.k1 + 1.0))
+            / (tf + self.config.k1 * (1.0 - self.config.b + self.config.b * dl / avg_dl));
+        idf * tf_component
+    }
+
     /// Searches the index using BM25 scoring.
     ///
     /// Returns up to `k` results sorted by descending BM25 score.
@@ -164,34 +177,95 @@ impl InvertedIndex {
 
         let n = self.doc_lengths.len() as f64;
         let avg_dl = self.total_length as f64 / n;
-
         let mut scores: HashMap<NodeId, f64> = HashMap::new();
 
         for token in &query_tokens {
             let Some(posting_list) = self.postings.get(token.as_str()) else {
                 continue;
             };
-
-            // IDF: log((N - df + 0.5) / (df + 0.5) + 1)
             let df = posting_list.postings.len() as f64;
-            let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
-
             for posting in &posting_list.postings {
                 let tf = f64::from(posting.term_freq);
                 let dl = f64::from(self.doc_lengths.get(&posting.node_id).copied().unwrap_or(0));
-
-                // BM25: IDF * (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * dl / avgdl))
-                let tf_component = (tf * (self.config.k1 + 1.0))
-                    / (tf + self.config.k1 * (1.0 - self.config.b + self.config.b * dl / avg_dl));
-
-                *scores.entry(posting.node_id).or_insert(0.0) += idf * tf_component;
+                *scores.entry(posting.node_id).or_insert(0.0) +=
+                    self.bm25_term_score(df, tf, dl, n, avg_dl);
             }
         }
 
-        // Sort by score descending, take top k
         let mut results: Vec<(NodeId, f64)> = scores.into_iter().collect();
         results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
         results.truncate(k);
+        results
+    }
+
+    /// Scores a single document against a query using BM25.
+    ///
+    /// Looks up each query term in its posting list, finds the entry for the
+    /// given node ID, and computes BM25 with corpus statistics. Returns `0.0`
+    /// if the document has no matching terms or doesn't exist.
+    ///
+    /// This is O(query_terms) per call and is intended for per-row evaluation.
+    #[must_use]
+    pub fn score_document(&self, id: NodeId, query: &str) -> f64 {
+        let query_tokens = self.tokenizer.tokenize(query);
+        if query_tokens.is_empty() || self.doc_lengths.is_empty() {
+            return 0.0;
+        }
+        let Some(&doc_len) = self.doc_lengths.get(&id) else {
+            return 0.0;
+        };
+        let n = self.doc_lengths.len() as f64;
+        let avg_dl = self.total_length as f64 / n;
+        let dl = f64::from(doc_len);
+        let mut score = 0.0;
+        for token in &query_tokens {
+            let Some(posting_list) = self.postings.get(token.as_str()) else {
+                continue;
+            };
+            let df = posting_list.postings.len() as f64;
+            let tf = posting_list
+                .postings
+                .iter()
+                .find(|p| p.node_id == id)
+                .map_or(0.0, |p| f64::from(p.term_freq));
+            if tf > 0.0 {
+                score += self.bm25_term_score(df, tf, dl, n, avg_dl);
+            }
+        }
+        score
+    }
+
+    /// Returns all documents scoring at or above `threshold` using BM25.
+    ///
+    /// Unlike [`search()`] (top-k), this returns every document above the
+    /// threshold, sorted by score descending. Intended for index-accelerated
+    /// text search with WHERE predicates.
+    #[must_use]
+    pub fn search_with_threshold(&self, query: &str, threshold: f64) -> Vec<(NodeId, f64)> {
+        let query_tokens = self.tokenizer.tokenize(query);
+        if query_tokens.is_empty() || self.doc_lengths.is_empty() {
+            return Vec::new();
+        }
+        let n = self.doc_lengths.len() as f64;
+        let avg_dl = self.total_length as f64 / n;
+        let mut scores: HashMap<NodeId, f64> = HashMap::new();
+        for token in &query_tokens {
+            let Some(posting_list) = self.postings.get(token.as_str()) else {
+                continue;
+            };
+            let df = posting_list.postings.len() as f64;
+            for posting in &posting_list.postings {
+                let tf = f64::from(posting.term_freq);
+                let dl = f64::from(self.doc_lengths.get(&posting.node_id).copied().unwrap_or(0));
+                *scores.entry(posting.node_id).or_insert(0.0) +=
+                    self.bm25_term_score(df, tf, dl, n, avg_dl);
+            }
+        }
+        let mut results: Vec<(NodeId, f64)> = scores
+            .into_iter()
+            .filter(|(_, score)| *score >= threshold)
+            .collect();
+        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
         results
     }
 
@@ -449,5 +523,96 @@ mod tests {
         // "common" matches all three
         let results = index.search("common", 10);
         assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn test_score_document_matches_search() {
+        let mut index = InvertedIndex::new(BM25Config::default());
+        index.insert(NodeId::new(1), "the quick brown fox jumps over the lazy dog");
+        index.insert(NodeId::new(2), "a fast red car drives on the highway");
+        index.insert(NodeId::new(3), "the brown dog sleeps all day");
+
+        let query = "brown dog";
+        let search_results = index.search(query, 10);
+
+        // Verify score_document returns the same score as search() for matching docs
+        for (node_id, search_score) in &search_results {
+            let doc_score = index.score_document(*node_id, query);
+            assert!(
+                (doc_score - search_score).abs() < 1e-10,
+                "score_document({:?}) = {doc_score} but search gave {search_score}",
+                node_id
+            );
+        }
+
+        // Node 2 has no matching terms — should score 0.0
+        let no_match_score = index.score_document(NodeId::new(2), query);
+        assert_eq!(no_match_score, 0.0, "non-matching doc should score 0.0");
+
+        // Non-existent doc should score 0.0
+        let nonexistent_score = index.score_document(NodeId::new(999), query);
+        assert_eq!(nonexistent_score, 0.0, "non-existent doc should score 0.0");
+    }
+
+    #[test]
+    fn test_search_with_threshold() {
+        let mut index = InvertedIndex::new(BM25Config::default());
+        index.insert(NodeId::new(1), "rust graph database query engine");
+        index.insert(NodeId::new(2), "python web framework django flask");
+        index.insert(NodeId::new(3), "rust systems programming language");
+        index.insert(NodeId::new(4), "graph theory algorithms data structures");
+        index.insert(NodeId::new(5), "database indexing storage engine optimization");
+
+        let query = "rust graph database";
+
+        // Get search results to calibrate the threshold
+        let search_results = index.search(query, 10);
+        assert!(search_results.len() >= 2, "need at least 2 matching docs for this test");
+
+        // Use the score of the second-highest result as our mid threshold
+        let mid_threshold = search_results[1].1;
+
+        // threshold=0 should return all matching docs (same set as search with no k limit)
+        let all_results = index.search_with_threshold(query, 0.0);
+        assert_eq!(
+            all_results.len(),
+            search_results.len(),
+            "threshold=0 should return all matching docs"
+        );
+
+        // Results should be sorted descending by score
+        for i in 1..all_results.len() {
+            assert!(
+                all_results[i - 1].1 >= all_results[i].1,
+                "results should be sorted descending"
+            );
+        }
+
+        // mid_threshold should filter out lower-scoring docs
+        let filtered = index.search_with_threshold(query, mid_threshold);
+        assert!(
+            filtered.len() <= search_results.len(),
+            "mid-threshold should not exceed total matches"
+        );
+        for (_, score) in &filtered {
+            assert!(
+                *score >= mid_threshold,
+                "all returned docs should score >= threshold"
+            );
+        }
+
+        // Very high threshold should return nothing
+        let empty_results = index.search_with_threshold(query, 1_000_000.0);
+        assert!(
+            empty_results.is_empty(),
+            "very high threshold should return no results"
+        );
+
+        // Empty query should return nothing
+        let empty_query_results = index.search_with_threshold("", 0.0);
+        assert!(
+            empty_query_results.is_empty(),
+            "empty query should return no results"
+        );
     }
 }

--- a/crates/grafeo-core/src/index/vector/quantized_hnsw.rs
+++ b/crates/grafeo-core/src/index/vector/quantized_hnsw.rs
@@ -399,7 +399,7 @@ impl QuantizedHnswIndex {
         // Get candidates using HNSW (with full precision distances for now)
         // In a production system, you'd modify HNSW to use quantized distances
         let num_candidates = if self.rescore {
-            k * self.rescore_factor
+            k.saturating_mul(self.rescore_factor)
         } else {
             k
         };
@@ -436,7 +436,7 @@ impl QuantizedHnswIndex {
 
         // Get candidates - use more candidates for binary (less accurate)
         let num_candidates = if self.rescore {
-            k * self.rescore_factor * 2 // Binary needs more candidates
+            k.saturating_mul(self.rescore_factor).saturating_mul(2) // Binary needs more candidates
         } else {
             k
         };
@@ -486,7 +486,7 @@ impl QuantizedHnswIndex {
 
         // Get candidates using HNSW
         let num_candidates = if self.rescore {
-            k * self.rescore_factor
+            k.saturating_mul(self.rescore_factor)
         } else {
             k
         };

--- a/crates/grafeo-engine/src/database/index.rs
+++ b/crates/grafeo-engine/src/database/index.rs
@@ -137,15 +137,16 @@ impl super::GrafeoDB {
         #[cfg(feature = "vector-index")]
         let mut vectors: Vec<(grafeo_common::types::NodeId, Vec<f32>)> = Vec::new();
 
-        for node in self.lpg_store().nodes_with_label(label) {
-            if let Some(Value::Vector(v)) = node.properties.get(&prop_key) {
+        let graph = self.graph_store();
+        for node_id in graph.nodes_by_label(label) {
+            if let Some(Value::Vector(v)) = graph.get_node_property(node_id, &prop_key) {
                 if let Some(expected) = found_dims {
                     if v.len() != expected {
                         return Err(grafeo_common::utils::error::Error::Internal(format!(
                             "Vector dimension mismatch: expected {}, found {} on node {}",
                             expected,
                             v.len(),
-                            node.id.0
+                            node_id.0
                         )));
                     }
                 } else {
@@ -153,7 +154,7 @@ impl super::GrafeoDB {
                 }
                 vector_count += 1;
                 #[cfg(feature = "vector-index")]
-                vectors.push((node.id, v.to_vec()));
+                vectors.push((node_id, v.to_vec()));
             }
         }
 
@@ -204,8 +205,9 @@ impl super::GrafeoDB {
 
             match &index {
                 VectorIndexKind::Hnsw(_) => {
+                    let graph = self.graph_store();
                     let accessor = grafeo_core::index::vector::PropertyVectorAccessor::new(
-                        &**self.lpg_store(),
+                        &*graph,
                         property,
                     );
                     for (node_id, vec) in &vectors {
@@ -381,10 +383,11 @@ impl super::GrafeoDB {
         let prop_key = PropertyKey::new(property);
 
         // Index all existing nodes with this label + property
-        let nodes = self.lpg_store().nodes_by_label(label);
+        let graph = self.graph_store();
+        let nodes = graph.nodes_by_label(label);
         for node_id in nodes {
             if let Some(Value::String(text)) =
-                self.lpg_store().get_node_property(node_id, &prop_key)
+                graph.get_node_property(node_id, &prop_key)
             {
                 index.insert(node_id, text.as_str());
             }

--- a/crates/grafeo-engine/src/database/mod.rs
+++ b/crates/grafeo-engine/src/database/mod.rs
@@ -198,6 +198,24 @@ impl GrafeoDB {
         )
     }
 
+    /// Returns a borrowed reference to the active graph store.
+    ///
+    /// In layered mode (after [`compact()`](Self::compact)), returns the
+    /// `LayeredStore` which merges the columnar base with the overlay.
+    /// Otherwise, returns the built-in `LpgStore`.
+    ///
+    /// Unlike [`graph_store()`](Self::graph_store) (which clones an `Arc`),
+    /// this borrows from `self` — suitable for constructing accessors that
+    /// need `&'a dyn GraphStore` tied to the database lifetime.
+    #[cfg(feature = "lpg")]
+    fn graph_store_ref(&self) -> &dyn grafeo_core::graph::GraphStore {
+        if let Some(ref ext_read) = self.external_read_store {
+            ext_read.as_ref()
+        } else {
+            &**self.lpg_store()
+        }
+    }
+
     /// Returns whether CDC is active (runtime check).
     #[cfg(feature = "cdc")]
     #[inline]
@@ -875,8 +893,8 @@ impl GrafeoDB {
 
         self.external_read_store = Some(Arc::clone(&layered) as Arc<dyn GraphStore>);
         self.external_write_store = Some(Arc::clone(&layered) as Arc<dyn GraphStoreMut>);
+        self.store = Some(Arc::clone(layered.overlay_store()));
         self.layered_store = Some(layered);
-        self.store = None;
         self.read_only = false;
         self.query_cache = Arc::new(QueryCache::default());
         self.projections.write().clear();
@@ -925,6 +943,7 @@ impl GrafeoDB {
 
         self.external_read_store = Some(Arc::clone(&new_layered) as Arc<dyn GraphStore>);
         self.external_write_store = Some(Arc::clone(&new_layered) as Arc<dyn GraphStoreMut>);
+        self.store = Some(Arc::clone(new_layered.overlay_store()));
         self.layered_store = Some(new_layered);
         self.query_cache = Arc::new(QueryCache::default());
 

--- a/crates/grafeo-engine/src/database/search.rs
+++ b/crates/grafeo-engine/src/database/search.rs
@@ -32,7 +32,7 @@ impl super::GrafeoDB {
             if let Some(storage) = map.get(&key) {
                 return grafeo_core::index::vector::VectorAccessorKind::Spilled(
                     grafeo_core::index::vector::SpillableVectorAccessor::new(
-                        &**self.lpg_store(),
+                        self.graph_store_ref(),
                         property,
                         std::sync::Arc::clone(storage)
                             as std::sync::Arc<dyn grafeo_core::index::vector::VectorStorage>,
@@ -41,7 +41,7 @@ impl super::GrafeoDB {
             }
         }
         grafeo_core::index::vector::VectorAccessorKind::Property(
-            grafeo_core::index::vector::PropertyVectorAccessor::new(&**self.lpg_store(), property),
+            grafeo_core::index::vector::PropertyVectorAccessor::new(self.graph_store_ref(), property),
         )
     }
 
@@ -54,7 +54,7 @@ impl super::GrafeoDB {
         property: &str,
     ) -> grafeo_core::index::vector::VectorAccessorKind<'a> {
         grafeo_core::index::vector::VectorAccessorKind::Property(
-            grafeo_core::index::vector::PropertyVectorAccessor::new(&**self.lpg_store(), property),
+            grafeo_core::index::vector::PropertyVectorAccessor::new(self.graph_store_ref(), property),
         )
     }
 
@@ -73,9 +73,11 @@ impl super::GrafeoDB {
     ) -> Option<std::collections::HashSet<NodeId>> {
         let filters = filters.filter(|f| !f.is_empty())?;
 
+        let graph = self.graph_store_ref();
+
         // Start with all nodes for this label
         let label_nodes: std::collections::HashSet<NodeId> =
-            self.lpg_store().nodes_by_label(label).into_iter().collect();
+            graph.nodes_by_label(label).into_iter().collect();
 
         let mut allowlist = label_nodes;
 
@@ -88,14 +90,13 @@ impl super::GrafeoDB {
                 // This is much faster when a prior filter has already narrowed the set.
                 let prop_key = grafeo_common::types::PropertyKey::new(key);
                 allowlist.retain(|&node_id| {
-                    self.lpg_store()
+                    graph
                         .get_node_property(node_id, &prop_key)
                         .is_some_and(|v| grafeo_core::LpgStore::matches_filter(&v, filter_value))
                 });
             } else {
                 // Equality filter: use indexed lookup when available
-                let matching: std::collections::HashSet<NodeId> = self
-                    .lpg_store()
+                let matching: std::collections::HashSet<NodeId> = graph
                     .find_nodes_by_property(key, filter_value)
                     .into_iter()
                     .collect();

--- a/crates/grafeo-engine/src/query/binder.rs
+++ b/crates/grafeo-engine/src/query/binder.rs
@@ -2529,7 +2529,7 @@ mod tests {
             property: "embedding".to_string(),
             label: Some("Doc".to_string()),
             query_vector: LogicalExpression::Variable("undefined_vec".to_string()),
-            k: 10,
+            k: Some(10),
             metric: None,
             min_similarity: None,
             max_distance: None,

--- a/crates/grafeo-engine/src/query/binder.rs
+++ b/crates/grafeo-engine/src/query/binder.rs
@@ -738,6 +738,33 @@ impl Binder {
                 Ok(())
             }
             LogicalOperator::Construct(construct) => self.bind_operator(&construct.input),
+            LogicalOperator::TextScan(scan) => {
+                // Register the node variable
+                self.context.add_variable(
+                    scan.variable.clone(),
+                    VariableInfo {
+                        name: scan.variable.clone(),
+                        data_type: LogicalType::Node,
+                        is_node: true,
+                        is_edge: false,
+                    },
+                );
+                // Optionally register the score column
+                if let Some(ref score_col) = scan.score_column {
+                    self.context.add_variable(
+                        score_col.clone(),
+                        VariableInfo {
+                            name: score_col.clone(),
+                            data_type: LogicalType::Float64,
+                            is_node: false,
+                            is_edge: false,
+                        },
+                    );
+                }
+                // Validate the query expression
+                self.validate_expression(&scan.query)?;
+                Ok(())
+            }
         }
     }
 

--- a/crates/grafeo-engine/src/query/optimizer/cardinality.rs
+++ b/crates/grafeo-engine/src/query/optimizer/cardinality.rs
@@ -17,7 +17,7 @@
 use crate::query::plan::{
     AggregateOp, BinaryOp, DistinctOp, ExpandOp, FilterOp, JoinOp, JoinType, LeftJoinOp, LimitOp,
     LogicalExpression, LogicalOperator, MultiWayJoinOp, NodeScanOp, ProjectOp, SkipOp, SortOp,
-    TripleComponent, TripleScanOp, UnaryOp, VectorJoinOp, VectorScanOp,
+    TextScanOp, TripleComponent, TripleScanOp, UnaryOp, VectorJoinOp, VectorScanOp,
 };
 use std::collections::HashMap;
 
@@ -705,6 +705,7 @@ impl CardinalityEstimator {
             LogicalOperator::MultiWayJoin(mwj) => self.estimate_multi_way_join(mwj),
             LogicalOperator::LeftJoin(lj) => self.estimate_left_join(lj),
             LogicalOperator::TripleScan(scan) => self.estimate_triple_scan(scan),
+            LogicalOperator::TextScan(scan) => self.estimate_text_scan(scan),
             _ => self.default_row_count as f64,
         }
     }
@@ -951,17 +952,42 @@ impl CardinalityEstimator {
     /// Vector scan returns at most k results (the k nearest neighbors).
     /// With similarity/distance filters, it may return fewer.
     fn estimate_vector_scan(&self, scan: &VectorScanOp) -> f64 {
-        let base_k = scan.k as f64;
-
-        // Apply filter selectivity if thresholds are specified
-        let selectivity = if scan.min_similarity.is_some() || scan.max_distance.is_some() {
-            // Assume 70% of results pass threshold filters
-            0.7
+        if let Some(k) = scan.k {
+            // Top-k mode: at most k results, reduced by filter selectivity
+            let selectivity = if scan.min_similarity.is_some() || scan.max_distance.is_some() {
+                0.7 // Assume 70% of results pass threshold filters
+            } else {
+                1.0
+            };
+            (k as f64 * selectivity).max(1.0)
         } else {
-            1.0
-        };
+            // Threshold-only mode: estimate 20% of indexed nodes match
+            let base = scan
+                .label
+                .as_deref()
+                .and_then(|l| self.table_stats.get(l))
+                .map_or(self.default_row_count as f64, |s| s.row_count as f64);
+            (base * 0.2).max(1.0)
+        }
+    }
 
-        (base_k * selectivity).max(1.0)
+    /// Estimates text scan cardinality using BM25 index.
+    ///
+    /// In top-k mode, returns at most k results. In threshold mode, assumes
+    /// 10% of the label's documents match the query.
+    fn estimate_text_scan(&self, scan: &TextScanOp) -> f64 {
+        if let Some(k) = scan.k {
+            // Top-k mode: at most k results
+            return k as f64;
+        }
+        // Threshold mode: estimate 10% of indexed documents match
+        let default_selectivity = 0.1;
+        let base = if let Some(stats) = self.table_stats.get(&scan.label) {
+            stats.row_count as f64
+        } else {
+            self.default_row_count as f64
+        };
+        (base * default_selectivity).max(1.0)
     }
 
     /// Estimates vector join cardinality.

--- a/crates/grafeo-engine/src/query/optimizer/cardinality.rs
+++ b/crates/grafeo-engine/src/query/optimizer/cardinality.rs
@@ -980,14 +980,18 @@ impl CardinalityEstimator {
             // Top-k mode: at most k results
             return k as f64;
         }
-        // Threshold mode: estimate 10% of indexed documents match
-        let default_selectivity = 0.1;
-        let base = if let Some(stats) = self.table_stats.get(&scan.label) {
-            stats.row_count as f64
-        } else {
-            self.default_row_count as f64
-        };
-        (base * default_selectivity).max(1.0)
+        if scan.threshold.is_some() {
+            // Threshold mode: estimate 10% of indexed documents match
+            let default_selectivity = 0.1;
+            let base = if let Some(stats) = self.table_stats.get(&scan.label) {
+                stats.row_count as f64
+            } else {
+                self.default_row_count as f64
+            };
+            return (base * default_selectivity).max(1.0);
+        }
+        // Default top-k(100) — matches executor fallback
+        100.0
     }
 
     /// Estimates vector join cardinality.

--- a/crates/grafeo-engine/src/query/optimizer/cost.rs
+++ b/crates/grafeo-engine/src/query/optimizer/cost.rs
@@ -5,7 +5,7 @@
 use crate::query::plan::{
     AggregateOp, DistinctOp, ExpandDirection, ExpandOp, FilterOp, JoinOp, JoinType, LeftJoinOp,
     LimitOp, LogicalOperator, MultiWayJoinOp, NodeScanOp, ProjectOp, ReturnOp, SkipOp, SortOp,
-    VectorJoinOp, VectorScanOp,
+    TextScanOp, VectorJoinOp, VectorScanOp,
 };
 use std::collections::HashMap;
 
@@ -233,6 +233,7 @@ impl CostModel {
                 let right_card = self.estimate_child_cardinality(&lj.right);
                 self.left_join_cost(lj, cardinality, left_card, right_card)
             }
+            LogicalOperator::TextScan(scan) => self.text_scan_cost(scan, cardinality),
             _ => Cost::cpu(cardinality * self.cpu_tuple_cost),
         }
     }
@@ -466,25 +467,40 @@ impl CostModel {
     /// HNSW index search is O(log N) per query, while brute-force is O(N).
     /// This estimates the HNSW case with ef search parameter.
     fn vector_scan_cost(&self, scan: &VectorScanOp, cardinality: f64) -> Cost {
-        // k determines output cardinality
-        let k = scan.k as f64;
+        let k = scan.k.unwrap_or(0) as f64;
+        let n = cardinality.max(1.0);
 
         // HNSW search cost: O(ef * log(N)) distance computations
-        // Assume ef = 64 (default), N = cardinality
+        // Brute-force: O(N) distance computations
         let ef = 64.0;
-        let n = cardinality.max(1.0);
         let search_cost = if scan.index_name.is_some() {
-            // HNSW: O(ef * log N)
-            ef * n.ln() * self.cpu_tuple_cost * 10.0 // Distance computation is ~10x regular tuple
+            ef * n.ln() * self.cpu_tuple_cost * 10.0
         } else {
-            // Brute-force: O(N)
             n * self.cpu_tuple_cost * 10.0
         };
 
-        // Memory for candidate heap
-        let memory = k * self.avg_tuple_size * 2.0;
+        // Memory for candidate heap (threshold mode uses cardinality estimate)
+        let output_rows = if k > 0.0 { k } else { cardinality };
+        let memory = output_rows * self.avg_tuple_size * 2.0;
 
         Cost::cpu(search_cost).with_memory(memory)
+    }
+
+    /// Estimates the cost of a text scan operation.
+    ///
+    /// BM25 scoring requires iterating over postings lists proportional to the
+    /// corpus size, with scoring being ~5x more expensive than a plain tuple
+    /// comparison. The index is in-memory so I/O cost is zero.
+    fn text_scan_cost(&self, scan: &TextScanOp, cardinality: f64) -> Cost {
+        // Use actual label row count for corpus size (BM25 scans the postings).
+        let corpus_size = self
+            .label_cardinalities
+            .get(&scan.label)
+            .copied()
+            .map_or(cardinality, |c| c as f64);
+        // BM25 scoring is ~5x a simple tuple comparison
+        let cpu = corpus_size * self.cpu_tuple_cost * 5.0;
+        Cost::cpu(cpu).with_memory(cardinality * self.avg_tuple_size)
     }
 
     /// Estimates the cost of a vector join operation.

--- a/crates/grafeo-engine/src/query/optimizer/cost.rs
+++ b/crates/grafeo-engine/src/query/optimizer/cost.rs
@@ -625,6 +625,7 @@ impl CostModel {
                 children_cost + self.multi_way_join_cost(mwj, cardinality)
             }
             LogicalOperator::Empty => Cost::zero(),
+            LogicalOperator::TextScan(scan) => self.text_scan_cost(scan, cardinality),
             _ => Cost::cpu(cardinality * self.cpu_tuple_cost),
         }
     }

--- a/crates/grafeo-engine/src/query/plan.rs
+++ b/crates/grafeo-engine/src/query/plan.rs
@@ -271,6 +271,9 @@ pub enum LogicalOperator {
     /// - Combining multiple vector sources with graph structure
     VectorJoin(VectorJoinOp),
 
+    /// Scan using full-text search with BM25 scoring.
+    TextScan(TextScanOp),
+
     // ==================== Set Operations ====================
     /// Set difference: rows in left that are not in right.
     Except(ExceptOp),
@@ -347,7 +350,7 @@ impl LogicalOperator {
             Self::MapCollect(op) => op.input.has_mutations(),
             Self::Return(op) => op.input.has_mutations(),
             Self::HorizontalAggregate(op) => op.input.has_mutations(),
-            Self::VectorScan(_) | Self::VectorJoin(_) => false,
+            Self::VectorScan(_) | Self::VectorJoin(_) | Self::TextScan(_) => false,
 
             // Operators with two children
             Self::Join(op) => op.left.has_mutations() || op.right.has_mutations(),
@@ -444,7 +447,8 @@ impl LogicalOperator {
             | Self::MoveGraph(_)
             | Self::AddGraph(_)
             | Self::CreatePropertyGraph(_)
-            | Self::LoadData(_) => vec![],
+            | Self::LoadData(_)
+            | Self::TextScan(_) => vec![],
         }
     }
 
@@ -579,6 +583,7 @@ impl LogicalOperator {
             Self::Apply(_) => String::new(),
             Self::VectorScan(op) => op.variable.clone(),
             Self::VectorJoin(op) => op.right_variable.clone(),
+            Self::TextScan(op) => format!("{}:{}", op.variable, op.label),
             _ => String::new(),
         }
     }
@@ -925,6 +930,42 @@ impl LogicalOperator {
                 if let Some(input) = &op.input {
                     input.fmt_tree(out, depth + 1);
                 }
+            }
+            Self::VectorScan(op) => {
+                let metric = op.metric.map_or("default", |m| match m {
+                    VectorMetric::Cosine => "cosine",
+                    VectorMetric::Euclidean => "euclidean",
+                    VectorMetric::DotProduct => "dot_product",
+                    VectorMetric::Manhattan => "manhattan",
+                });
+                let mode = match op.k {
+                    Some(k) => format!("top-{k}"),
+                    None => "threshold".to_string(),
+                };
+                let _ = writeln!(
+                    out,
+                    "{indent}VectorScan ({var}:{label}.{prop}, {metric}, {mode})",
+                    var = op.variable,
+                    label = op.label.as_deref().unwrap_or("*"),
+                    prop = op.property,
+                );
+                if let Some(input) = &op.input {
+                    input.fmt_tree(out, depth + 1);
+                }
+            }
+            Self::TextScan(op) => {
+                let mode = match op.k {
+                    Some(k) => format!("top-{k}"),
+                    None => "threshold".to_string(),
+                };
+                let query = fmt_expr(&op.query);
+                let _ = writeln!(
+                    out,
+                    "{indent}TextScan ({var}:{label}.{prop}, query={query}, {mode})",
+                    var = op.variable,
+                    label = op.label,
+                    prop = op.property,
+                );
             }
             Self::Empty => {
                 let _ = writeln!(out, "{indent}Empty");
@@ -1872,8 +1913,8 @@ pub struct VectorScanOp {
     pub label: Option<String>,
     /// The query vector expression.
     pub query_vector: LogicalExpression,
-    /// Number of nearest neighbors to return.
-    pub k: usize,
+    /// Number of nearest neighbors to return (None = threshold mode only).
+    pub k: Option<usize>,
     /// Distance metric (None = use index default, typically cosine).
     pub metric: Option<VectorMetric>,
     /// Minimum similarity threshold (filters results below this).
@@ -1948,6 +1989,25 @@ pub struct VectorJoinOp {
     pub max_distance: Option<f32>,
     /// Variable to bind the distance/similarity score.
     pub score_variable: Option<String>,
+}
+
+/// Text search scan using BM25 inverted index.
+#[derive(Debug, Clone)]
+pub struct TextScanOp {
+    /// Variable to bind matched nodes.
+    pub variable: String,
+    /// Label of nodes to search.
+    pub label: String,
+    /// Property holding the text to search.
+    pub property: String,
+    /// The search query expression (must resolve to a string).
+    pub query: LogicalExpression,
+    /// Top-k limit (None = threshold mode or default 100).
+    pub k: Option<usize>,
+    /// Minimum score threshold (None = top-k mode).
+    pub threshold: Option<f64>,
+    /// Optional column name to bind the BM25 score.
+    pub score_column: Option<String>,
 }
 
 /// Return results (terminal operator).

--- a/crates/grafeo-engine/src/query/planner/lpg/filter.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/filter.rs
@@ -8,6 +8,9 @@ use super::{
     UnionOperator, Value, convert_binary_op, convert_filter_expression,
 };
 
+#[cfg(feature = "text-index")]
+use super::Error;
+
 /// Cross-type equality comparison with Int64/Float64 coercion.
 fn values_equal_coerced(a: &Value, b: &Value) -> bool {
     match (a, b) {
@@ -71,6 +74,24 @@ impl super::Planner {
 
         // Try to use range optimization for range predicates (>, <, >=, <=)
         if let Some(result) = self.try_plan_filter_with_range_index(filter)? {
+            return Ok(result);
+        }
+
+        // Try compound hybrid first (both vector AND/OR text in same predicate)
+        #[cfg(all(feature = "vector-index", feature = "text-index"))]
+        if let Some(result) = self.try_plan_filter_compound_hybrid(filter)? {
+            return Ok(result);
+        }
+
+        // Try to use vector index for similarity/distance predicates
+        #[cfg(feature = "vector-index")]
+        if let Some(result) = self.try_plan_filter_with_vector_index(filter)? {
+            return Ok(result);
+        }
+
+        // Try to use text index for text_score/text_match predicates
+        #[cfg(feature = "text-index")]
+        if let Some(result) = self.try_plan_filter_with_text_index(filter)? {
             return Ok(result);
         }
 
@@ -1261,5 +1282,653 @@ impl super::Planner {
         };
 
         Some((left_var, left_prop, min_val, max_val, min_inc, max_inc))
+    }
+}
+
+/// Extracted vector predicate from a filter expression.
+#[cfg(feature = "vector-index")]
+struct ExtractedVectorPredicate {
+    property: String,
+    /// Variable bound in the property access (e.g. `n` in `n.embedding`).
+    /// Validated against the enclosing NodeScan variable before pushdown.
+    variable: String,
+    query_vector: LogicalExpression,
+    metric: super::VectorMetric,
+    min_similarity: Option<f32>,
+    max_distance: Option<f32>,
+    remaining: Option<LogicalExpression>,
+}
+
+#[cfg(feature = "vector-index")]
+impl super::Planner {
+    /// Tries to push a vector similarity/distance predicate down into a VectorScan operator.
+    ///
+    /// Recognizes patterns like:
+    /// - `cosine_similarity(n.embedding, $qv) > 0.8`
+    /// - `euclidean_distance(n.embedding, $qv) < 0.5`
+    ///
+    /// Returns `Ok(Some((operator, columns)))` if rewritten, `Ok(None)` otherwise.
+    pub(super) fn try_plan_filter_with_vector_index(
+        &self,
+        filter: &super::FilterOp,
+    ) -> Result<Option<(Box<dyn Operator>, Vec<String>)>> {
+        // Only push down when input is a full label scan (no nested input)
+        let LogicalOperator::NodeScan(scan) = filter.input.as_ref() else {
+            return Ok(None);
+        };
+        let Some(ref label) = scan.label else {
+            return Ok(None);
+        };
+
+        // Extract a vector predicate from the filter expression
+        let Some(extracted) = self.extract_vector_predicate(&filter.predicate) else {
+            return Ok(None);
+        };
+
+        // Ensure the predicate references the same variable as the scan being planned
+        if extracted.variable != scan.variable {
+            return Ok(None);
+        }
+
+        // Check that a vector index exists (or fall through to brute-force eval)
+        if !self.store.has_vector_index(label, &extracted.property) {
+            return Ok(None);
+        }
+
+        // Build VectorScanOp
+        let vector_scan = super::VectorScanOp {
+            variable: scan.variable.clone(),
+            index_name: Some(format!("{}:{}", label, extracted.property)),
+            property: extracted.property.clone(),
+            label: Some(label.clone()),
+            query_vector: extracted.query_vector.clone(),
+            k: None, // threshold mode — filter by similarity/distance, no top-k limit
+            metric: Some(extracted.metric),
+            min_similarity: extracted.min_similarity,
+            max_distance: extracted.max_distance,
+            input: None,
+        };
+
+        // Plan through the VectorScan path
+        let (scan_op, scan_columns) =
+            self.plan_operator(&LogicalOperator::VectorScan(vector_scan))?;
+
+        // If there are remaining predicates (AND with non-vector conditions), wrap in filter
+        if let Some(remaining) = &extracted.remaining {
+            let variable_columns: HashMap<String, usize> = scan_columns
+                .iter()
+                .enumerate()
+                .map(|(i, name)| (name.clone(), i))
+                .collect();
+            let filter_expr = self.convert_expression(remaining)?;
+            let predicate = ExpressionPredicate::new(
+                filter_expr,
+                variable_columns,
+                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+            )
+            .with_transaction_context(self.viewing_epoch, self.transaction_id)
+            .with_session_context(self.session_context.clone());
+            let filter_op = Box::new(FilterOperator::new(scan_op, Box::new(predicate)));
+            Ok(Some((filter_op, scan_columns)))
+        } else {
+            Ok(Some((scan_op, scan_columns)))
+        }
+    }
+
+    /// Recursively extracts a vector predicate from a (potentially compound) expression.
+    fn extract_vector_predicate(
+        &self,
+        expr: &LogicalExpression,
+    ) -> Option<ExtractedVectorPredicate> {
+        match expr {
+            LogicalExpression::Binary { left, op, right } => {
+                // Try the left side as a vector function call
+                if let LogicalExpression::FunctionCall { name, args, .. } = left.as_ref() {
+                    if let Some(extracted) = self.try_extract_vector_fn(name, args, op, right) {
+                        return Some(extracted);
+                    }
+                }
+                // AND: recurse into both sides, accumulating remaining predicates
+                if *op == BinaryOp::And {
+                    if let Some(mut extracted) = self.extract_vector_predicate(left) {
+                        extracted.remaining = Some(match extracted.remaining {
+                            Some(prev) => LogicalExpression::Binary {
+                                left: Box::new(prev),
+                                op: BinaryOp::And,
+                                right: right.clone(),
+                            },
+                            None => *right.clone(),
+                        });
+                        return Some(extracted);
+                    }
+                    if let Some(mut extracted) = self.extract_vector_predicate(right) {
+                        extracted.remaining = Some(match extracted.remaining {
+                            Some(prev) => LogicalExpression::Binary {
+                                left: left.clone(),
+                                op: BinaryOp::And,
+                                right: Box::new(prev),
+                            },
+                            None => *left.clone(),
+                        });
+                        return Some(extracted);
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    /// Tries to extract a vector function call predicate.
+    ///
+    /// Recognizes: `cosine_similarity(n.prop, vec) > threshold`
+    /// and the distance variants: `euclidean_distance(n.prop, vec) < threshold`
+    fn try_extract_vector_fn(
+        &self,
+        name: &str,
+        args: &[LogicalExpression],
+        op: &BinaryOp,
+        threshold: &LogicalExpression,
+    ) -> Option<ExtractedVectorPredicate> {
+        if args.len() != 2 {
+            return None;
+        }
+
+        let (metric, is_similarity) = match name {
+            "cosine_similarity" => (super::VectorMetric::Cosine, true),
+            "dot_product" => (super::VectorMetric::DotProduct, true),
+            "euclidean_distance" => (super::VectorMetric::Euclidean, false),
+            "manhattan_distance" => (super::VectorMetric::Manhattan, false),
+            _ => return None,
+        };
+
+        // Similarity: >, >= threshold.  Distance: <, <= threshold.
+        let valid_op = if is_similarity {
+            matches!(op, BinaryOp::Gt | BinaryOp::Ge)
+        } else {
+            matches!(op, BinaryOp::Lt | BinaryOp::Le)
+        };
+        if !valid_op {
+            return None;
+        }
+
+        // One arg must be a property access, the other a vector literal/parameter
+        let (variable, property, query_vector) =
+            if let LogicalExpression::Property { variable, property } = &args[0] {
+                (variable.clone(), property.clone(), args[1].clone())
+            } else if let LogicalExpression::Property { variable, property } = &args[1] {
+                (variable.clone(), property.clone(), args[0].clone())
+            } else {
+                return None;
+            };
+
+        // Extract threshold value
+        let threshold_val = match threshold {
+            LogicalExpression::Literal(Value::Float64(v)) => *v as f32,
+            LogicalExpression::Literal(Value::Int64(v)) => *v as f32,
+            _ => return None,
+        };
+
+        let (min_similarity, max_distance) = if is_similarity {
+            (Some(threshold_val), None)
+        } else {
+            (None, Some(threshold_val))
+        };
+
+        Some(ExtractedVectorPredicate {
+            property,
+            variable,
+            query_vector,
+            metric,
+            min_similarity,
+            max_distance,
+            remaining: None,
+        })
+    }
+}
+
+/// Extracted text predicate from a filter expression.
+#[cfg(feature = "text-index")]
+struct ExtractedTextPredicate {
+    property: String,
+    /// Variable bound in the property access (e.g. `n` in `n.body`).
+    /// Validated against the enclosing NodeScan variable before pushdown.
+    variable: String,
+    query_expr: LogicalExpression,
+    threshold: f64,
+    remaining: Option<LogicalExpression>,
+}
+
+#[cfg(feature = "text-index")]
+impl super::Planner {
+    /// Tries to push a text search predicate down into a TextScan operator.
+    ///
+    /// Recognizes patterns like:
+    /// - `text_score(n.body, "search terms") > 0.5`
+    /// - `text_match(n.body, "search terms")`  (standalone boolean)
+    ///
+    /// Errors if the required text index does not exist (design decision D2).
+    ///
+    /// Returns `Ok(Some((operator, columns)))` if rewritten, `Ok(None)` otherwise.
+    pub(super) fn try_plan_filter_with_text_index(
+        &self,
+        filter: &super::FilterOp,
+    ) -> Result<Option<(Box<dyn Operator>, Vec<String>)>> {
+        // Only push down when input is a full label scan (no nested input)
+        let LogicalOperator::NodeScan(scan) = filter.input.as_ref() else {
+            return Ok(None);
+        };
+        let Some(ref label) = scan.label else {
+            return Ok(None);
+        };
+
+        // Extract a text predicate from the filter expression
+        let Some(extracted) = self.extract_text_predicate(&filter.predicate) else {
+            return Ok(None);
+        };
+
+        // Ensure the predicate references the same variable as the scan being planned
+        if extracted.variable != scan.variable {
+            return Ok(None);
+        }
+
+        // Check that a text index exists — error if missing (unlike vector which falls through)
+        if !self.store.has_text_index(label, &extracted.property) {
+            return Err(Error::InvalidValue(format!(
+                "text_score/text_match requires a text index on ({}, {}). \
+                 Create one with: CREATE TEXT INDEX ON :{}({})",
+                label, extracted.property, label, extracted.property
+            )));
+        }
+
+        // Build TextScanOp — always project the score column so downstream
+        // RETURN/ORDER BY expressions can reference it instead of recomputing.
+        let text_scan = super::TextScanOp {
+            variable: scan.variable.clone(),
+            property: extracted.property.clone(),
+            label: label.clone(),
+            query: extracted.query_expr.clone(),
+            k: None,
+            threshold: Some(extracted.threshold),
+            score_column: Some(format!("_tscore_{}", scan.variable)),
+        };
+
+        // Plan through the TextScan path
+        let (scan_op, scan_columns) =
+            self.plan_operator(&LogicalOperator::TextScan(text_scan))?;
+
+        // If there are remaining predicates (AND with non-text conditions), wrap in filter
+        if let Some(remaining) = &extracted.remaining {
+            let variable_columns: HashMap<String, usize> = scan_columns
+                .iter()
+                .enumerate()
+                .map(|(i, name)| (name.clone(), i))
+                .collect();
+            let filter_expr = self.convert_expression(remaining)?;
+            let predicate = ExpressionPredicate::new(
+                filter_expr,
+                variable_columns,
+                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+            )
+            .with_transaction_context(self.viewing_epoch, self.transaction_id)
+            .with_session_context(self.session_context.clone());
+            let filter_op = Box::new(FilterOperator::new(scan_op, Box::new(predicate)));
+            Ok(Some((filter_op, scan_columns)))
+        } else {
+            Ok(Some((scan_op, scan_columns)))
+        }
+    }
+
+    /// Recursively extracts a text predicate from a (potentially compound) expression.
+    fn extract_text_predicate(
+        &self,
+        expr: &LogicalExpression,
+    ) -> Option<ExtractedTextPredicate> {
+        match expr {
+            LogicalExpression::Binary { left, op, right } => {
+                // text_score(n.prop, "query") > threshold
+                if let LogicalExpression::FunctionCall { name, args, .. } = left.as_ref() {
+                    if name == "text_score" && matches!(op, BinaryOp::Gt | BinaryOp::Ge) {
+                        if let Some(extracted) = self.try_extract_text_fn(args, right) {
+                            return Some(extracted);
+                        }
+                    }
+                }
+                // AND: recurse into both sides, accumulating remaining predicates
+                if *op == BinaryOp::And {
+                    // Try left as text, right as remaining
+                    if let Some(mut extracted) = self.extract_text_predicate(left) {
+                        extracted.remaining = Some(match extracted.remaining {
+                            Some(prev) => LogicalExpression::Binary {
+                                left: Box::new(prev),
+                                op: BinaryOp::And,
+                                right: right.clone(),
+                            },
+                            None => *right.clone(),
+                        });
+                        return Some(extracted);
+                    }
+                    // Try right as text, left as remaining
+                    if let Some(mut extracted) = self.extract_text_predicate(right) {
+                        extracted.remaining = Some(match extracted.remaining {
+                            Some(prev) => LogicalExpression::Binary {
+                                left: left.clone(),
+                                op: BinaryOp::And,
+                                right: Box::new(prev),
+                            },
+                            None => *left.clone(),
+                        });
+                        return Some(extracted);
+                    }
+                }
+                None
+            }
+            // text_match(n.prop, "query") — standalone boolean (score > 0.0)
+            LogicalExpression::FunctionCall { name, args, .. } if name == "text_match" => {
+                self.try_extract_text_fn(args, &LogicalExpression::Literal(Value::Float64(0.0)))
+            }
+            _ => None,
+        }
+    }
+
+    /// Tries to extract the property, variable, query expression, and threshold
+    /// from a `text_score` or `text_match` argument list.
+    fn try_extract_text_fn(
+        &self,
+        args: &[LogicalExpression],
+        threshold_expr: &LogicalExpression,
+    ) -> Option<ExtractedTextPredicate> {
+        if args.len() != 2 {
+            return None;
+        }
+
+        let LogicalExpression::Property { variable, property } = &args[0] else {
+            return None;
+        };
+
+        let threshold = match threshold_expr {
+            LogicalExpression::Literal(Value::Float64(v)) => *v,
+            LogicalExpression::Literal(Value::Int64(v)) => *v as f64,
+            _ => return None,
+        };
+
+        Some(ExtractedTextPredicate {
+            property: property.clone(),
+            variable: variable.clone(),
+            query_expr: args[1].clone(),
+            threshold,
+            remaining: None,
+        })
+    }
+}
+
+#[cfg(all(feature = "vector-index", feature = "text-index"))]
+impl super::Planner {
+    /// Tries to plan a filter that contains BOTH a vector predicate and a text predicate.
+    ///
+    /// When both predicates are present, runs both index scans independently and
+    /// hash-joins the results: intersect (Inner join) for AND, union (Full join) for OR.
+    /// Both scores are projected as columns for downstream use.
+    ///
+    /// For AND: extractors recurse into the AND tree (finding vector/text anywhere).
+    /// For OR: extracts from each OR operand independently, requiring each side
+    /// to be a pure vector or text predicate (no mixed scalar conditions).
+    ///
+    /// Falls through to individual checks when only one predicate is present.
+    pub(super) fn try_plan_filter_compound_hybrid(
+        &self,
+        filter: &super::FilterOp,
+    ) -> Result<Option<(Box<dyn Operator>, Vec<String>)>> {
+        let LogicalOperator::NodeScan(scan) = filter.input.as_ref() else {
+            return Ok(None);
+        };
+        let Some(ref label) = scan.label else {
+            return Ok(None);
+        };
+
+        // Extract vector and text predicates. Strategy depends on AND vs OR.
+        let (vector_pred, text_pred, is_or) =
+            if let LogicalExpression::Binary {
+                left,
+                op: BinaryOp::Or,
+                right,
+            } = &filter.predicate
+            {
+                // OR: extract from each operand independently.
+                // Try vector-left + text-right, then vector-right + text-left.
+                let result = self
+                    .extract_vector_predicate(left)
+                    .and_then(|v| self.extract_text_predicate(right).map(|t| (v, t)))
+                    .or_else(|| {
+                        self.extract_vector_predicate(right)
+                            .and_then(|v| self.extract_text_predicate(left).map(|t| (v, t)))
+                    });
+                let Some((v, t)) = result else {
+                    return Ok(None);
+                };
+                (v, t, true)
+            } else {
+                // AND: extractors recurse into the AND tree (existing behavior).
+                let vector = self.extract_vector_predicate(&filter.predicate);
+                let text = self.extract_text_predicate(&filter.predicate);
+                match (vector, text) {
+                    (Some(v), Some(t)) => (v, t, false),
+                    _ => return Ok(None),
+                }
+            };
+
+        // Validate both reference the scan variable
+        if vector_pred.variable != scan.variable || text_pred.variable != scan.variable {
+            return Ok(None);
+        }
+
+        // Check both indexes exist; fall through for missing vector index,
+        // error for missing text index (consistent with individual text pushdown)
+        if !self.store.has_vector_index(label, &vector_pred.property) {
+            return Ok(None);
+        }
+        if !self.store.has_text_index(label, &text_pred.property) {
+            return Err(Error::InvalidValue(format!(
+                "text_score/text_match requires a text index on ({}, {}). \
+                 Create one with: CREATE TEXT INDEX ON :{}({})",
+                label, text_pred.property, label, text_pred.property
+            )));
+        }
+
+        // Build VectorScanOp (threshold mode — return all candidates above threshold)
+        let vector_scan_op = LogicalOperator::VectorScan(super::VectorScanOp {
+            variable: scan.variable.clone(),
+            index_name: Some(format!("{}:{}", label, vector_pred.property)),
+            property: vector_pred.property.clone(),
+            label: Some(label.clone()),
+            query_vector: vector_pred.query_vector.clone(),
+            k: None, // threshold mode
+            metric: Some(vector_pred.metric),
+            min_similarity: vector_pred.min_similarity,
+            max_distance: vector_pred.max_distance,
+            input: None,
+        });
+
+        // Build TextScanOp (threshold mode — always project score column)
+        let text_scan_op = LogicalOperator::TextScan(super::TextScanOp {
+            variable: scan.variable.clone(),
+            property: text_pred.property.clone(),
+            label: label.clone(),
+            query: text_pred.query_expr.clone(),
+            k: None,
+            threshold: Some(text_pred.threshold),
+            score_column: Some(format!("_tscore_{}", scan.variable)),
+        });
+
+        let (left_op, left_cols) = self.plan_operator(&vector_scan_op)?;
+        let (right_op, right_cols) = self.plan_operator(&text_scan_op)?;
+
+        // For OR with scalar remainders on either branch, wrap that branch
+        // in a filter before the join. E.g., for
+        //   cosine_similarity(...) > 0.8 OR (text_match(...) AND published = true)
+        // the text branch gets a Filter(published = true) around its TextScan.
+        let left_op = if let Some(remaining) = &vector_pred.remaining {
+            let variable_columns: HashMap<String, usize> = left_cols
+                .iter()
+                .enumerate()
+                .map(|(i, name)| (name.clone(), i))
+                .collect();
+            let filter_expr = self.convert_expression(remaining)?;
+            let predicate = ExpressionPredicate::new(
+                filter_expr,
+                variable_columns,
+                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+            )
+            .with_transaction_context(self.viewing_epoch, self.transaction_id)
+            .with_session_context(self.session_context.clone());
+            Box::new(FilterOperator::new(left_op, Box::new(predicate))) as Box<dyn Operator>
+        } else {
+            left_op
+        };
+
+        let right_op = if let Some(remaining) = &text_pred.remaining {
+            let variable_columns: HashMap<String, usize> = right_cols
+                .iter()
+                .enumerate()
+                .map(|(i, name)| (name.clone(), i))
+                .collect();
+            let filter_expr = self.convert_expression(remaining)?;
+            let predicate = ExpressionPredicate::new(
+                filter_expr,
+                variable_columns,
+                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+            )
+            .with_transaction_context(self.viewing_epoch, self.transaction_id)
+            .with_session_context(self.session_context.clone());
+            Box::new(FilterOperator::new(right_op, Box::new(predicate))) as Box<dyn Operator>
+        } else {
+            right_op
+        };
+
+        // Determine join type: AND → Inner (intersect), OR → Full (union)
+        let join_type = if is_or {
+            PhysicalJoinType::Full
+        } else {
+            PhysicalJoinType::Inner
+        };
+
+        // HashJoin outputs all left columns + all right columns.
+        // Right side: [variable, _tscore_variable]. The variable column is a duplicate
+        // of left column 0 and must be projected out.
+        let mut all_cols = left_cols.clone();
+        all_cols.extend(right_cols.iter().cloned());
+        let all_schema = self.derive_schema_from_columns(&all_cols);
+
+        let join_op: Box<dyn Operator> = Box::new(HashJoinOperator::new(
+            left_op,
+            right_op,
+            vec![0], // probe key: column 0 (NodeId / variable)
+            vec![0], // build key: column 0 (NodeId / variable)
+            join_type,
+            all_schema,
+        ));
+
+        // Project out the duplicate node-variable column from the right side.
+        // left_cols = [variable, _vscore_variable]  (indices 0, 1)
+        // right_cols = [variable, _tscore_variable]  (indices 2, 3 in all_cols)
+        // Output: [variable, _vscore_variable, _tscore_variable]
+        //
+        // For OR (Full join): right-only rows have NULL in left column 0.
+        // Use COALESCE(left_var, right_var) so the variable is always non-NULL.
+        let left_count = left_cols.len();
+        let mut proj_exprs: Vec<super::ProjectExpr> = Vec::new();
+        let mut output_cols: Vec<String> = Vec::new();
+
+        for (i, col) in left_cols.iter().enumerate() {
+            if i == 0 && is_or {
+                // For OR joins, coalesce the variable from both sides
+                proj_exprs.push(super::ProjectExpr::Coalesce {
+                    first: 0,
+                    second: left_count,
+                });
+            } else {
+                proj_exprs.push(super::ProjectExpr::Column(i));
+            }
+            output_cols.push(col.clone());
+        }
+        for (i, col) in right_cols.iter().enumerate() {
+            if i == 0 {
+                continue; // Duplicate variable column (merged via Coalesce above)
+            }
+            proj_exprs.push(super::ProjectExpr::Column(left_count + i));
+            output_cols.push(col.clone());
+        }
+
+        let proj_schema = self.derive_schema_from_columns(&output_cols);
+        let proj_op: Box<dyn Operator> =
+            Box::new(super::ProjectOperator::new(join_op, proj_exprs, proj_schema));
+
+        // Apply any remaining scalar predicates (parts of the expression that are
+        // neither vector nor text, e.g. an extra AND condition)
+        let scalar_remaining = self.extract_scalar_remaining(&filter.predicate);
+        if let Some(remaining) = scalar_remaining {
+            let variable_columns: HashMap<String, usize> = output_cols
+                .iter()
+                .enumerate()
+                .map(|(i, name)| (name.clone(), i))
+                .collect();
+            let filter_expr = self.convert_expression(&remaining)?;
+            let predicate = ExpressionPredicate::new(
+                filter_expr,
+                variable_columns,
+                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+            )
+            .with_transaction_context(self.viewing_epoch, self.transaction_id)
+            .with_session_context(self.session_context.clone());
+            Ok(Some((
+                Box::new(FilterOperator::new(proj_op, Box::new(predicate))),
+                output_cols,
+            )))
+        } else {
+            Ok(Some((proj_op, output_cols)))
+        }
+    }
+
+    /// Extracts the parts of a predicate that are neither a vector nor a text sub-predicate.
+    ///
+    /// Recursively walks AND trees. At each leaf (non-AND node), checks whether
+    /// it is a vector or text predicate. Keeps only the scalar (non-index) parts.
+    /// Used to find conditions that must be applied after the hash join.
+    fn extract_scalar_remaining(
+        &self,
+        expr: &LogicalExpression,
+    ) -> Option<LogicalExpression> {
+        match expr {
+            LogicalExpression::Binary {
+                left,
+                op: BinaryOp::And,
+                right,
+            } => {
+                // Recurse into both sides of AND
+                let left_scalar = self.extract_scalar_remaining(left);
+                let right_scalar = self.extract_scalar_remaining(right);
+
+                match (left_scalar, right_scalar) {
+                    (Some(l), Some(r)) => Some(LogicalExpression::Binary {
+                        left: Box::new(l),
+                        op: BinaryOp::And,
+                        right: Box::new(r),
+                    }),
+                    (Some(l), None) => Some(l),
+                    (None, Some(r)) => Some(r),
+                    (None, None) => None,
+                }
+            }
+            // Leaf node: check if it's a vector or text predicate
+            other => {
+                let is_vector = self.extract_vector_predicate(other).is_some();
+                let is_text = self.extract_text_predicate(other).is_some();
+                if is_vector || is_text {
+                    None // Handled by index scan, drop it
+                } else {
+                    Some(other.clone()) // Scalar predicate, keep it
+                }
+            }
+        }
     }
 }

--- a/crates/grafeo-engine/src/query/planner/lpg/filter.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/filter.rs
@@ -1919,6 +1919,20 @@ impl super::Planner {
                     (None, None) => None,
                 }
             }
+            LogicalExpression::Binary {
+                left,
+                op: BinaryOp::Or,
+                right,
+            } => {
+                // If both sides of OR are index predicates, the full-join
+                // already computes the union — no scalar filter needed.
+                let left_remaining = self.extract_scalar_remaining(left);
+                let right_remaining = self.extract_scalar_remaining(right);
+                match (left_remaining, right_remaining) {
+                    (None, None) => None,
+                    _ => Some(expr.clone()),
+                }
+            }
             // Leaf node: check if it's a vector or text predicate
             other => {
                 let is_vector = self.extract_vector_predicate(other).is_some();

--- a/crates/grafeo-engine/src/query/planner/lpg/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/mod.rs
@@ -21,8 +21,10 @@ use crate::query::plan::{
     HorizontalAggregateOp, IntersectOp, JoinOp, JoinType, LeftJoinOp, LimitOp, LogicalExpression,
     LogicalOperator, LogicalPlan, MapCollectOp, MergeOp, MergeRelationshipOp, MultiWayJoinOp,
     NodeScanOp, OtherwiseOp, PathMode, RemoveLabelOp, ReturnOp, SetPropertyOp, ShortestPathOp,
-    SkipOp, SortOp, SortOrder, UnaryOp, UnionOp, UnwindOp,
+    SkipOp, SortOp, SortOrder, TextScanOp, UnaryOp, UnionOp, UnwindOp,
 };
+#[cfg(feature = "vector-index")]
+use crate::query::plan::{VectorMetric, VectorScanOp};
 use grafeo_common::grafeo_debug_span;
 use grafeo_common::types::{EpochId, TransactionId};
 use grafeo_common::types::{LogicalType, Value};
@@ -656,11 +658,20 @@ impl Planner {
                 Ok((operator, vec![load.variable.clone()]))
             }
             LogicalOperator::Empty => Err(Error::Internal("Empty plan".to_string())),
+            #[cfg(feature = "vector-index")]
+            LogicalOperator::VectorScan(scan) => self.plan_vector_scan(scan),
+            #[cfg(not(feature = "vector-index"))]
             LogicalOperator::VectorScan(_) => Err(Error::Internal(
                 "VectorScan requires vector-index feature".to_string(),
             )),
             LogicalOperator::VectorJoin(_) => Err(Error::Internal(
                 "VectorJoin requires vector-index feature".to_string(),
+            )),
+            #[cfg(feature = "text-index")]
+            LogicalOperator::TextScan(scan) => self.plan_text_scan(scan),
+            #[cfg(not(feature = "text-index"))]
+            LogicalOperator::TextScan(_) => Err(Error::Internal(
+                "TextScan requires text-index feature".to_string(),
             )),
             _ => Err(Error::Internal(format!(
                 "Unsupported operator: {:?}",
@@ -737,6 +748,169 @@ impl Planner {
         let operator = Box::new(MapCollectOperator::new(child_op, key_idx, value_idx));
         self.scalar_columns.borrow_mut().insert(mc.alias.clone());
         Ok((operator, vec![mc.alias.clone()]))
+    }
+
+    /// Plans a text search scan operator using BM25 inverted index.
+    #[cfg(feature = "text-index")]
+    fn plan_text_scan(&self, scan: &TextScanOp) -> Result<(Box<dyn Operator>, Vec<String>)> {
+        use grafeo_core::execution::operators::TextScanOperator;
+
+        let query_string = match &scan.query {
+            LogicalExpression::Literal(Value::String(s)) => s.to_string(),
+            LogicalExpression::Parameter(name) => {
+                return Err(Error::Internal(format!(
+                    "TextScan query parameter ${} not resolved",
+                    name
+                )));
+            }
+            _ => {
+                return Err(Error::Internal(
+                    "TextScan query must be a string literal or parameter".to_string(),
+                ))
+            }
+        };
+
+        let operator: Box<dyn Operator> = if let Some(k) = scan.k {
+            Box::new(TextScanOperator::top_k(
+                Arc::clone(&self.store),
+                &scan.label,
+                &scan.property,
+                &query_string,
+                k,
+            ))
+        } else if let Some(threshold) = scan.threshold {
+            Box::new(TextScanOperator::with_threshold(
+                Arc::clone(&self.store),
+                &scan.label,
+                &scan.property,
+                &query_string,
+                threshold,
+            ))
+        } else {
+            Box::new(TextScanOperator::top_k(
+                Arc::clone(&self.store),
+                &scan.label,
+                &scan.property,
+                &query_string,
+                100,
+            ))
+        };
+
+        let mut columns = vec![scan.variable.clone()];
+        if let Some(ref score_col) = scan.score_column {
+            columns.push(score_col.clone());
+        }
+
+        Ok((operator, columns))
+    }
+
+    /// Plans a VectorScan logical operator into a physical VectorScanOperator.
+    #[cfg(feature = "vector-index")]
+    pub(super) fn plan_vector_scan(
+        &self,
+        scan: &VectorScanOp,
+    ) -> Result<(Box<dyn Operator>, Vec<String>)> {
+        use grafeo_core::execution::operators::VectorScanOperator;
+        use grafeo_core::index::vector::DistanceMetric;
+
+        // Resolve the query vector expression to Vec<f32>
+        let query_vec = self.resolve_vector_literal(&scan.query_vector)?;
+
+        // Map VectorMetric to DistanceMetric
+        let metric = match scan.metric {
+            Some(VectorMetric::Cosine) | None => DistanceMetric::Cosine,
+            Some(VectorMetric::Euclidean) => DistanceMetric::Euclidean,
+            Some(VectorMetric::DotProduct) => DistanceMetric::DotProduct,
+            Some(VectorMetric::Manhattan) => DistanceMetric::Manhattan,
+        };
+
+        let k = scan.k.unwrap_or(usize::MAX);
+
+        // Try HNSW-accelerated path when an index handle is available.
+        // The with_metric() builder ensures threshold comparisons use the
+        // correct distance scale regardless of with_index()'s default.
+        let mut operator = if let Some(ref label) = scan.label {
+            if let Some(handle) = self.store.get_vector_index_handle(label, &scan.property) {
+                use grafeo_core::index::vector::VectorIndexKind;
+                if let Ok(index) = handle.downcast::<VectorIndexKind>() {
+                    VectorScanOperator::with_index(
+                        Arc::clone(&self.store),
+                        index,
+                        query_vec.clone(),
+                        k,
+                    )
+                    .with_property(&scan.property)
+                    .with_label(label)
+                    .with_metric(metric)
+                } else {
+                    VectorScanOperator::brute_force(
+                        Arc::clone(&self.store), &scan.property, query_vec.clone(), k, metric,
+                    ).with_label(label)
+                }
+            } else {
+                VectorScanOperator::brute_force(
+                    Arc::clone(&self.store), &scan.property, query_vec.clone(), k, metric,
+                ).with_label(label)
+            }
+        } else {
+            VectorScanOperator::brute_force(
+                Arc::clone(&self.store), &scan.property, query_vec, k, metric,
+            )
+        };
+
+        if let Some(sim) = scan.min_similarity {
+            operator = operator.with_min_similarity(sim);
+        }
+        if let Some(dist) = scan.max_distance {
+            operator = operator.with_max_distance(dist);
+        }
+
+        let mut columns = vec![scan.variable.clone()];
+        // VectorScan always projects a score column
+        columns.push(format!("_vscore_{}", scan.variable));
+
+        Ok((Box::new(operator), columns))
+    }
+
+    /// Resolves a LogicalExpression to a Vec<f32> for vector operations.
+    #[cfg(feature = "vector-index")]
+    pub(super) fn resolve_vector_literal(&self, expr: &LogicalExpression) -> Result<Vec<f32>> {
+        match expr {
+            LogicalExpression::Literal(Value::Vector(v)) => Ok(v.to_vec()),
+            LogicalExpression::Literal(Value::List(list)) => {
+                let mut vec = Vec::with_capacity(list.len());
+                for item in list.iter() {
+                    match item {
+                        Value::Float64(f) => vec.push(*f as f32),
+                        Value::Int64(i) => vec.push(*i as f32),
+                        _ => {
+                            return Err(Error::Internal(
+                                "Vector elements must be numeric".to_string(),
+                            ))
+                        }
+                    }
+                }
+                Ok(vec)
+            }
+            // GQL/Cypher parser produces List([Literal(Float64), ...]) for inline vectors like
+            // [0.9, 0.1, 0.0] — handle this form by recursively resolving each element.
+            LogicalExpression::List(items) => {
+                let mut vec = Vec::with_capacity(items.len());
+                for item in items {
+                    match item {
+                        LogicalExpression::Literal(Value::Float64(f)) => vec.push(*f as f32),
+                        LogicalExpression::Literal(Value::Int64(i)) => vec.push(*i as f32),
+                        _ => {
+                            return Err(Error::Internal(
+                                "Vector elements must be numeric literals".to_string(),
+                            ))
+                        }
+                    }
+                }
+                Ok(vec)
+            }
+            _ => Err(Error::Internal("Expected vector literal".to_string())),
+        }
     }
 }
 

--- a/crates/grafeo-engine/src/query/planner/lpg/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/mod.rs
@@ -824,24 +824,31 @@ impl Planner {
             Some(VectorMetric::Manhattan) => DistanceMetric::Manhattan,
         };
 
+        // Top-k mode uses HNSW index when available; threshold/unbounded
+        // mode always uses brute-force scan since HNSW is designed for
+        // bounded k and passing huge k degrades to a full traversal anyway.
         let k = scan.k.unwrap_or(usize::MAX);
+        let use_index = scan.k.is_some();
 
-        // Try HNSW-accelerated path when an index handle is available.
-        // The with_metric() builder ensures threshold comparisons use the
-        // correct distance scale regardless of with_index()'s default.
         let mut operator = if let Some(ref label) = scan.label {
-            if let Some(handle) = self.store.get_vector_index_handle(label, &scan.property) {
-                use grafeo_core::index::vector::VectorIndexKind;
-                if let Ok(index) = handle.downcast::<VectorIndexKind>() {
-                    VectorScanOperator::with_index(
-                        Arc::clone(&self.store),
-                        index,
-                        query_vec.clone(),
-                        k,
-                    )
-                    .with_property(&scan.property)
-                    .with_label(label)
-                    .with_metric(metric)
+            if use_index {
+                if let Some(handle) = self.store.get_vector_index_handle(label, &scan.property) {
+                    use grafeo_core::index::vector::VectorIndexKind;
+                    if let Ok(index) = handle.downcast::<VectorIndexKind>() {
+                        VectorScanOperator::with_index(
+                            Arc::clone(&self.store),
+                            index,
+                            query_vec.clone(),
+                            k,
+                        )
+                        .with_property(&scan.property)
+                        .with_label(label)
+                        .with_metric(metric)
+                    } else {
+                        VectorScanOperator::brute_force(
+                            Arc::clone(&self.store), &scan.property, query_vec.clone(), k, metric,
+                        ).with_label(label)
+                    }
                 } else {
                     VectorScanOperator::brute_force(
                         Arc::clone(&self.store), &scan.property, query_vec.clone(), k, metric,
@@ -866,8 +873,14 @@ impl Planner {
         }
 
         let mut columns = vec![scan.variable.clone()];
-        // VectorScan always projects a score column
-        columns.push(format!("_vscore_{}", scan.variable));
+        // VectorScan always projects a score column keyed by metric+property
+        let metric_tag = match scan.metric {
+            Some(VectorMetric::Cosine) | None => "cos",
+            Some(VectorMetric::Euclidean) => "euc",
+            Some(VectorMetric::DotProduct) => "dot",
+            Some(VectorMetric::Manhattan) => "man",
+        };
+        columns.push(format!("_vscore_{}_{}_{}", metric_tag, scan.property, scan.variable));
 
         Ok((Box::new(operator), columns))
     }

--- a/crates/grafeo-engine/src/query/planner/lpg/project.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/project.rs
@@ -227,14 +227,32 @@ impl super::Planner {
                                     )));
                                 }
                             }
-                            // For other functions (head, tail, size, etc.), use expression evaluation
+                            // For other functions (head, tail, size, etc.), use expression evaluation.
+                            // As a special case, if this is a vector/text score function and the
+                            // scan already projected a score column, reference that column directly
+                            // instead of recomputing the distance/score.
                             _ => {
-                                let filter_expr = self.convert_expression(&item.expression)?;
-                                projections.push(ProjectExpr::Expression {
-                                    expr: filter_expr,
-                                    variable_columns: variable_columns.clone(),
-                                });
-                                output_types.push(LogicalType::Any);
+                                if let Some(score_col) = self
+                                    .find_projected_score(&item.expression, &input_columns)
+                                {
+                                    let col_idx =
+                                        *variable_columns.get(&score_col).ok_or_else(|| {
+                                            Error::Internal(format!(
+                                                "Score column '{}' not found in input",
+                                                score_col
+                                            ))
+                                        })?;
+                                    projections.push(ProjectExpr::Column(col_idx));
+                                    output_types.push(LogicalType::Any);
+                                } else {
+                                    let filter_expr =
+                                        self.convert_expression(&item.expression)?;
+                                    projections.push(ProjectExpr::Expression {
+                                        expr: filter_expr,
+                                        variable_columns: variable_columns.clone(),
+                                    });
+                                    output_types.push(LogicalType::Any);
+                                }
                             }
                         }
                     }
@@ -503,6 +521,12 @@ impl super::Planner {
     /// that case we inject a property projection BEFORE the Return so the sort
     /// key is available in the output columns.
     pub(super) fn plan_sort(&self, sort: &SortOp) -> Result<(Box<dyn Operator>, Vec<String>)> {
+        // Top-K optimization: Sort(fn) + Limit(k) + NodeScan
+        // can be rewritten to VectorScan(k) or TextScan(k)
+        if let Some(result) = self.try_topk_rewrite(sort)? {
+            return Ok(result);
+        }
+
         // Collect variable references from an expression tree (e.g., `n` in `labels(n)[0]`).
         fn collect_vars(expr: &LogicalExpression, out: &mut Vec<String>) {
             match expr {
@@ -698,16 +722,30 @@ impl super::Planner {
                 }
                 _ => {
                     // Complex expression (Labels, Type, FunctionCall, IndexAccess, etc.)
-                    let col_name = format!("__expr_{:?}", key.expression);
-                    if !variable_columns.contains_key(&col_name) {
-                        let filter_expr = self.convert_expression(&key.expression)?;
-                        extra_projections.push(SortExtraProjection::Expression {
-                            filter_expr,
-                            col_name: col_name.clone(),
-                        });
-                        variable_columns.insert(col_name, next_col_idx);
-                        next_col_idx += 1;
-                        expr_extra_count += 1;
+                    // If this is a vector/text score function and the scan already projected
+                    // a score column, register a direct alias so resolve_sort_expression
+                    // picks it up without injecting a new projection.
+                    if let Some(score_col) =
+                        self.find_projected_score(&key.expression, &input_columns)
+                    {
+                        let col_name = format!("__expr_{:?}", key.expression);
+                        if !variable_columns.contains_key(&col_name) {
+                            if let Some(&existing_idx) = variable_columns.get(&score_col) {
+                                variable_columns.insert(col_name, existing_idx);
+                            }
+                        }
+                    } else {
+                        let col_name = format!("__expr_{:?}", key.expression);
+                        if !variable_columns.contains_key(&col_name) {
+                            let filter_expr = self.convert_expression(&key.expression)?;
+                            extra_projections.push(SortExtraProjection::Expression {
+                                filter_expr,
+                                col_name: col_name.clone(),
+                            });
+                            variable_columns.insert(col_name, next_col_idx);
+                            next_col_idx += 1;
+                            expr_extra_count += 1;
+                        }
                     }
                 }
             }
@@ -856,5 +894,216 @@ impl super::Planner {
                 }
             })
             .collect()
+    }
+
+    /// Attempts to rewrite Sort+Limit on a vector/text function into
+    /// a direct index scan that returns results in order.
+    fn try_topk_rewrite(
+        &self,
+        sort: &SortOp,
+    ) -> Result<Option<(Box<dyn Operator>, Vec<String>)>> {
+        // Must have exactly one sort key
+        if sort.keys.len() != 1 {
+            return Ok(None);
+        }
+        let sort_key = &sort.keys[0];
+
+        // Input must be Limit (Sort wraps Limit in the AST)
+        let LogicalOperator::Limit(limit) = sort.input.as_ref() else {
+            return Ok(None);
+        };
+        // Parameter-based limits can't be used for top-K rewrite at plan time
+        let crate::query::plan::CountExpr::Literal(k) = &limit.count else {
+            return Ok(None); // Non-constant limit
+        };
+        let k = *k;
+
+        // Walk through the Limit's input to find a NodeScan
+        let Some((scan_var, scan_label)) = self.find_node_scan(&limit.input) else {
+            return Ok(None);
+        };
+        let Some(ref label) = scan_label else {
+            return Ok(None); // No label → can't look up index
+        };
+
+        // Sort key must be a vector or text function call
+        match &sort_key.expression {
+            LogicalExpression::FunctionCall { name, args, .. } => {
+                match name.as_str() {
+                    #[cfg(feature = "vector-index")]
+                    "cosine_similarity" | "euclidean_distance" | "dot_product"
+                    | "manhattan_distance" => {
+                        self.try_vector_topk(name, args, k, &scan_var, label, sort_key)
+                    }
+                    #[cfg(feature = "text-index")]
+                    "text_score" => {
+                        self.try_text_topk(args, k, &scan_var, label, sort_key)
+                    }
+                    _ => Ok(None),
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Walks through Return/Project operators to find the underlying NodeScan.
+    fn find_node_scan(&self, op: &LogicalOperator) -> Option<(String, Option<String>)> {
+        match op {
+            LogicalOperator::NodeScan(scan) => Some((scan.variable.clone(), scan.label.clone())),
+            LogicalOperator::Return(ret) => self.find_node_scan(&ret.input),
+            LogicalOperator::Project(proj) => self.find_node_scan(&proj.input),
+            _ => None,
+        }
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn try_vector_topk(
+        &self,
+        fn_name: &str,
+        args: &[LogicalExpression],
+        k: usize,
+        scan_var: &str,
+        label: &str,
+        sort_key: &crate::query::plan::SortKey,
+    ) -> Result<Option<(Box<dyn Operator>, Vec<String>)>> {
+        if args.len() != 2 {
+            return Ok(None);
+        }
+
+        // Determine metric and expected sort direction
+        let (metric, is_similarity) = match fn_name {
+            "cosine_similarity" => (super::VectorMetric::Cosine, true),
+            "dot_product" => (super::VectorMetric::DotProduct, true),
+            "euclidean_distance" => (super::VectorMetric::Euclidean, false),
+            "manhattan_distance" => (super::VectorMetric::Manhattan, false),
+            _ => return Ok(None),
+        };
+
+        // Similarity needs DESC, distance needs ASC
+        let expected_order = if is_similarity {
+            SortOrder::Descending
+        } else {
+            SortOrder::Ascending
+        };
+        if sort_key.order != expected_order {
+            return Ok(None); // Wrong direction — can't use index
+        }
+
+        // Extract property and query vector
+        let (property, query_vector) =
+            if let LogicalExpression::Property { variable, property } = &args[0] {
+                if variable != scan_var {
+                    return Ok(None);
+                }
+                (property.clone(), args[1].clone())
+            } else if let LogicalExpression::Property { variable, property } = &args[1] {
+                if variable != scan_var {
+                    return Ok(None);
+                }
+                (property.clone(), args[0].clone())
+            } else {
+                return Ok(None);
+            };
+
+        // Check for vector index
+        if !self.store.has_vector_index(label, &property) {
+            return Ok(None);
+        }
+
+        let vector_scan = super::VectorScanOp {
+            variable: scan_var.to_string(),
+            index_name: Some(format!("{}:{}", label, property)),
+            property,
+            label: Some(label.to_string()),
+            query_vector,
+            k: Some(k),
+            metric: Some(metric),
+            min_similarity: None,
+            max_distance: None,
+            input: None,
+        };
+
+        self.plan_operator(&LogicalOperator::VectorScan(vector_scan))
+            .map(Some)
+    }
+
+    #[cfg(feature = "text-index")]
+    fn try_text_topk(
+        &self,
+        args: &[LogicalExpression],
+        k: usize,
+        scan_var: &str,
+        label: &str,
+        sort_key: &crate::query::plan::SortKey,
+    ) -> Result<Option<(Box<dyn Operator>, Vec<String>)>> {
+        if args.len() != 2 {
+            return Ok(None);
+        }
+
+        // text_score needs DESC order
+        if sort_key.order != SortOrder::Descending {
+            return Ok(None);
+        }
+
+        // First arg must be property access on the scan variable
+        let LogicalExpression::Property { variable, property } = &args[0] else {
+            return Ok(None);
+        };
+        if variable != scan_var {
+            return Ok(None);
+        }
+
+        // Check for text index (required)
+        if !self.store.has_text_index(label, property) {
+            return Ok(None); // Silently skip — error will come from text pushdown if used
+        }
+
+        let text_scan = super::TextScanOp {
+            variable: scan_var.to_string(),
+            property: property.clone(),
+            label: label.to_string(),
+            query: args[1].clone(),
+            k: Some(k),
+            threshold: None,
+            score_column: Some(format!("_tscore_{}", scan_var)),
+        };
+
+        self.plan_operator(&LogicalOperator::TextScan(text_scan))
+            .map(Some)
+    }
+
+    /// Checks if a logical expression matches a projected score column.
+    ///
+    /// When `VectorScan` or `TextScan` already computed a score and projected it
+    /// as `_vscore_{var}` / `_tscore_{var}`, downstream expressions that call the
+    /// same function can reference the projected column instead of recomputing the
+    /// distance or BM25 score.
+    ///
+    /// Returns the column name to reference, or `None` if no reuse is possible.
+    pub(super) fn find_projected_score(
+        &self,
+        expr: &LogicalExpression,
+        columns: &[String],
+    ) -> Option<String> {
+        if let LogicalExpression::FunctionCall { name, args, .. } = expr {
+            let is_vector_fn = matches!(
+                name.as_str(),
+                "cosine_similarity" | "euclidean_distance" | "dot_product" | "manhattan_distance"
+            );
+            let is_text_fn = name == "text_score";
+
+            if is_vector_fn || is_text_fn {
+                let prefix = if is_vector_fn { "_vscore_" } else { "_tscore_" };
+                // The first arg is the property access n.prop; variable is the
+                // node variable whose score column was projected by the scan.
+                if let Some(LogicalExpression::Property { variable, .. }) = args.first() {
+                    let score_col = format!("{}{}", prefix, variable);
+                    if columns.contains(&score_col) {
+                        return Some(score_col);
+                    }
+                }
+            }
+        }
+        None
     }
 }

--- a/crates/grafeo-engine/src/query/planner/lpg/project.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/project.rs
@@ -1093,11 +1093,21 @@ impl super::Planner {
             let is_text_fn = name == "text_score";
 
             if is_vector_fn || is_text_fn {
-                let prefix = if is_vector_fn { "_vscore_" } else { "_tscore_" };
                 // The first arg is the property access n.prop; variable is the
                 // node variable whose score column was projected by the scan.
-                if let Some(LogicalExpression::Property { variable, .. }) = args.first() {
-                    let score_col = format!("{}{}", prefix, variable);
+                if let Some(LogicalExpression::Property { variable, property, .. }) = args.first() {
+                    let score_col = if is_vector_fn {
+                        let metric_tag = match name.as_str() {
+                            "cosine_similarity" => "cos",
+                            "euclidean_distance" => "euc",
+                            "dot_product" => "dot",
+                            "manhattan_distance" => "man",
+                            _ => "cos",
+                        };
+                        format!("_vscore_{}_{}_{}", metric_tag, property, variable)
+                    } else {
+                        format!("_tscore_{}", variable)
+                    };
                     if columns.contains(&score_col) {
                         return Some(score_col);
                     }

--- a/crates/grafeo-engine/src/query/processor.rs
+++ b/crates/grafeo-engine/src/query/processor.rs
@@ -945,6 +945,9 @@ fn substitute_in_operator(op: &mut LogicalOperator, params: &QueryParams) -> Res
             substitute_in_expression(&mut join.query_vector, params)?;
             substitute_in_operator(&mut join.input, params)?;
         }
+        LogicalOperator::TextScan(scan) => {
+            substitute_in_expression(&mut scan.query, params)?;
+        }
         LogicalOperator::Except(except) => {
             substitute_in_operator(&mut except.left, params)?;
             substitute_in_operator(&mut except.right, params)?;

--- a/crates/grafeo-engine/tests/hybrid_query.rs
+++ b/crates/grafeo-engine/tests/hybrid_query.rs
@@ -1,0 +1,697 @@
+//! End-to-end integration tests for unified hybrid queries.
+//!
+//! Tests the full pipeline: Cypher parsing → planning → pushdown → execution.
+//! Covers text pushdown, vector pushdown, text_match, text_score,
+//! graph+vector per-row eval, error on missing text index,
+//! and brute-force fallback without vector index.
+//!
+//! ```bash
+//! cargo test -p grafeo-engine --features text-index,vector-index,gql --test hybrid_query 2>&1 | tail -20
+//! ```
+
+#![cfg(all(feature = "text-index", feature = "vector-index", feature = "gql"))]
+
+use grafeo_common::types::Value;
+use grafeo_engine::database::QueryResult;
+use grafeo_engine::GrafeoDB;
+
+// ============================================================================
+// Shared test fixture
+// ============================================================================
+
+fn setup_article_db() -> GrafeoDB {
+    let db = GrafeoDB::new_in_memory();
+
+    // Create articles with embeddings and text
+    let a1 = db.create_node(&["Article"]);
+    db.set_node_property(a1, "title", Value::String("Graph Neural Networks".into()));
+    db.set_node_property(
+        a1,
+        "body",
+        Value::String(
+            "attention mechanisms in graph neural networks for node classification".into(),
+        ),
+    );
+    db.set_node_property(
+        a1,
+        "embedding",
+        Value::Vector(vec![0.9f32, 0.1, 0.0].into()),
+    );
+
+    let a2 = db.create_node(&["Article"]);
+    db.set_node_property(a2, "title", Value::String("Rust Database Internals".into()));
+    db.set_node_property(
+        a2,
+        "body",
+        Value::String("building a database engine in rust with MVCC transactions".into()),
+    );
+    db.set_node_property(
+        a2,
+        "embedding",
+        Value::Vector(vec![0.1f32, 0.9, 0.0].into()),
+    );
+
+    let a3 = db.create_node(&["Article"]);
+    db.set_node_property(
+        a3,
+        "title",
+        Value::String("Transformer Architectures".into()),
+    );
+    db.set_node_property(
+        a3,
+        "body",
+        Value::String(
+            "attention mechanisms and transformer models for natural language".into(),
+        ),
+    );
+    db.set_node_property(
+        a3,
+        "embedding",
+        Value::Vector(vec![0.8f32, 0.2, 0.1].into()),
+    );
+
+    // Create user + friend with relationships
+    let user = db.create_node(&["User"]);
+    db.set_node_property(user, "name", Value::String("Alice".into()));
+    let friend = db.create_node(&["User"]);
+    db.set_node_property(friend, "name", Value::String("Bob".into()));
+    db.create_edge(user, friend, "FOLLOWS");
+    db.create_edge(friend, a1, "WROTE");
+    db.create_edge(friend, a2, "WROTE");
+
+    // Create indexes
+    db.create_vector_index("Article", "embedding", Some(3), Some("cosine"), None, None, None)
+        .expect("create vector index");
+    db.create_text_index("Article", "body").expect("create text index");
+
+    db
+}
+
+// ============================================================================
+// Helper: extract string values from the first column of a result
+// ============================================================================
+
+fn collect_strings(result: &QueryResult) -> Vec<String> {
+    result
+        .rows()
+        .iter()
+        .filter_map(|row| {
+            if let Some(Value::String(s)) = row.first() {
+                Some(s.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+// ============================================================================
+// Test 1: text_match in WHERE clause
+// ============================================================================
+
+#[test]
+fn test_text_match_where() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    let result = session
+        .execute("MATCH (doc:Article) WHERE text_match(doc.body, 'rust database') RETURN doc.title")
+        .expect("text_match query should succeed");
+
+    let titles = collect_strings(&result);
+    assert_eq!(
+        titles.len(),
+        1,
+        "Expected 1 result for 'rust database', got: {:?}",
+        titles
+    );
+    assert_eq!(
+        titles[0], "Rust Database Internals",
+        "Expected 'Rust Database Internals', got: {:?}",
+        titles
+    );
+}
+
+// ============================================================================
+// Test 2: text_score > 0.0 in WHERE clause
+// ============================================================================
+
+#[test]
+fn test_text_score_where() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    let result = session
+        .execute(
+            "MATCH (doc:Article) WHERE text_score(doc.body, 'attention mechanisms') > 0.0 RETURN doc.title",
+        )
+        .expect("text_score query should succeed");
+
+    let titles = collect_strings(&result);
+    assert_eq!(
+        titles.len(),
+        2,
+        "Expected 2 results for 'attention mechanisms' (articles 1 and 3), got: {:?}",
+        titles
+    );
+    assert!(
+        titles.contains(&"Graph Neural Networks".to_string()),
+        "Expected 'Graph Neural Networks' in results: {:?}",
+        titles
+    );
+    assert!(
+        titles.contains(&"Transformer Architectures".to_string()),
+        "Expected 'Transformer Architectures' in results: {:?}",
+        titles
+    );
+}
+
+// ============================================================================
+// Test 3: vector cosine_similarity with index pushdown
+// ============================================================================
+
+#[test]
+fn test_vector_where_with_pushdown() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    let result = session
+        .execute(
+            "MATCH (doc:Article) WHERE cosine_similarity(doc.embedding, [0.85, 0.15, 0.05]) > 0.5 RETURN doc.title",
+        )
+        .expect("cosine_similarity query should succeed");
+
+    let titles = collect_strings(&result);
+    assert!(
+        !titles.is_empty(),
+        "Expected at least 1 result for cosine_similarity > 0.5, got none"
+    );
+    assert!(
+        titles.contains(&"Graph Neural Networks".to_string()),
+        "Expected 'Graph Neural Networks' in cosine_similarity results (embedding [0.9, 0.1, 0.0] is close to query [0.85, 0.15, 0.05]): {:?}",
+        titles
+    );
+}
+
+// ============================================================================
+// Test 4: text_score without text index → must error
+// ============================================================================
+
+#[test]
+fn test_text_score_without_index_errors() {
+    let db = GrafeoDB::new_in_memory();
+    // Create nodes but NO text index
+    let n = db.create_node(&["Article"]);
+    db.set_node_property(
+        n,
+        "body",
+        Value::String("some body text about rust".into()),
+    );
+
+    let session = db.session();
+    let result = session.execute(
+        "MATCH (doc:Article) WHERE text_score(doc.body, 'rust') > 0.0 RETURN doc.title",
+    );
+
+    assert!(
+        result.is_err(),
+        "Expected error when using text_score without a text index, but got success"
+    );
+}
+
+// ============================================================================
+// Test 5: cosine_similarity without vector index → brute-force fallback
+// ============================================================================
+
+#[test]
+fn test_vector_without_index_brute_force() {
+    let db = GrafeoDB::new_in_memory();
+    // Create articles WITHOUT a vector index
+    let a1 = db.create_node(&["Article"]);
+    db.set_node_property(a1, "title", Value::String("Graph Neural Networks".into()));
+    db.set_node_property(
+        a1,
+        "embedding",
+        Value::Vector(vec![0.9f32, 0.1, 0.0].into()),
+    );
+
+    let a2 = db.create_node(&["Article"]);
+    db.set_node_property(a2, "title", Value::String("Rust Database Internals".into()));
+    db.set_node_property(
+        a2,
+        "embedding",
+        Value::Vector(vec![0.1f32, 0.9, 0.0].into()),
+    );
+
+    // NO vector index created — should fall back to brute-force per-row evaluation
+    let session = db.session();
+    let result = session
+        .execute(
+            "MATCH (doc:Article) WHERE cosine_similarity(doc.embedding, [0.85, 0.15, 0.05]) > 0.5 RETURN doc.title",
+        )
+        .expect("cosine_similarity should work without index via brute-force fallback");
+
+    let titles = collect_strings(&result);
+    assert!(
+        !titles.is_empty(),
+        "Brute-force fallback should find at least 1 result"
+    );
+    assert!(
+        titles.contains(&"Graph Neural Networks".to_string()),
+        "Expected 'Graph Neural Networks' via brute-force evaluation: {:?}",
+        titles
+    );
+}
+
+// ============================================================================
+// Test 6: Graph traversal + vector similarity per-row eval
+// ============================================================================
+
+#[test]
+fn test_graph_plus_vector_per_row_eval() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // Alice follows Bob; Bob wrote articles 1 and 2.
+    // Article 1 embedding [0.9, 0.1, 0.0] is close to query [0.85, 0.15, 0.05].
+    // Article 2 embedding [0.1, 0.9, 0.0] is far from query.
+    let result = session
+        .execute(
+            "MATCH (u:User {name: 'Alice'})-[:FOLLOWS]->(friend)-[:WROTE]->(doc:Article) \
+             WHERE cosine_similarity(doc.embedding, [0.85, 0.15, 0.05]) > 0.3 \
+             RETURN doc.title",
+        )
+        .expect("graph + vector query should succeed");
+
+    let titles = collect_strings(&result);
+
+    // At a threshold of 0.3, article 1 ([0.9, 0.1, 0.0]) should match
+    // (cosine similarity with [0.85, 0.15, 0.05] ≈ 0.998).
+    assert!(
+        !titles.is_empty(),
+        "Expected at least one article from Alice→Bob→Article traversal with similarity > 0.3"
+    );
+    assert!(
+        titles.contains(&"Graph Neural Networks".to_string()),
+        "Expected 'Graph Neural Networks' (article with similar embedding): {:?}",
+        titles
+    );
+
+    // Article 2 embedding [0.1, 0.9, 0.0] vs query [0.85, 0.15, 0.05]:
+    // cosine similarity ≈ 0.1*0.85 + 0.9*0.15 ≈ 0.085 + 0.135 = 0.22 < 0.3
+    // So "Rust Database Internals" should NOT be in results.
+    assert!(
+        !titles.contains(&"Rust Database Internals".to_string()),
+        "Expected 'Rust Database Internals' to be filtered out (low similarity): {:?}",
+        titles
+    );
+}
+
+// ============================================================================
+// Test 7: AND compound — vector similarity AND text match on bare label scan
+// ============================================================================
+
+#[test]
+fn test_compound_vector_and_text() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // Both vector similarity AND text match on bare label scan.
+    // Articles 1 and 3 mention "attention" AND are close to [0.85, 0.15, 0.05].
+    // Article 2 (rust database) doesn't mention "attention".
+    let result = session
+        .execute(
+            "MATCH (doc:Article) \
+             WHERE cosine_similarity(doc.embedding, [0.85, 0.15, 0.05]) > 0.3 \
+               AND text_match(doc.body, 'attention mechanisms') \
+             RETURN doc.title",
+        )
+        .expect("AND compound query (vector + text) should succeed");
+
+    assert!(
+        result.row_count() >= 1,
+        "AND compound should return at least 1 article (articles 1 and 3 match both), got {}",
+        result.row_count()
+    );
+
+    let titles = collect_strings(&result);
+    assert!(
+        !titles.contains(&"Rust Database Internals".to_string()),
+        "AND compound should not return 'Rust Database Internals' (no 'attention' in body): {:?}",
+        titles
+    );
+}
+
+// ============================================================================
+// Test 8: OR compound — vector similarity OR text match (union)
+// ============================================================================
+
+#[test]
+fn test_compound_vector_or_text() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // Vector similarity OR text match — should union results.
+    // cosine_similarity > 0.9 matches article 2 (embedding [0.1, 0.9, 0.0]).
+    // text_match matches articles 1 and 3 ("attention mechanisms").
+    // Union should return all 3 articles.
+    let result = session
+        .execute(
+            "MATCH (doc:Article) \
+             WHERE cosine_similarity(doc.embedding, [0.1, 0.9, 0.0]) > 0.9 \
+                OR text_match(doc.body, 'attention mechanisms') \
+             RETURN doc.title",
+        )
+        .expect("OR compound query (vector | text) should succeed");
+
+    assert!(
+        result.row_count() >= 2,
+        "OR should union vector and text results, got {}",
+        result.row_count()
+    );
+}
+
+// ============================================================================
+// Test 9: euclidean_distance pushdown
+// ============================================================================
+
+#[test]
+fn test_euclidean_distance_pushdown() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // Article 1 has embedding [0.9, 0.1, 0.0] — distance 0.0 from itself.
+    let result = session
+        .execute(
+            "MATCH (doc:Article) \
+             WHERE euclidean_distance(doc.embedding, [0.9, 0.1, 0.0]) < 0.5 \
+             RETURN doc.title",
+        )
+        .expect("euclidean_distance query should succeed");
+
+    assert!(
+        result.row_count() >= 1,
+        "Expected at least 1 result for euclidean_distance < 0.5, got {}",
+        result.row_count()
+    );
+}
+
+// ============================================================================
+// Test 10: text_match as a standalone boolean (not text_score > threshold)
+// ============================================================================
+
+#[test]
+fn test_text_match_standalone_boolean() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // text_match as a standalone boolean (not text_score > threshold).
+    // Only article 2 body mentions "rust".
+    let result = session
+        .execute(
+            "MATCH (doc:Article) \
+             WHERE text_match(doc.body, 'rust') \
+             RETURN doc.title",
+        )
+        .expect("text_match standalone boolean query should succeed");
+
+    assert_eq!(
+        result.row_count(),
+        1,
+        "Expected exactly 1 result for text_match 'rust' (only 'Rust Database Internals'), got {}",
+        result.row_count()
+    );
+}
+
+// ============================================================================
+// Test 11: Operator inversion (cosine_similarity < threshold) — no pushdown,
+//          should still work via brute-force per-row eval
+// ============================================================================
+
+#[test]
+fn test_operator_inversion_no_pushdown() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // cosine_similarity < 0.3 should NOT push down (inverted comparison).
+    // Should still work via brute-force per-row eval.
+    // Article 2 ([0.1, 0.9, 0.0]) has low cosine similarity to [0.9, 0.1, 0.0].
+    let result = session
+        .execute(
+            "MATCH (doc:Article) \
+             WHERE cosine_similarity(doc.embedding, [0.9, 0.1, 0.0]) < 0.3 \
+             RETURN doc.title",
+        )
+        .expect("inverted cosine_similarity query should succeed via brute-force fallback");
+
+    assert!(
+        result.row_count() >= 1,
+        "Expected at least 1 article with cosine_similarity < 0.3 (article 2 should qualify), got {}",
+        result.row_count()
+    );
+}
+
+// ============================================================================
+// Test 12: text_score in both WHERE and RETURN (score projection)
+// ============================================================================
+
+#[test]
+fn test_score_in_return() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // Score projection: text_score appears in both WHERE and RETURN.
+    let result = session
+        .execute(
+            "MATCH (doc:Article) \
+             WHERE text_score(doc.body, 'attention mechanisms') > 0.0 \
+             RETURN doc.title, text_score(doc.body, 'attention mechanisms') AS score",
+        )
+        .expect("text_score in WHERE + RETURN should succeed");
+
+    assert_eq!(
+        result.row_count(),
+        2,
+        "Expected 2 articles matching 'attention mechanisms', got {}",
+        result.row_count()
+    );
+    assert_eq!(
+        result.column_count(),
+        2,
+        "Expected 2 columns (title, score), got {}",
+        result.column_count()
+    );
+
+    // Verify scores are positive Float64 values.
+    for row in result.rows() {
+        if let Value::Float64(s) = &row[1] {
+            assert!(*s > 0.0, "Score should be positive, got {}", s);
+        } else {
+            panic!("Expected Float64 score in column 1, got {:?}", row[1]);
+        }
+    }
+}
+
+// ============================================================================
+// Test 13: text_score in RETURN only (no WHERE pushdown) — per-row eval
+// ============================================================================
+
+#[test]
+fn test_text_score_in_return_only() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // text_score in RETURN only (no WHERE pushdown) — per-row eval for all rows.
+    // All 3 articles should be returned; non-matching articles get 0 or Null score.
+    let result = session
+        .execute(
+            "MATCH (doc:Article) \
+             RETURN doc.title, text_score(doc.body, 'rust database') AS score",
+        )
+        .expect("text_score in RETURN only should succeed");
+
+    assert_eq!(
+        result.row_count(),
+        3,
+        "Expected all 3 articles when text_score is in RETURN only (no filter), got {}",
+        result.row_count()
+    );
+}
+
+// ============================================================================
+// Test 14: Empty query string should match nothing
+// ============================================================================
+
+#[test]
+fn test_empty_query_string() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // Empty query string — either returns 0 rows or errors gracefully.
+    // Either outcome is acceptable; we assert zero rows if it succeeds.
+    let result = session.execute(
+        "MATCH (doc:Article) \
+         WHERE text_match(doc.body, '') \
+         RETURN doc.title",
+    );
+
+    match result {
+        Ok(r) => {
+            assert_eq!(
+                r.row_count(),
+                0,
+                "Empty query string should match nothing, got {} rows",
+                r.row_count()
+            );
+        }
+        Err(_) => {
+            // Graceful error on empty query string is also acceptable.
+        }
+    }
+}
+
+// ============================================================================
+// Test 15: Top-K recognition (ORDER BY + LIMIT → index scan)
+// ============================================================================
+
+#[test]
+fn test_topk_order_by_text_score() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // ORDER BY text_score DESC LIMIT 1 — should rewrite to TextScan(k=1)
+    let result = session
+        .execute(
+            "MATCH (doc:Article) \
+             RETURN doc.title, text_score(doc.body, 'attention mechanisms') AS rank \
+             ORDER BY rank DESC LIMIT 1",
+        )
+        .unwrap();
+
+    assert_eq!(result.row_count(), 1, "Top-1 should return exactly 1 row");
+}
+
+#[test]
+fn test_topk_order_by_vector_similarity() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // ORDER BY cosine_similarity DESC LIMIT 2 — should rewrite to VectorScan(k=2)
+    let result = session
+        .execute(
+            "MATCH (doc:Article) \
+             RETURN doc.title, cosine_similarity(doc.embedding, [0.85, 0.15, 0.05]) AS sim \
+             ORDER BY sim DESC LIMIT 2",
+        )
+        .unwrap();
+
+    assert_eq!(result.row_count(), 2, "Top-2 should return exactly 2 rows");
+}
+
+// ============================================================================
+// Test 17: dot_product pushdown
+// ============================================================================
+
+#[test]
+fn test_dot_product_pushdown() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // dot_product is a similarity metric (higher = more similar)
+    // Article 1 embedding [0.9, 0.1, 0.0], query [0.9, 0.1, 0.0]
+    // dot_product = 0.81 + 0.01 + 0.0 = 0.82
+    let result = session
+        .execute(
+            "MATCH (doc:Article) \
+             WHERE dot_product(doc.embedding, [0.9, 0.1, 0.0]) > 0.5 \
+             RETURN doc.title",
+        )
+        .unwrap();
+
+    assert!(
+        result.row_count() >= 1,
+        "dot_product > 0.5 should match at least article 1, got {}",
+        result.row_count()
+    );
+}
+
+// ============================================================================
+// Test 18: manhattan_distance pushdown
+// ============================================================================
+
+#[test]
+fn test_manhattan_distance_pushdown() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // manhattan_distance is a distance metric (lower = more similar)
+    // Article 1 embedding [0.9, 0.1, 0.0], query [0.9, 0.1, 0.0]
+    // manhattan_distance = 0.0
+    let result = session
+        .execute(
+            "MATCH (doc:Article) \
+             WHERE manhattan_distance(doc.embedding, [0.9, 0.1, 0.0]) < 0.5 \
+             RETURN doc.title",
+        )
+        .unwrap();
+
+    assert!(
+        result.row_count() >= 1,
+        "manhattan_distance < 0.5 should match at least article 1, got {}",
+        result.row_count()
+    );
+}
+
+// ============================================================================
+// Test 19: EXPLAIN output shows TextScan / VectorScan operators
+// ============================================================================
+
+#[test]
+fn test_explain_shows_text_scan() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // PROFILE shows the physical plan with actual operator names.
+    // If pushdown fired, we'll see TextScan(BM25) instead of Filter.
+    let result = session
+        .execute(
+            "PROFILE MATCH (doc:Article) \
+             WHERE text_score(doc.body, 'attention') > 0.0 \
+             RETURN doc.title",
+        )
+        .unwrap();
+
+    assert_eq!(result.row_count(), 1);
+    let plan = match &result.rows()[0][0] {
+        Value::String(s) => s.to_string(),
+        other => panic!("Expected String profile, got {:?}", other),
+    };
+    assert!(
+        plan.contains("TextScan"),
+        "PROFILE should show TextScan(BM25) operator (pushdown fired):\n{plan}"
+    );
+}
+
+#[test]
+fn test_profile_shows_vector_scan() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    let result = session
+        .execute(
+            "PROFILE MATCH (doc:Article) \
+             WHERE cosine_similarity(doc.embedding, [0.85, 0.15, 0.05]) > 0.5 \
+             RETURN doc.title",
+        )
+        .unwrap();
+
+    assert_eq!(result.row_count(), 1);
+    let plan = match &result.rows()[0][0] {
+        Value::String(s) => s.to_string(),
+        other => panic!("Expected String profile, got {:?}", other),
+    };
+    assert!(
+        plan.contains("VectorScan"),
+        "PROFILE should show VectorScan operator (pushdown fired):\n{plan}"
+    );
+}

--- a/crates/grafeo-engine/tests/post_compact_index.rs
+++ b/crates/grafeo-engine/tests/post_compact_index.rs
@@ -1,0 +1,235 @@
+//! Tests for index operations after compact().
+//!
+//! Validates that vector and text indexes work correctly when the database
+//! is in layered mode (after compact()), including the full cycle of
+//! insert → compact → create index → search.
+//!
+//! ```bash
+//! cargo test -p grafeo-engine --features full --test post_compact_index
+//! ```
+
+#![cfg(all(feature = "compact-store", feature = "lpg"))]
+
+use grafeo_common::types::Value;
+use grafeo_engine::GrafeoDB;
+
+fn vec3(x: f32, y: f32, z: f32) -> Value {
+    Value::Vector(vec![x, y, z].into())
+}
+
+/// Helper: create a DB with vector data, compact it, then return it.
+fn setup_compacted_vector_db() -> GrafeoDB {
+    let mut db = GrafeoDB::new_in_memory();
+
+    let n1 = db.create_node(&["Doc"]);
+    db.set_node_property(n1, "embedding", vec3(1.0, 0.0, 0.0));
+    db.set_node_property(n1, "title", Value::String("alpha".into()));
+
+    let n2 = db.create_node(&["Doc"]);
+    db.set_node_property(n2, "embedding", vec3(0.0, 1.0, 0.0));
+    db.set_node_property(n2, "title", Value::String("beta".into()));
+
+    let n3 = db.create_node(&["Doc"]);
+    db.set_node_property(n3, "embedding", vec3(0.0, 0.0, 1.0));
+    db.set_node_property(n3, "title", Value::String("gamma".into()));
+
+    db.compact().expect("compact");
+    db
+}
+
+// ── Vector index after compact ─────────────────────────────────────
+
+#[test]
+#[cfg(feature = "vector-index")]
+fn vector_index_after_compact_returns_results() {
+    let db = setup_compacted_vector_db();
+
+    db.create_vector_index("Doc", "embedding", Some(3), Some("cosine"), None, None, None)
+        .expect("create vector index after compact");
+
+    let results = db
+        .vector_search("Doc", "embedding", &[1.0, 0.0, 0.0], 3, None, None)
+        .expect("vector search after compact");
+
+    assert_eq!(results.len(), 3, "should find all 3 pre-compact nodes");
+}
+
+#[test]
+#[cfg(feature = "vector-index")]
+fn vector_index_after_compact_nearest_neighbor_is_correct() {
+    let db = setup_compacted_vector_db();
+
+    db.create_vector_index("Doc", "embedding", Some(3), Some("cosine"), None, None, None)
+        .expect("create vector index");
+
+    let results = db
+        .vector_search("Doc", "embedding", &[1.0, 0.0, 0.0], 1, None, None)
+        .expect("search");
+
+    assert_eq!(results.len(), 1);
+    // Nearest to [1,0,0] should be node 1 (the one with [1,0,0])
+    let (nearest_id, distance) = results[0];
+    assert!(
+        distance < 0.01,
+        "exact match should have near-zero distance, got {distance}"
+    );
+
+    // Verify it's the right node by checking its property
+    let title = db.graph_store().get_node_property(
+        nearest_id,
+        &grafeo_common::types::PropertyKey::new("title"),
+    );
+    assert_eq!(title, Some(Value::String("alpha".into())));
+}
+
+#[test]
+#[cfg(feature = "vector-index")]
+fn rebuild_vector_index_after_compact() {
+    let db = setup_compacted_vector_db();
+
+    db.create_vector_index("Doc", "embedding", Some(3), Some("cosine"), None, None, None)
+        .expect("create");
+
+    db.rebuild_vector_index("Doc", "embedding")
+        .expect("rebuild after compact");
+
+    let results = db
+        .vector_search("Doc", "embedding", &[0.0, 1.0, 0.0], 3, None, None)
+        .expect("search after rebuild");
+
+    assert_eq!(results.len(), 3);
+}
+
+#[test]
+#[cfg(feature = "vector-index")]
+fn vector_search_with_filter_after_compact() {
+    let mut db = GrafeoDB::new_in_memory();
+
+    let n1 = db.create_node(&["Doc"]);
+    db.set_node_property(n1, "embedding", vec3(1.0, 0.0, 0.0));
+    db.set_node_property(n1, "category", Value::String("science".into()));
+
+    let n2 = db.create_node(&["Doc"]);
+    db.set_node_property(n2, "embedding", vec3(0.0, 1.0, 0.0));
+    db.set_node_property(n2, "category", Value::String("art".into()));
+
+    let n3 = db.create_node(&["Doc"]);
+    db.set_node_property(n3, "embedding", vec3(0.0, 0.0, 1.0));
+    db.set_node_property(n3, "category", Value::String("science".into()));
+
+    db.compact().expect("compact");
+    db.create_property_index("category");
+    db.create_vector_index("Doc", "embedding", Some(3), Some("cosine"), None, None, None)
+        .expect("create vector index");
+
+    let mut filters = std::collections::HashMap::new();
+    filters.insert("category".to_string(), Value::String("science".into()));
+
+    let results = db
+        .vector_search("Doc", "embedding", &[1.0, 0.0, 0.0], 3, None, Some(&filters))
+        .expect("filtered search");
+
+    assert_eq!(results.len(), 2, "should only return science nodes");
+}
+
+// ── Text index after compact ───────────────────────────────────────
+
+#[test]
+#[cfg(feature = "text-index")]
+fn text_index_after_compact() {
+    let mut db = GrafeoDB::new_in_memory();
+
+    let n1 = db.create_node(&["Article"]);
+    db.set_node_property(n1, "body", Value::String("the quick brown fox jumps over the lazy dog".into()));
+
+    let n2 = db.create_node(&["Article"]);
+    db.set_node_property(n2, "body", Value::String("a fast brown fox leaps over a sleepy hound".into()));
+
+    let n3 = db.create_node(&["Article"]);
+    db.set_node_property(n3, "body", Value::String("the cat sat on the mat".into()));
+
+    db.compact().expect("compact");
+
+    db.create_text_index("Article", "body").expect("create text index after compact");
+
+    let results = db.text_search("Article", "body", "fox", 10).expect("text search");
+    assert_eq!(results.len(), 2, "should find both fox articles from pre-compact data");
+}
+
+// ── Snapshot round-trip ────────────────────────────────────────────
+
+#[test]
+#[cfg(feature = "vector-index")]
+fn snapshot_compact_vector_index_round_trip() {
+    // Phase 1: build DB, export snapshot
+    let snapshot_bytes = {
+        let db = GrafeoDB::new_in_memory();
+        let n1 = db.create_node(&["Doc"]);
+        db.set_node_property(n1, "embedding", vec3(1.0, 0.0, 0.0));
+        let n2 = db.create_node(&["Doc"]);
+        db.set_node_property(n2, "embedding", vec3(0.0, 1.0, 0.0));
+        let n3 = db.create_node(&["Doc"]);
+        db.set_node_property(n3, "embedding", vec3(0.0, 0.0, 1.0));
+        db.export_snapshot().expect("export")
+    };
+
+    // Phase 2: import → compact → create index → search
+    let mut db = GrafeoDB::import_snapshot(&snapshot_bytes).expect("import");
+    db.compact().expect("compact after import");
+
+    db.create_vector_index("Doc", "embedding", Some(3), Some("cosine"), None, None, None)
+        .expect("create vector index after snapshot+compact");
+
+    let results = db
+        .vector_search("Doc", "embedding", &[1.0, 0.0, 0.0], 3, None, None)
+        .expect("vector search after snapshot+compact");
+
+    assert_eq!(results.len(), 3, "should find all nodes from snapshot");
+}
+
+// ── LayeredStore trait method forwarding ────────────────────────────
+
+#[test]
+#[cfg(feature = "vector-index")]
+fn layered_store_has_vector_index_forwards_to_overlay() {
+
+    let mut db = GrafeoDB::new_in_memory();
+
+    let n = db.create_node(&["Doc"]);
+    db.set_node_property(n, "embedding", vec3(1.0, 0.0, 0.0));
+
+    db.compact().expect("compact");
+
+    // No index yet — graph_store (LayeredStore) should report false
+    let gs = db.graph_store();
+    assert!(!gs.has_vector_index("Doc", "embedding"));
+
+    // Create index on the overlay via the imperative API
+    db.create_vector_index("Doc", "embedding", Some(3), Some("cosine"), None, None, None)
+        .expect("create");
+
+    // Now LayeredStore should forward to overlay and report true
+    let gs = db.graph_store();
+    assert!(gs.has_vector_index("Doc", "embedding"));
+    assert!(gs.get_vector_index_handle("Doc", "embedding").is_some());
+}
+
+#[test]
+#[cfg(feature = "text-index")]
+fn layered_store_has_text_index_forwards_to_overlay() {
+
+    let mut db = GrafeoDB::new_in_memory();
+
+    let n = db.create_node(&["Article"]);
+    db.set_node_property(n, "body", Value::String("hello world".into()));
+
+    db.compact().expect("compact");
+
+    let gs = db.graph_store();
+    assert!(!gs.has_text_index("Article", "body"));
+
+    db.create_text_index("Article", "body").expect("create");
+
+    let gs = db.graph_store();
+    assert!(gs.has_text_index("Article", "body"));
+}

--- a/docs/superpowers/plans/2026-04-14-unified-hybrid-queries.md
+++ b/docs/superpowers/plans/2026-04-14-unified-hybrid-queries.md
@@ -1,0 +1,2069 @@
+# Unified Hybrid Queries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make graph + vector + text compose in a single Cypher/GQL query with index-accelerated execution.
+
+**Architecture:** Teach the query planner to recognize vector/text function calls in WHERE and ORDER BY, rewrite them into existing VectorScan/new TextScan physical operators when backed by indexes, project scores for downstream reuse, and handle compound predicates by running both indexes and joining results.
+
+**Tech Stack:** Rust, grafeo-core (operators, indexes), grafeo-engine (planner, optimizer), feature flags: `vector-index`, `text-index`, `hybrid-search`
+
+**Spec:** `docs/superpowers/specs/2026-04-14-unified-hybrid-queries-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `crates/grafeo-core/src/index/text/inverted_index.rs` | Modify | Add `score_document()`, `search_with_threshold()` |
+| `crates/grafeo-core/src/execution/operators/scan_text.rs` | Create | `TextScanOperator` — BM25 index scan, outputs `(NodeId, Float64)` |
+| `crates/grafeo-core/src/execution/operators/mod.rs` | Modify | Export `TextScanOperator` |
+| `crates/grafeo-core/src/execution/operators/filter.rs` | Modify | Add `eval_text_fn` to function cascade |
+| `crates/grafeo-engine/src/query/plan.rs` | Modify | Add `TextScan(TextScanOp)` to `LogicalOperator`, define `TextScanOp` struct |
+| `crates/grafeo-engine/src/query/planner/lpg/filter.rs` | Modify | Add `try_plan_filter_with_vector_index()`, `try_plan_filter_with_text_index()`, `try_plan_filter_compound_hybrid()` |
+| `crates/grafeo-engine/src/query/planner/lpg/mod.rs` | Modify | Add `plan_text_scan()` dispatch, top-K recognition in `plan_operator()` |
+| `crates/grafeo-engine/src/query/planner/lpg/project.rs` | Modify | Score projection + expression rewriting in `plan_sort()` |
+| `crates/grafeo-engine/src/query/optimizer/cardinality.rs` | Modify | Add `estimate_text_scan()` |
+| `crates/grafeo-engine/src/query/optimizer/cost.rs` | Modify | Add TextScan cost formula |
+| `crates/grafeo-engine/tests/hybrid_query.rs` | Create | End-to-end integration tests |
+
+---
+
+### Task 1: InvertedIndex API — `score_document()` and `search_with_threshold()`
+
+**Files:**
+- Modify: `crates/grafeo-core/src/index/text/inverted_index.rs`
+
+These two methods are the foundation. `score_document()` enables per-row text scoring in the filter fallback path. `search_with_threshold()` enables TextScan when the predicate is `text_score(...) > threshold`.
+
+- [ ] **Step 1: Write failing test for `score_document()`**
+
+Add to the existing `#[cfg(test)] mod tests` block at line 300:
+
+```rust
+#[test]
+fn test_score_document_matches_search() {
+    let mut index = InvertedIndex::new(BM25Config::default());
+    index.insert(NodeId::new(1), "the quick brown fox jumps over the lazy dog");
+    index.insert(NodeId::new(2), "a fast red car drives on the highway");
+    index.insert(NodeId::new(3), "the brown dog sleeps all day");
+
+    // score_document should return the same score as search for each doc
+    let search_results = index.search("brown dog", 10);
+    for (node_id, expected_score) in &search_results {
+        let single_score = index.score_document(*node_id, "brown dog");
+        assert!(
+            (single_score - expected_score).abs() < 1e-10,
+            "score_document({:?}) = {}, search = {}",
+            node_id, single_score, expected_score
+        );
+    }
+
+    // Document not matching any terms should score 0
+    assert_eq!(index.score_document(NodeId::new(2), "brown dog"), 0.0);
+
+    // Non-existent document should score 0
+    assert_eq!(index.score_document(NodeId::new(999), "brown dog"), 0.0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p grafeo-core --features text-index -- test_score_document_matches_search`
+Expected: FAIL — `score_document` method doesn't exist.
+
+- [ ] **Step 3: Implement `score_document()`**
+
+Add after the `search()` method (after line 193), before `contains()`:
+
+```rust
+/// Scores a single document against a query using BM25.
+///
+/// Looks up each query term in its posting list, finds the entry for `id`,
+/// and computes BM25 with the corpus statistics in this index.
+/// Returns 0.0 if the document has no matching terms or doesn't exist.
+///
+/// O(query_terms) per call — does not iterate the full corpus.
+pub fn score_document(&self, id: NodeId, query: &str) -> f64 {
+    let query_tokens = self.tokenizer.tokenize(query);
+    if query_tokens.is_empty() || self.doc_lengths.is_empty() {
+        return 0.0;
+    }
+
+    let Some(&doc_len) = self.doc_lengths.get(&id) else {
+        return 0.0;
+    };
+
+    let n = self.doc_lengths.len() as f64;
+    let avg_dl = self.total_length as f64 / n;
+    let dl = f64::from(doc_len);
+    let mut score = 0.0;
+
+    for token in &query_tokens {
+        let Some(posting_list) = self.postings.get(token.as_str()) else {
+            continue;
+        };
+
+        let df = posting_list.postings.len() as f64;
+        let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+
+        // Find this document's term frequency in the posting list
+        let tf = posting_list
+            .postings
+            .iter()
+            .find(|p| p.node_id == id)
+            .map_or(0.0, |p| f64::from(p.term_freq));
+
+        if tf > 0.0 {
+            let tf_component = (tf * (self.config.k1 + 1.0))
+                / (tf + self.config.k1 * (1.0 - self.config.b + self.config.b * dl / avg_dl));
+            score += idf * tf_component;
+        }
+    }
+
+    score
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p grafeo-core --features text-index -- test_score_document_matches_search`
+Expected: PASS
+
+- [ ] **Step 5: Write failing test for `search_with_threshold()`**
+
+```rust
+#[test]
+fn test_search_with_threshold() {
+    let mut index = InvertedIndex::new(BM25Config::default());
+    index.insert(NodeId::new(1), "rust graph database engine");
+    index.insert(NodeId::new(2), "rust programming language systems web server framework database engine query optimizer");
+    index.insert(NodeId::new(3), "python web framework");
+
+    // Get scores from search to calibrate threshold
+    let all_results = index.search("rust database", 10);
+    assert_eq!(all_results.len(), 2); // nodes 1 and 2
+
+    // Node 1 scores higher (shorter doc, both terms)
+    let high_score = all_results[0].1;
+    let low_score = all_results[1].1;
+    assert!(high_score > low_score);
+
+    // Threshold between the two scores: only node 1 should pass
+    let mid_threshold = (high_score + low_score) / 2.0;
+    let filtered = index.search_with_threshold("rust database", mid_threshold);
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].0, NodeId::new(1));
+    assert!(filtered[0].1 >= mid_threshold);
+
+    // Threshold of 0 returns all matching docs
+    let all = index.search_with_threshold("rust database", 0.0);
+    assert_eq!(all.len(), 2);
+
+    // Very high threshold returns nothing
+    let none = index.search_with_threshold("rust database", 999.0);
+    assert!(none.is_empty());
+
+    // Empty query returns nothing
+    let empty = index.search_with_threshold("", 0.0);
+    assert!(empty.is_empty());
+}
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `cargo test -p grafeo-core --features text-index -- test_search_with_threshold`
+Expected: FAIL — `search_with_threshold` method doesn't exist.
+
+- [ ] **Step 7: Implement `search_with_threshold()`**
+
+Add after `score_document()`:
+
+```rust
+/// Returns all documents scoring above `threshold` for the given query.
+///
+/// Unlike `search()` which returns top-k, this returns every document
+/// whose BM25 score exceeds the threshold. Results are sorted by score
+/// descending.
+pub fn search_with_threshold(&self, query: &str, threshold: f64) -> Vec<(NodeId, f64)> {
+    let query_tokens = self.tokenizer.tokenize(query);
+    if query_tokens.is_empty() || self.doc_lengths.is_empty() {
+        return Vec::new();
+    }
+
+    let n = self.doc_lengths.len() as f64;
+    let avg_dl = self.total_length as f64 / n;
+
+    let mut scores: HashMap<NodeId, f64> = HashMap::new();
+
+    for token in &query_tokens {
+        let Some(posting_list) = self.postings.get(token.as_str()) else {
+            continue;
+        };
+
+        let df = posting_list.postings.len() as f64;
+        let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+
+        for posting in &posting_list.postings {
+            let tf = f64::from(posting.term_freq);
+            let dl = f64::from(self.doc_lengths.get(&posting.node_id).copied().unwrap_or(0));
+
+            let tf_component = (tf * (self.config.k1 + 1.0))
+                / (tf + self.config.k1 * (1.0 - self.config.b + self.config.b * dl / avg_dl));
+
+            *scores.entry(posting.node_id).or_insert(0.0) += idf * tf_component;
+        }
+    }
+
+    let mut results: Vec<(NodeId, f64)> = scores
+        .into_iter()
+        .filter(|(_, score)| *score >= threshold)
+        .collect();
+    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    results
+}
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `cargo test -p grafeo-core --features text-index -- test_search_with_threshold`
+Expected: PASS
+
+- [ ] **Step 9: Run all existing inverted index tests to check for regressions**
+
+Run: `cargo test -p grafeo-core --features text-index -- inverted_index::tests`
+Expected: All existing tests PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/grafeo-core/src/index/text/inverted_index.rs
+git commit -m "feat(text): add score_document() and search_with_threshold() to InvertedIndex
+
+score_document() scores a single document in O(query_terms) for per-row
+evaluation. search_with_threshold() returns all documents above a BM25
+threshold for TextScan WHERE predicates."
+```
+
+---
+
+### Task 2: TextScanOperator
+
+**Files:**
+- Create: `crates/grafeo-core/src/execution/operators/scan_text.rs`
+- Modify: `crates/grafeo-core/src/execution/operators/mod.rs`
+
+Modeled directly on `VectorScanOperator` (`scan_vector.rs`). Same output schema: `(NodeId, Float64)`.
+
+- [ ] **Step 1: Write failing test**
+
+Create `crates/grafeo-core/src/execution/operators/scan_text.rs` with the test module first:
+
+```rust
+//! Full-text search scan operator.
+//!
+//! Performs BM25-scored search using an inverted index, returning
+//! matching nodes with their relevance scores.
+
+use super::{Operator, OperatorError, OperatorResult};
+use crate::execution::DataChunk;
+use crate::index::text::InvertedIndex;
+use grafeo_common::types::{LogicalType, NodeId, Value};
+use std::sync::{Arc, RwLock};
+
+// Struct and impl will go here
+
+#[cfg(all(test, feature = "text-index"))]
+mod tests {
+    use super::*;
+    use crate::index::text::BM25Config;
+
+    fn make_index() -> Arc<RwLock<InvertedIndex>> {
+        let mut index = InvertedIndex::new(BM25Config::default());
+        index.insert(NodeId::new(1), "rust graph database engine");
+        index.insert(NodeId::new(2), "python web framework");
+        index.insert(NodeId::new(3), "rust systems programming language");
+        Arc::new(RwLock::new(index))
+    }
+
+    #[test]
+    fn test_text_scan_top_k() {
+        let index = make_index();
+        let mut scan = TextScanOperator::top_k(Arc::clone(&index), "rust", 2);
+
+        let chunk = scan.next().unwrap().unwrap();
+        assert_eq!(chunk.row_count(), 2);
+
+        // Both nodes 1 and 3 mention "rust"
+        let n1 = chunk.column(0).unwrap().get_node_id(0);
+        let score1 = chunk.column(1).unwrap().get_float64(0);
+        assert!(n1.is_some());
+        assert!(score1.unwrap() > 0.0);
+
+        // Should be exhausted
+        assert!(scan.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_text_scan_with_threshold() {
+        let index = make_index();
+        // Get all results first to find a threshold
+        let all = index.read().unwrap().search("rust database", 10);
+        assert_eq!(all.len(), 2); // nodes 1 and 3
+
+        // Use a threshold that only the top result passes
+        let mid = (all[0].1 + all[1].1) / 2.0;
+        let mut scan = TextScanOperator::with_threshold(Arc::clone(&index), "rust database", mid);
+
+        let chunk = scan.next().unwrap().unwrap();
+        assert_eq!(chunk.row_count(), 1);
+        assert_eq!(chunk.column(0).unwrap().get_node_id(0), Some(all[0].0));
+
+        assert!(scan.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_text_scan_no_matches() {
+        let index = make_index();
+        let mut scan = TextScanOperator::top_k(Arc::clone(&index), "nonexistent", 10);
+        assert!(scan.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_text_scan_reset() {
+        let index = make_index();
+        let mut scan = TextScanOperator::top_k(Arc::clone(&index), "rust", 10);
+
+        let chunk1 = scan.next().unwrap().unwrap();
+        assert_eq!(chunk1.row_count(), 2);
+        assert!(scan.next().unwrap().is_none());
+
+        scan.reset();
+        let chunk2 = scan.next().unwrap().unwrap();
+        assert_eq!(chunk2.row_count(), 2);
+    }
+
+    #[test]
+    fn test_text_scan_name() {
+        let index = make_index();
+        let scan = TextScanOperator::top_k(Arc::clone(&index), "rust", 10);
+        assert_eq!(scan.name(), "TextScan(BM25)");
+    }
+
+    #[test]
+    fn test_text_scan_chunk_capacity() {
+        let index = make_index();
+        let mut scan = TextScanOperator::top_k(Arc::clone(&index), "rust", 10)
+            .with_chunk_capacity(1);
+
+        let chunk1 = scan.next().unwrap().unwrap();
+        assert_eq!(chunk1.row_count(), 1);
+        let chunk2 = scan.next().unwrap().unwrap();
+        assert_eq!(chunk2.row_count(), 1);
+        assert!(scan.next().unwrap().is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p grafeo-core --features text-index,lpg -- scan_text::tests`
+Expected: FAIL — `TextScanOperator` not defined.
+
+- [ ] **Step 3: Implement `TextScanOperator`**
+
+Add above the test module in `scan_text.rs`:
+
+```rust
+/// A scan operator that finds nodes by full-text search with BM25 scoring.
+///
+/// Operates in two modes:
+/// - **Top-K**: Returns the k highest-scoring documents (for ORDER BY + LIMIT)
+/// - **Threshold**: Returns all documents scoring above a threshold (for WHERE)
+///
+/// # Output Schema
+///
+/// Returns a DataChunk with two columns:
+/// 1. `Node` — The matched node ID
+/// 2. `Float64` — The BM25 relevance score
+pub struct TextScanOperator {
+    /// The text index to search.
+    index: Arc<RwLock<InvertedIndex>>,
+    /// The search query string.
+    query: String,
+    /// Top-k mode (None = threshold mode).
+    k: Option<usize>,
+    /// Threshold mode (None = top-k mode).
+    threshold: Option<f64>,
+    /// Cached results from search.
+    results: Vec<(NodeId, f64)>,
+    /// Current position in results.
+    position: usize,
+    /// Whether search has been executed.
+    executed: bool,
+    /// Chunk capacity.
+    chunk_capacity: usize,
+}
+
+impl TextScanOperator {
+    /// Creates a text scan that returns the top-k results by BM25 score.
+    #[must_use]
+    pub fn top_k(index: Arc<RwLock<InvertedIndex>>, query: impl Into<String>, k: usize) -> Self {
+        Self {
+            index,
+            query: query.into(),
+            k: Some(k),
+            threshold: None,
+            results: Vec::new(),
+            position: 0,
+            executed: false,
+            chunk_capacity: 2048,
+        }
+    }
+
+    /// Creates a text scan that returns all documents above a score threshold.
+    #[must_use]
+    pub fn with_threshold(
+        index: Arc<RwLock<InvertedIndex>>,
+        query: impl Into<String>,
+        threshold: f64,
+    ) -> Self {
+        Self {
+            index,
+            query: query.into(),
+            k: None,
+            threshold: Some(threshold),
+            results: Vec::new(),
+            position: 0,
+            executed: false,
+            chunk_capacity: 2048,
+        }
+    }
+
+    /// Sets the chunk capacity for output batches.
+    #[must_use]
+    pub fn with_chunk_capacity(mut self, capacity: usize) -> Self {
+        self.chunk_capacity = capacity;
+        self
+    }
+
+    /// Executes the text search (lazily on first next() call).
+    fn execute_search(&mut self) {
+        if self.executed {
+            return;
+        }
+        self.executed = true;
+
+        let index = self.index.read().unwrap();
+        self.results = if let Some(k) = self.k {
+            index.search(&self.query, k)
+        } else if let Some(threshold) = self.threshold {
+            index.search_with_threshold(&self.query, threshold)
+        } else {
+            Vec::new()
+        };
+    }
+}
+
+impl Operator for TextScanOperator {
+    fn next(&mut self) -> OperatorResult {
+        self.execute_search();
+
+        if self.position >= self.results.len() {
+            return Ok(None);
+        }
+
+        let schema = [LogicalType::Node, LogicalType::Float64];
+        let mut chunk = DataChunk::with_capacity(&schema, self.chunk_capacity);
+
+        let end = (self.position + self.chunk_capacity).min(self.results.len());
+        let count = end - self.position;
+
+        {
+            let node_col = chunk
+                .column_mut(0)
+                .ok_or_else(|| OperatorError::ColumnNotFound("node column".into()))?;
+            for i in self.position..end {
+                node_col.push_node_id(self.results[i].0);
+            }
+        }
+
+        {
+            let score_col = chunk
+                .column_mut(1)
+                .ok_or_else(|| OperatorError::ColumnNotFound("score column".into()))?;
+            for i in self.position..end {
+                score_col.push_float64(self.results[i].1);
+            }
+        }
+
+        chunk.set_count(count);
+        self.position = end;
+
+        Ok(Some(chunk))
+    }
+
+    fn reset(&mut self) {
+        self.position = 0;
+        self.results.clear();
+        self.executed = false;
+    }
+
+    fn name(&self) -> &'static str {
+        "TextScan(BM25)"
+    }
+}
+```
+
+- [ ] **Step 4: Add module and export to `mod.rs`**
+
+In `crates/grafeo-core/src/execution/operators/mod.rs`, add after line 43 (`mod scan_vector;`):
+
+```rust
+#[cfg(feature = "text-index")]
+mod scan_text;
+```
+
+And add the export after line 98 (`pub use scan_vector::VectorScanOperator;`):
+
+```rust
+#[cfg(feature = "text-index")]
+pub use scan_text::TextScanOperator;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p grafeo-core --features text-index,lpg -- scan_text::tests`
+Expected: All 6 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/grafeo-core/src/execution/operators/scan_text.rs crates/grafeo-core/src/execution/operators/mod.rs
+git commit -m "feat(operators): add TextScanOperator for BM25 index scans
+
+Parallel to VectorScanOperator. Supports top-k and threshold modes.
+Outputs (NodeId, Float64) DataChunks with BM25 relevance scores."
+```
+
+---
+
+### Task 3: eval_text_fn — per-row text scoring in filter evaluation
+
+**Files:**
+- Modify: `crates/grafeo-core/src/execution/operators/filter.rs`
+
+This adds `text_score()` and `text_match()` as functions callable in WHERE clauses. When no planner pushdown fires (e.g., graph traversal narrows candidates), this is the execution path. It calls `InvertedIndex.score_document()` for each candidate row.
+
+- [ ] **Step 1: Write failing test**
+
+Add to the existing test module in `filter.rs` (after line 3951). The filter operator's `eval_function` already dispatches through `eval_vector_fn` etc. We need the store to have a text index. For unit testing, we test `eval_text_fn` directly. But the method is private on `ExpressionPredicate`, so we test through a full filter evaluation with a mock:
+
+```rust
+#[cfg(all(test, feature = "text-index", feature = "lpg"))]
+mod text_fn_tests {
+    use super::*;
+    use crate::graph::lpg::LpgStore;
+
+    #[test]
+    fn test_text_score_function() {
+        let store = Arc::new(LpgStore::new().unwrap());
+
+        // Create nodes with string properties
+        let n1 = store.create_node(&["Article"]);
+        store.set_node_property(n1, "body", Value::String("rust graph database engine".into()));
+        let n2 = store.create_node(&["Article"]);
+        store.set_node_property(n2, "body", Value::String("python web framework".into()));
+
+        // Create and populate text index
+        store.create_text_index("Article", "body").unwrap();
+
+        // Build a filter expression: text_score(n.body, "rust database") > 0
+        let filter_expr = FilterExpression::BinaryOp {
+            left: Box::new(FilterExpression::FunctionCall {
+                name: "text_score".to_string(),
+                args: vec![
+                    FilterExpression::PropertyAccess {
+                        object: Box::new(FilterExpression::Variable("doc".to_string())),
+                        property: "body".to_string(),
+                    },
+                    FilterExpression::Literal(Value::String("rust database".into())),
+                ],
+            }),
+            op: BinaryFilterOp::Gt,
+            right: Box::new(FilterExpression::Literal(Value::Float64(0.0))),
+        };
+
+        // Create a chunk with node IDs
+        let schema = [LogicalType::Node];
+        let mut chunk = DataChunk::with_capacity(&schema, 2);
+        chunk.column_mut(0).unwrap().push_node_id(n1);
+        chunk.column_mut(0).unwrap().push_node_id(n2);
+        chunk.set_count(2);
+
+        let variable_columns: HashMap<String, usize> = [("doc".to_string(), 0)].into_iter().collect();
+
+        let predicate = ExpressionPredicate::new(
+            filter_expr,
+            variable_columns,
+            Arc::clone(&store) as Arc<dyn GraphStore>,
+        );
+
+        // n1 has "rust" and "database" -> should match
+        assert!(predicate.evaluate(&chunk, 0));
+        // n2 has neither -> should not match
+        assert!(!predicate.evaluate(&chunk, 1));
+    }
+
+    #[test]
+    fn test_text_match_function() {
+        let store = Arc::new(LpgStore::new().unwrap());
+
+        let n1 = store.create_node(&["Article"]);
+        store.set_node_property(n1, "body", Value::String("rust graph database engine".into()));
+        let n2 = store.create_node(&["Article"]);
+        store.set_node_property(n2, "body", Value::String("python web framework".into()));
+
+        store.create_text_index("Article", "body").unwrap();
+
+        // text_match(doc.body, "rust") -> should return Bool
+        let filter_expr = FilterExpression::FunctionCall {
+            name: "text_match".to_string(),
+            args: vec![
+                FilterExpression::PropertyAccess {
+                    object: Box::new(FilterExpression::Variable("doc".to_string())),
+                    property: "body".to_string(),
+                },
+                FilterExpression::Literal(Value::String("rust".into())),
+            ],
+        };
+
+        let schema = [LogicalType::Node];
+        let mut chunk = DataChunk::with_capacity(&schema, 2);
+        chunk.column_mut(0).unwrap().push_node_id(n1);
+        chunk.column_mut(0).unwrap().push_node_id(n2);
+        chunk.set_count(2);
+
+        let variable_columns: HashMap<String, usize> = [("doc".to_string(), 0)].into_iter().collect();
+
+        let predicate = ExpressionPredicate::new(
+            filter_expr,
+            variable_columns,
+            Arc::clone(&store) as Arc<dyn GraphStore>,
+        );
+
+        // text_match returns Bool, so we check directly
+        // n1 has "rust" -> true, n2 doesn't -> false
+        assert!(predicate.evaluate(&chunk, 0));
+        assert!(!predicate.evaluate(&chunk, 1));
+    }
+}
+```
+
+**Note:** The exact `FilterExpression` variant names (`BinaryOp`, `PropertyAccess`, etc.) must match the actual enum in `filter.rs`. Read the `FilterExpression` enum definition (around line 459) before writing the test — adapt variant names and field names to match exactly. The test above uses placeholder names; the implementer must verify against the actual enum.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p grafeo-core --features text-index,lpg -- text_fn_tests`
+Expected: FAIL — `text_score` and `text_match` not recognized by `eval_function`.
+
+- [ ] **Step 3: Implement `eval_text_fn()`**
+
+Add the method to the `ExpressionPredicate` impl block, after `eval_vector_fn` (after line 3331):
+
+```rust
+#[cfg(feature = "text-index")]
+fn eval_text_fn(
+    &self,
+    name: &str,
+    args: &[FilterExpression],
+    chunk: &DataChunk,
+    row: usize,
+) -> Option<Value> {
+    match name {
+        "text_score" | "text_match" => {
+            if args.len() != 2 {
+                return None;
+            }
+
+            // First arg: property access -> need node_id and property name
+            // Extract the node_id from the chunk and the property name from the expression
+            let (node_id, property_name) = self.extract_node_and_property(&args[0], chunk, row)?;
+
+            // Second arg: query string
+            let query_val = self.eval_expr(&args[1], chunk, row)?;
+            let query_str = match &query_val {
+                Value::String(s) => s.as_ref(),
+                _ => return None,
+            };
+
+            // Get the node's label(s) to look up the text index
+            let labels = self.store.get_node_labels(node_id)?;
+            let label = labels.first()?;
+
+            // Look up the text index for (label, property)
+            let index = self.store.get_text_index(label, &property_name)?;
+            let index_guard = index.read().ok()?;
+            let score = index_guard.score_document(node_id, query_str);
+
+            if name == "text_match" {
+                Some(Value::Bool(score > 0.0))
+            } else {
+                Some(Value::Float64(score))
+            }
+        }
+        _ => None,
+    }
+}
+```
+
+**Note:** The `extract_node_and_property` helper may not exist. The implementer should check how `eval_vector_fn` extracts property values from `FilterExpression` args and follow the same pattern. The key steps are: (1) evaluate the property access expression to get the Value, (2) get the node_id from the chunk at the variable's column index, (3) get the property name from the expression AST. Adapt to the actual `FilterExpression` structure.
+
+- [ ] **Step 4: Add `eval_text_fn` to the function cascade**
+
+In the `eval_function` method (line 1558-1576), add after the `eval_vector_fn` call:
+
+```rust
+.or_else(|| self.eval_vector_fn(name, args, chunk, row))
+#[cfg(feature = "text-index")]
+.or_else(|| self.eval_text_fn(name, args, chunk, row))
+.or_else(|| self.eval_session_fn(name, args, chunk, row))
+```
+
+**Note:** Inline `#[cfg]` on method chain calls may not compile. If not, use a conditional block:
+
+```rust
+let result = self.eval_vector_fn(name, args, chunk, row);
+#[cfg(feature = "text-index")]
+let result = result.or_else(|| self.eval_text_fn(name, args, chunk, row));
+let result = result.or_else(|| self.eval_session_fn(name, args, chunk, row));
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p grafeo-core --features text-index,lpg -- text_fn_tests`
+Expected: PASS
+
+- [ ] **Step 6: Run all filter tests for regressions**
+
+Run: `cargo test -p grafeo-core --features text-index,lpg -- filter::tests`
+Expected: All existing tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/grafeo-core/src/execution/operators/filter.rs
+git commit -m "feat(filter): add text_score() and text_match() function evaluation
+
+Per-row BM25 scoring via InvertedIndex.score_document(). Used as the
+fallback path when planner pushdown doesn't fire (e.g., graph traversal
+already narrowed candidates)."
+```
+
+---
+
+### Task 4: TextScanOp logical operator + planner dispatch
+
+**Files:**
+- Modify: `crates/grafeo-engine/src/query/plan.rs` (add `TextScanOp` struct and `LogicalOperator::TextScan` variant)
+- Modify: `crates/grafeo-engine/src/query/planner/lpg/mod.rs` (add `plan_text_scan()` method, dispatch in `plan_operator()`)
+
+- [ ] **Step 1: Add `TextScanOp` to plan.rs**
+
+After `VectorJoinOp` definition (around line 1951), add:
+
+```rust
+/// Text search scan using BM25 inverted index.
+///
+/// Produced by the planner when it recognizes text_score/text_match
+/// predicates in WHERE or text_score in ORDER BY + LIMIT.
+#[derive(Debug, Clone)]
+pub struct TextScanOp {
+    /// The variable name bound to matched nodes.
+    pub variable: String,
+    /// The property containing indexed text.
+    pub property: String,
+    /// The label to look up the text index.
+    pub label: String,
+    /// The search query (literal or parameter).
+    pub query: LogicalExpression,
+    /// Top-k limit (for ORDER BY + LIMIT mode).
+    pub k: Option<usize>,
+    /// Score threshold (for WHERE mode).
+    pub threshold: Option<f64>,
+    /// Synthetic column name for the projected score.
+    pub score_column: Option<String>,
+}
+```
+
+Add the variant to `LogicalOperator` enum, after `VectorJoin` (line 272):
+
+```rust
+/// Scan using full-text search with BM25 scoring.
+TextScan(TextScanOp),
+```
+
+- [ ] **Step 2: Add `plan_text_scan()` to the planner**
+
+In `crates/grafeo-engine/src/query/planner/lpg/mod.rs`, add a method to the `Planner` impl:
+
+```rust
+/// Plans a TextScan operator into a physical TextScanOperator.
+#[cfg(feature = "text-index")]
+fn plan_text_scan(
+    &self,
+    scan: &TextScanOp,
+) -> Result<(Box<dyn Operator>, Vec<String>)> {
+    use grafeo_core::execution::operators::TextScanOperator;
+
+    // Resolve the query expression to a string value
+    let query_string = match &scan.query {
+        LogicalExpression::Literal(Value::String(s)) => s.to_string(),
+        LogicalExpression::Parameter(name) => {
+            // Parameter resolution would happen here at execution time
+            // For now, return error if unresolved
+            return Err(Error::Internal(format!(
+                "TextScan query parameter ${} not resolved", name
+            )));
+        }
+        _ => return Err(Error::Internal(
+            "TextScan query must be a string literal or parameter".to_string(),
+        )),
+    };
+
+    // Look up the text index
+    let index = self.store.get_text_index(&scan.label, &scan.property)
+        .ok_or_else(|| Error::Internal(format!(
+            "No text index on ({}, {})", scan.label, scan.property
+        )))?;
+
+    // Create the physical operator
+    let operator: Box<dyn Operator> = if let Some(k) = scan.k {
+        Box::new(TextScanOperator::top_k(index, &query_string, k))
+    } else if let Some(threshold) = scan.threshold {
+        Box::new(TextScanOperator::with_threshold(index, &query_string, threshold))
+    } else {
+        Box::new(TextScanOperator::top_k(index, &query_string, 100))
+    };
+
+    // Output columns: variable (node), score column if named
+    let mut columns = vec![scan.variable.clone()];
+    if let Some(ref score_col) = scan.score_column {
+        columns.push(score_col.clone());
+    }
+
+    Ok((operator, columns))
+}
+```
+
+- [ ] **Step 3: Add dispatch in `plan_operator()`**
+
+In `plan_operator()` (line 659-661), replace the VectorScan error and add TextScan handling:
+
+```rust
+#[cfg(feature = "vector-index")]
+LogicalOperator::VectorScan(scan) => self.plan_vector_scan(scan),
+#[cfg(not(feature = "vector-index"))]
+LogicalOperator::VectorScan(_) => Err(Error::Internal(
+    "VectorScan requires vector-index feature".to_string(),
+)),
+#[cfg(feature = "text-index")]
+LogicalOperator::TextScan(scan) => self.plan_text_scan(scan),
+#[cfg(not(feature = "text-index"))]
+LogicalOperator::TextScan(_) => Err(Error::Internal(
+    "TextScan requires text-index feature".to_string(),
+)),
+```
+
+**Note:** The VectorScan dispatch may already have a feature-gated handler elsewhere. Check if `plan_vector_scan` exists in another file before adding it. If the current code only has the error stub (lines 659-661), replace it.
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cargo check -p grafeo-engine --features text-index,vector-index,lpg,gql`
+Expected: Compiles without errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/grafeo-engine/src/query/plan.rs crates/grafeo-engine/src/query/planner/lpg/mod.rs
+git commit -m "feat(planner): add TextScanOp logical operator and plan_text_scan dispatch
+
+TextScanOp holds the query, label, property, optional k/threshold.
+The planner resolves it to a physical TextScanOperator, looking up
+the text index from the store."
+```
+
+---
+
+### Task 5: Vector predicate pushdown in filter.rs
+
+**Files:**
+- Modify: `crates/grafeo-engine/src/query/planner/lpg/filter.rs`
+
+This is the core planner rewrite. Pattern-match vector function calls in WHERE predicates, check for HNSW index, produce VectorScanOperator.
+
+- [ ] **Step 1: Add `try_plan_filter_with_vector_index()` method**
+
+Add to the `Planner` impl block in `filter.rs`, after `try_plan_filter_with_range_index()` (after line 1122):
+
+```rust
+/// Attempts to push a vector similarity predicate into an HNSW index scan.
+///
+/// Recognizes patterns like:
+/// - `cosine_similarity(n.prop, $vec) > 0.7` → VectorScan with min_similarity
+/// - `euclidean_distance(n.prop, $vec) < 2.0` → VectorScan with max_distance
+///
+/// Only fires when the input is a NodeScan (full label scan). If the input
+/// is already narrowed by graph traversal, per-row eval is faster.
+#[cfg(feature = "vector-index")]
+pub(super) fn try_plan_filter_with_vector_index(
+    &self,
+    filter: &FilterOp,
+) -> Result<Option<(Box<dyn Operator>, Vec<String>)>> {
+    // Only push down when input is a full label scan
+    let LogicalOperator::NodeScan(scan) = filter.input.as_ref() else {
+        return Ok(None);
+    };
+    let Some(ref label) = scan.label else {
+        return Ok(None); // No label → can't look up index
+    };
+
+    // Extract a vector predicate from the filter expression
+    let Some(extracted) = self.extract_vector_predicate(&filter.predicate) else {
+        return Ok(None);
+    };
+
+    // Check that a vector index exists for this (label, property)
+    if self.store.get_vector_index(label, &extracted.property).is_none() {
+        return Ok(None); // No index → fall through to brute-force eval
+    }
+
+    // Build VectorScanOp
+    let vector_scan = VectorScanOp {
+        variable: scan.variable.clone(),
+        index_name: Some(format!("{}:{}", label, extracted.property)),
+        property: extracted.property.clone(),
+        label: Some(label.clone()),
+        query_vector: extracted.query_vector.clone(),
+        k: 0, // threshold mode, not top-k
+        metric: Some(extracted.metric),
+        min_similarity: extracted.min_similarity,
+        max_distance: extracted.max_distance,
+        input: None,
+    };
+
+    // Plan it through the existing VectorScan path
+    let (scan_op, scan_columns) = self.plan_operator(
+        &LogicalOperator::VectorScan(vector_scan)
+    )?;
+
+    // If there are remaining predicates (AND with non-vector conditions),
+    // wrap in a FilterOperator
+    if let Some(remaining) = &extracted.remaining {
+        let variable_columns: HashMap<String, usize> = scan_columns
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.clone(), i))
+            .collect();
+        let filter_expr = self.convert_expression(remaining)?;
+        let predicate = ExpressionPredicate::new(
+            filter_expr,
+            variable_columns,
+            Arc::clone(&self.store) as Arc<dyn GraphStore>,
+        )
+        .with_transaction_context(self.viewing_epoch, self.transaction_id)
+        .with_session_context(self.session_context.clone());
+        let filter_op = Box::new(FilterOperator::new(scan_op, Box::new(predicate)));
+        Ok(Some((filter_op, scan_columns)))
+    } else {
+        Ok(Some((scan_op, scan_columns)))
+    }
+}
+```
+
+- [ ] **Step 2: Implement the predicate extraction helper**
+
+```rust
+/// Result of extracting a vector predicate from a filter expression.
+#[cfg(feature = "vector-index")]
+struct ExtractedVectorPredicate {
+    property: String,
+    variable: String,
+    query_vector: LogicalExpression,
+    metric: VectorMetric,
+    min_similarity: Option<f32>,
+    max_distance: Option<f32>,
+    remaining: Option<LogicalExpression>,
+}
+
+#[cfg(feature = "vector-index")]
+impl super::Planner {
+    /// Extracts a vector similarity/distance predicate from a logical expression.
+    ///
+    /// Matches patterns like:
+    /// - `cosine_similarity(n.prop, expr) > threshold`
+    /// - `euclidean_distance(n.prop, expr) < threshold`
+    ///
+    /// For AND expressions, extracts the vector predicate and returns the
+    /// non-vector parts as `remaining`.
+    fn extract_vector_predicate(
+        &self,
+        expr: &LogicalExpression,
+    ) -> Option<ExtractedVectorPredicate> {
+        match expr {
+            // Direct: vector_fn(n.prop, vec) > threshold
+            LogicalExpression::Binary { left, op, right } => {
+                // Try left side as function call
+                if let LogicalExpression::FunctionCall { name, args, .. } = left.as_ref() {
+                    if let Some(extracted) = self.try_extract_vector_fn(name, args, op, right) {
+                        return Some(extracted);
+                    }
+                }
+                // AND: recurse into both sides
+                if *op == BinaryOp::And {
+                    // Try left as vector, right as remaining
+                    if let Some(mut extracted) = self.extract_vector_predicate(left) {
+                        extracted.remaining = Some(match extracted.remaining {
+                            Some(prev) => LogicalExpression::Binary {
+                                left: Box::new(prev),
+                                op: BinaryOp::And,
+                                right: right.clone(),
+                            },
+                            None => *right.clone(),
+                        });
+                        return Some(extracted);
+                    }
+                    // Try right as vector, left as remaining
+                    if let Some(mut extracted) = self.extract_vector_predicate(right) {
+                        extracted.remaining = Some(match extracted.remaining {
+                            Some(prev) => LogicalExpression::Binary {
+                                left: left.clone(),
+                                op: BinaryOp::And,
+                                right: Box::new(prev),
+                            },
+                            None => *left.clone(),
+                        });
+                        return Some(extracted);
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    /// Tries to extract a vector function call + threshold comparison.
+    fn try_extract_vector_fn(
+        &self,
+        name: &str,
+        args: &[LogicalExpression],
+        op: &BinaryOp,
+        threshold: &LogicalExpression,
+    ) -> Option<ExtractedVectorPredicate> {
+        if args.len() != 2 {
+            return None;
+        }
+
+        // Determine metric and comparison direction
+        let (metric, is_similarity) = match name {
+            "cosine_similarity" => (VectorMetric::Cosine, true),
+            "dot_product" => (VectorMetric::DotProduct, true),
+            "euclidean_distance" => (VectorMetric::Euclidean, false),
+            "manhattan_distance" => (VectorMetric::Manhattan, false),
+            _ => return None,
+        };
+
+        // Similarity uses >, distance uses <
+        let valid_op = if is_similarity {
+            matches!(op, BinaryOp::Gt | BinaryOp::Ge)
+        } else {
+            matches!(op, BinaryOp::Lt | BinaryOp::Le)
+        };
+        if !valid_op {
+            return None; // Inverted comparison (e.g., cosine < 0.3) — no pushdown
+        }
+
+        // One arg must be a property access, the other a vector literal/parameter
+        let (variable, property, query_vector) =
+            if let LogicalExpression::Property { variable, property } = &args[0] {
+                (variable.clone(), property.clone(), args[1].clone())
+            } else if let LogicalExpression::Property { variable, property } = &args[1] {
+                (variable.clone(), property.clone(), args[0].clone())
+            } else {
+                return None; // Both args are property accesses (node-to-node) — no pushdown
+            };
+
+        // Extract threshold value
+        let threshold_val = match threshold {
+            LogicalExpression::Literal(Value::Float64(v)) => *v as f32,
+            LogicalExpression::Literal(Value::Int64(v)) => *v as f32,
+            _ => return None, // Non-literal threshold — no pushdown
+        };
+
+        let (min_similarity, max_distance) = if is_similarity {
+            (Some(threshold_val), None)
+        } else {
+            (None, Some(threshold_val))
+        };
+
+        Some(ExtractedVectorPredicate {
+            property,
+            variable,
+            query_vector,
+            metric,
+            min_similarity,
+            max_distance,
+            remaining: None,
+        })
+    }
+}
+```
+
+- [ ] **Step 3: Hook into `plan_filter()`**
+
+In `plan_filter()`, after the range index attempt (line 73-75), add:
+
+```rust
+// Try to use vector index for similarity/distance predicates
+#[cfg(feature = "vector-index")]
+if let Some(result) = self.try_plan_filter_with_vector_index(filter)? {
+    return Ok(result);
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cargo check -p grafeo-engine --features vector-index,lpg,gql`
+Expected: Compiles. (There will be import warnings for `VectorScanOp`, `VectorMetric` — add them to the import block at the top of `filter.rs`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/grafeo-engine/src/query/planner/lpg/filter.rs
+git commit -m "feat(planner): vector predicate pushdown into HNSW index scans
+
+Recognizes cosine_similarity/euclidean_distance/dot_product/manhattan_distance
+in WHERE clauses, checks for HNSW index, rewrites to VectorScan operator.
+Only fires on NodeScan input (bare label scan). Compound AND predicates
+extract the vector part and leave remaining as residual filter."
+```
+
+---
+
+### Task 6: Text predicate pushdown in filter.rs
+
+**Files:**
+- Modify: `crates/grafeo-engine/src/query/planner/lpg/filter.rs`
+
+Same pattern as Task 5 but for `text_score()` and `text_match()`. Errors if no text index exists (per design decision D2).
+
+- [ ] **Step 1: Add `try_plan_filter_with_text_index()` method**
+
+Follow the same pattern as `try_plan_filter_with_vector_index()`. Key differences:
+- Matches `text_score(n.prop, "query") > threshold` and `text_match(n.prop, "query")`
+- `text_match` is treated as `text_score > 0.0`
+- Errors (not falls through) if no text index exists
+- Produces `TextScanOp` instead of `VectorScanOp`
+
+```rust
+#[cfg(feature = "text-index")]
+pub(super) fn try_plan_filter_with_text_index(
+    &self,
+    filter: &FilterOp,
+) -> Result<Option<(Box<dyn Operator>, Vec<String>)>> {
+    let LogicalOperator::NodeScan(scan) = filter.input.as_ref() else {
+        return Ok(None);
+    };
+    let Some(ref label) = scan.label else {
+        return Ok(None);
+    };
+
+    let Some(extracted) = self.extract_text_predicate(&filter.predicate) else {
+        return Ok(None);
+    };
+
+    // Text functions REQUIRE a text index (design decision D2)
+    if self.store.get_text_index(label, &extracted.property).is_none() {
+        return Err(Error::Query(format!(
+            "text_score/text_match requires a text index on ({}, {}). \
+             Create one with: db.create_text_index(\"{}\", \"{}\")",
+            label, extracted.property, label, extracted.property
+        )));
+    }
+
+    let text_scan = TextScanOp {
+        variable: scan.variable.clone(),
+        property: extracted.property.clone(),
+        label: label.clone(),
+        query: extracted.query_expr.clone(),
+        k: None,
+        threshold: Some(extracted.threshold),
+        score_column: None,
+    };
+
+    let (scan_op, scan_columns) = self.plan_operator(
+        &LogicalOperator::TextScan(text_scan)
+    )?;
+
+    // Handle remaining predicates
+    if let Some(remaining) = &extracted.remaining {
+        let variable_columns: HashMap<String, usize> = scan_columns
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.clone(), i))
+            .collect();
+        let filter_expr = self.convert_expression(remaining)?;
+        let predicate = ExpressionPredicate::new(
+            filter_expr,
+            variable_columns,
+            Arc::clone(&self.store) as Arc<dyn GraphStore>,
+        )
+        .with_transaction_context(self.viewing_epoch, self.transaction_id)
+        .with_session_context(self.session_context.clone());
+        let filter_op = Box::new(FilterOperator::new(scan_op, Box::new(predicate)));
+        Ok(Some((filter_op, scan_columns)))
+    } else {
+        Ok(Some((scan_op, scan_columns)))
+    }
+}
+```
+
+- [ ] **Step 2: Implement text predicate extraction helper**
+
+```rust
+#[cfg(feature = "text-index")]
+struct ExtractedTextPredicate {
+    property: String,
+    query_expr: LogicalExpression,
+    threshold: f64,
+    remaining: Option<LogicalExpression>,
+}
+
+#[cfg(feature = "text-index")]
+impl super::Planner {
+    fn extract_text_predicate(
+        &self,
+        expr: &LogicalExpression,
+    ) -> Option<ExtractedTextPredicate> {
+        match expr {
+            LogicalExpression::Binary { left, op, right } => {
+                // text_score(n.prop, "query") > threshold
+                if let LogicalExpression::FunctionCall { name, args, .. } = left.as_ref() {
+                    if name == "text_score" && matches!(op, BinaryOp::Gt | BinaryOp::Ge) {
+                        if let Some(extracted) = self.try_extract_text_fn(args, right) {
+                            return Some(extracted);
+                        }
+                    }
+                }
+                // AND: recurse (same pattern as vector extraction)
+                if *op == BinaryOp::And {
+                    if let Some(mut extracted) = self.extract_text_predicate(left) {
+                        extracted.remaining = Some(match extracted.remaining {
+                            Some(prev) => LogicalExpression::Binary {
+                                left: Box::new(prev),
+                                op: BinaryOp::And,
+                                right: right.clone(),
+                            },
+                            None => *right.clone(),
+                        });
+                        return Some(extracted);
+                    }
+                    if let Some(mut extracted) = self.extract_text_predicate(right) {
+                        extracted.remaining = Some(match extracted.remaining {
+                            Some(prev) => LogicalExpression::Binary {
+                                left: left.clone(),
+                                op: BinaryOp::And,
+                                right: Box::new(prev),
+                            },
+                            None => *left.clone(),
+                        });
+                        return Some(extracted);
+                    }
+                }
+                None
+            }
+            // text_match(n.prop, "query") — standalone boolean
+            LogicalExpression::FunctionCall { name, args, .. } if name == "text_match" => {
+                self.try_extract_text_fn(args, &LogicalExpression::Literal(Value::Float64(0.0)))
+            }
+            _ => None,
+        }
+    }
+
+    fn try_extract_text_fn(
+        &self,
+        args: &[LogicalExpression],
+        threshold_expr: &LogicalExpression,
+    ) -> Option<ExtractedTextPredicate> {
+        if args.len() != 2 {
+            return None;
+        }
+
+        let LogicalExpression::Property { property, .. } = &args[0] else {
+            return None;
+        };
+
+        let threshold = match threshold_expr {
+            LogicalExpression::Literal(Value::Float64(v)) => *v,
+            LogicalExpression::Literal(Value::Int64(v)) => *v as f64,
+            _ => return None,
+        };
+
+        Some(ExtractedTextPredicate {
+            property: property.clone(),
+            query_expr: args[1].clone(),
+            threshold,
+            remaining: None,
+        })
+    }
+}
+```
+
+- [ ] **Step 3: Hook into `plan_filter()`**
+
+After the vector index attempt:
+
+```rust
+#[cfg(feature = "text-index")]
+if let Some(result) = self.try_plan_filter_with_text_index(filter)? {
+    return Ok(result);
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cargo check -p grafeo-engine --features text-index,vector-index,lpg,gql`
+Expected: Compiles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/grafeo-engine/src/query/planner/lpg/filter.rs
+git commit -m "feat(planner): text predicate pushdown into BM25 index scans
+
+Recognizes text_score()/text_match() in WHERE clauses, checks for text index
+(errors if missing per D2), rewrites to TextScan operator. Only fires on
+NodeScan input."
+```
+
+---
+
+### Task 7: Compound hybrid scan (AND/OR with both vector and text)
+
+**Files:**
+- Modify: `crates/grafeo-engine/src/query/planner/lpg/filter.rs`
+
+When both vector and text predicates exist in the same WHERE clause.
+
+- [ ] **Step 1: Implement `try_plan_filter_compound_hybrid()`**
+
+After both individual pushdown methods:
+
+```rust
+/// Handles compound predicates with both vector AND/OR text.
+///
+/// Runs both index scans independently and hash-joins the results:
+/// - AND → intersect on NodeId
+/// - OR → union on NodeId
+#[cfg(all(feature = "vector-index", feature = "text-index"))]
+pub(super) fn try_plan_filter_compound_hybrid(
+    &self,
+    filter: &FilterOp,
+) -> Result<Option<(Box<dyn Operator>, Vec<String>)>> {
+    let LogicalOperator::NodeScan(scan) = filter.input.as_ref() else {
+        return Ok(None);
+    };
+    let Some(ref label) = scan.label else {
+        return Ok(None);
+    };
+
+    // Try to extract both vector and text predicates
+    let vector = self.extract_vector_predicate(&filter.predicate);
+    let text = self.extract_text_predicate(&filter.predicate);
+
+    // Only proceed if BOTH are present
+    let (vector_pred, text_pred) = match (vector, text) {
+        (Some(v), Some(t)) => (v, t),
+        _ => return Ok(None),
+    };
+
+    // Check both indexes exist
+    if self.store.get_vector_index(label, &vector_pred.property).is_none() {
+        return Ok(None);
+    }
+    if self.store.get_text_index(label, &text_pred.property).is_none() {
+        return Err(Error::Query(format!(
+            "text_score/text_match requires a text index on ({}, {})",
+            label, text_pred.property
+        )));
+    }
+
+    // Build and plan both scan operators
+    let vector_scan_op = LogicalOperator::VectorScan(VectorScanOp {
+        variable: scan.variable.clone(),
+        index_name: Some(format!("{}:{}", label, vector_pred.property)),
+        property: vector_pred.property.clone(),
+        label: Some(label.clone()),
+        query_vector: vector_pred.query_vector.clone(),
+        k: 0,
+        metric: Some(vector_pred.metric),
+        min_similarity: vector_pred.min_similarity,
+        max_distance: vector_pred.max_distance,
+        input: None,
+    });
+
+    let text_scan_op = LogicalOperator::TextScan(TextScanOp {
+        variable: scan.variable.clone(),
+        property: text_pred.property.clone(),
+        label: label.clone(),
+        query: text_pred.query_expr.clone(),
+        k: None,
+        threshold: Some(text_pred.threshold),
+        score_column: None,
+    });
+
+    let (left_op, left_cols) = self.plan_operator(&vector_scan_op)?;
+    let (right_op, right_cols) = self.plan_operator(&text_scan_op)?;
+
+    // Hash-join on NodeId (column 0 in both)
+    // Determine join type based on AND vs OR
+    let is_or = self.is_or_compound(&filter.predicate);
+    let join_type = if is_or {
+        PhysicalJoinType::Full // Union semantics
+    } else {
+        PhysicalJoinType::Inner // Intersect semantics
+    };
+
+    let join_condition = JoinCondition::Equality(EqualityCondition {
+        left_column: 0,
+        right_column: 0,
+    });
+
+    let mut columns = left_cols;
+    // Add right score column (right col 1 = text score)
+    if right_cols.len() > 1 {
+        columns.push(right_cols[1].clone());
+    }
+
+    let join_op = Box::new(HashJoinOperator::new(
+        left_op,
+        right_op,
+        join_condition,
+        join_type,
+    ));
+
+    // Apply any remaining scalar predicates
+    // (predicates that are neither vector nor text)
+    let scalar_remaining = self.extract_scalar_remaining(&filter.predicate);
+    if let Some(remaining) = scalar_remaining {
+        let variable_columns: HashMap<String, usize> = columns
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.clone(), i))
+            .collect();
+        let filter_expr = self.convert_expression(&remaining)?;
+        let predicate = ExpressionPredicate::new(
+            filter_expr,
+            variable_columns,
+            Arc::clone(&self.store) as Arc<dyn GraphStore>,
+        )
+        .with_transaction_context(self.viewing_epoch, self.transaction_id)
+        .with_session_context(self.session_context.clone());
+        Ok(Some((Box::new(FilterOperator::new(join_op, Box::new(predicate))), columns)))
+    } else {
+        Ok(Some((join_op, columns)))
+    }
+}
+```
+
+**Note:** The implementer needs to:
+1. Verify `HashJoinOperator::new` signature and `PhysicalJoinType` variants exist as named. Check `join.rs` for the actual API.
+2. Implement `is_or_compound()` — check if the top-level predicate is an OR containing both vector and text parts.
+3. Implement `extract_scalar_remaining()` — extract parts of the predicate that are neither vector nor text functions.
+
+- [ ] **Step 2: Hook into `plan_filter()` — compound check runs before individual checks**
+
+Reorder the hooks in `plan_filter()`:
+
+```rust
+// Try compound hybrid first (both vector AND text in same predicate)
+#[cfg(all(feature = "vector-index", feature = "text-index"))]
+if let Some(result) = self.try_plan_filter_compound_hybrid(filter)? {
+    return Ok(result);
+}
+
+// Try individual vector pushdown
+#[cfg(feature = "vector-index")]
+if let Some(result) = self.try_plan_filter_with_vector_index(filter)? {
+    return Ok(result);
+}
+
+// Try individual text pushdown
+#[cfg(feature = "text-index")]
+if let Some(result) = self.try_plan_filter_with_text_index(filter)? {
+    return Ok(result);
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo check -p grafeo-engine --features hybrid-search,lpg,gql`
+Expected: Compiles.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/grafeo-engine/src/query/planner/lpg/filter.rs
+git commit -m "feat(planner): compound hybrid scan for vector AND/OR text predicates
+
+When both vector and text predicates are present, runs both index scans
+and hash-joins the results (intersect for AND, union for OR). Both
+scores are projected as columns for downstream use."
+```
+
+---
+
+### Task 8: Top-K recognition (ORDER BY + LIMIT → index scan)
+
+**Files:**
+- Modify: `crates/grafeo-engine/src/query/planner/lpg/project.rs`
+
+Recognize `Sort(vector_fn/text_fn) → Limit(k) → NodeScan` and rewrite to VectorScan(k)/TextScan(k), eliminating Sort and Limit.
+
+- [ ] **Step 1: Add top-K detection in `plan_sort()`**
+
+At the beginning of `plan_sort()` (line 505), before the existing logic, add an early-return check:
+
+```rust
+pub(super) fn plan_sort(&self, sort: &SortOp) -> Result<(Box<dyn Operator>, Vec<String>)> {
+    // Top-K optimization: Sort(vector_fn) → Limit → NodeScan
+    // can be rewritten to a single VectorScan(k) or TextScan(k)
+    if let Some(result) = self.try_topk_rewrite(sort)? {
+        return Ok(result);
+    }
+
+    // ... existing plan_sort logic continues
+```
+
+- [ ] **Step 2: Implement `try_topk_rewrite()`**
+
+Add to the `Planner` impl (in `project.rs` or a new helper file):
+
+```rust
+/// Attempts to rewrite Sort+Limit on a vector/text function into
+/// a direct index scan that returns results in order.
+fn try_topk_rewrite(
+    &self,
+    sort: &SortOp,
+) -> Result<Option<(Box<dyn Operator>, Vec<String>)>> {
+    // Must have exactly one sort key
+    if sort.keys.len() != 1 {
+        return Ok(None);
+    }
+    let sort_key = &sort.keys[0];
+
+    // Input must be Limit → NodeScan (or Limit → Return → NodeScan)
+    // Walk through to find the Limit and the underlying scan
+    let (limit_count, inner_op) = match sort.input.as_ref() {
+        LogicalOperator::Limit(limit) => {
+            (limit.count.value(), limit.input.as_ref())
+        }
+        _ => return Ok(None),
+    };
+    let Some(k) = limit_count else {
+        return Ok(None);
+    };
+
+    // Inner should be a NodeScan (possibly wrapped in Return/Project)
+    let node_scan = self.find_node_scan(inner_op);
+    let Some((scan_var, scan_label)) = node_scan else {
+        return Ok(None);
+    };
+    let Some(ref label) = scan_label else {
+        return Ok(None);
+    };
+
+    // Sort key must be a vector or text function call
+    match &sort_key.expression {
+        LogicalExpression::FunctionCall { name, args, .. } => {
+            match name.as_str() {
+                #[cfg(feature = "vector-index")]
+                "cosine_similarity" | "euclidean_distance" | "dot_product" | "manhattan_distance" => {
+                    self.try_vector_topk(name, args, k as usize, &scan_var, label, sort_key)
+                }
+                #[cfg(feature = "text-index")]
+                "text_score" => {
+                    self.try_text_topk(args, k as usize, &scan_var, label)
+                }
+                _ => Ok(None),
+            }
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Walks through Return/Project operators to find the underlying NodeScan.
+fn find_node_scan(&self, op: &LogicalOperator) -> Option<(String, Option<String>)> {
+    match op {
+        LogicalOperator::NodeScan(scan) => Some((scan.variable.clone(), scan.label.clone())),
+        LogicalOperator::Return(ret) => self.find_node_scan(&ret.input),
+        LogicalOperator::Project(proj) => self.find_node_scan(&proj.input),
+        _ => None,
+    }
+}
+```
+
+The `try_vector_topk` and `try_text_topk` methods construct the respective scan operators with `k` set and no threshold, following the same extraction logic from Tasks 5/6 but applied to sort key expressions instead of WHERE predicates.
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo check -p grafeo-engine --features hybrid-search,lpg,gql`
+Expected: Compiles.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/grafeo-engine/src/query/planner/lpg/project.rs
+git commit -m "feat(planner): top-K recognition rewrites Sort+Limit to index scan
+
+Detects ORDER BY cosine_similarity/text_score + LIMIT k above a NodeScan
+and rewrites to VectorScan(k)/TextScan(k), eliminating both Sort and Limit
+operators. HNSW and BM25 already return results in score order."
+```
+
+---
+
+### Task 9: Score projection + expression rewriting
+
+**Files:**
+- Modify: `crates/grafeo-engine/src/query/planner/lpg/filter.rs` (assign score column names during pushdown)
+- Modify: `crates/grafeo-engine/src/query/planner/lpg/project.rs` (rewrite matching expressions in RETURN/ORDER BY)
+
+When VectorScan/TextScan produces a score column, downstream expressions that call the same function with the same arguments should read the projected column instead of recomputing.
+
+- [ ] **Step 1: Assign score column names during pushdown**
+
+In `try_plan_filter_with_vector_index()` (Task 5), after creating the VectorScanOp, set the score column:
+
+```rust
+// The VectorScan output is (NodeId, score). Name the score column.
+let score_column = format!("_vscore_{}", scan.variable);
+```
+
+Add this `score_column` to the returned columns list so downstream operators know about it.
+
+Same for `try_plan_filter_with_text_index()`:
+
+```rust
+let score_column = format!("_tscore_{}", scan.variable);
+```
+
+- [ ] **Step 2: Rewrite matching expressions in project/sort planning**
+
+In `plan_sort()` and `plan_project()` (project.rs), before converting expressions to physical form, check if any expression matches a vector/text function whose score is already projected:
+
+```rust
+/// Checks if a logical expression matches a projected score column.
+/// If so, returns the column name to reference instead of recomputing.
+fn find_projected_score(
+    &self,
+    expr: &LogicalExpression,
+    columns: &[String],
+) -> Option<String> {
+    if let LogicalExpression::FunctionCall { name, args, .. } = expr {
+        let is_vector_fn = matches!(
+            name.as_str(),
+            "cosine_similarity" | "euclidean_distance" | "dot_product" | "manhattan_distance"
+        );
+        let is_text_fn = name == "text_score";
+
+        if is_vector_fn || is_text_fn {
+            // Check if a matching _vscore_* or _tscore_* column exists
+            let prefix = if is_vector_fn { "_vscore_" } else { "_tscore_" };
+            if let Some(LogicalExpression::Property { variable, .. }) = args.first() {
+                let score_col = format!("{}{}", prefix, variable);
+                if columns.contains(&score_col) {
+                    return Some(score_col);
+                }
+            }
+        }
+    }
+    None
+}
+```
+
+Use this in expression conversion: if `find_projected_score` returns a column name, emit a column reference instead of a function call.
+
+- [ ] **Step 3: Verify compilation and run existing tests**
+
+Run: `cargo test -p grafeo-engine --features hybrid-search,lpg,gql`
+Expected: All existing tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/grafeo-engine/src/query/planner/lpg/filter.rs crates/grafeo-engine/src/query/planner/lpg/project.rs
+git commit -m "feat(planner): score projection eliminates redundant vector/text computation
+
+When VectorScan or TextScan produces a score column, downstream RETURN
+and ORDER BY expressions that call the same function are rewritten to
+reference the projected column. Avoids reloading embeddings and
+recomputing distances."
+```
+
+---
+
+### Task 10: Cost model + cardinality estimation
+
+**Files:**
+- Modify: `crates/grafeo-engine/src/query/optimizer/cardinality.rs`
+- Modify: `crates/grafeo-engine/src/query/optimizer/cost.rs`
+
+- [ ] **Step 1: Add `estimate_text_scan()` to cardinality.rs**
+
+Find the existing `estimate_vector_scan()` method (around line 940) and add a parallel method after it:
+
+```rust
+fn estimate_text_scan(&self, scan: &TextScanOp) -> f64 {
+    if let Some(k) = scan.k {
+        // Top-k mode: at most k results
+        return k as f64;
+    }
+    // Threshold mode: estimate 10% of indexed documents match
+    let default_selectivity = 0.1;
+    // Try to get index size from table stats
+    let base = self.table_stats
+        .get(&scan.label)
+        .map_or(1000.0, |s| s.row_count as f64);
+    (base * default_selectivity).max(1.0)
+}
+```
+
+Wire it into the main `estimate()` dispatch method, matching `LogicalOperator::TextScan(scan) => self.estimate_text_scan(scan)`.
+
+- [ ] **Step 2: Add TextScan cost formula to cost.rs**
+
+Find the VectorScan cost estimation (around line 468) and add after it:
+
+```rust
+LogicalOperator::TextScan(scan) => {
+    let cardinality = self.card_estimator.estimate(op);
+    let index_size = cardinality * 10.0; // Approximate corpus size
+    // BM25 scoring is ~5x a simple tuple comparison
+    let cpu = index_size * self.cpu_tuple_cost * 5.0;
+    let io = 0.0; // In-memory index
+    Cost { cpu, io, memory: cardinality * self.avg_tuple_size, network: 0.0 }
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo check -p grafeo-engine --features hybrid-search,lpg,gql`
+Expected: Compiles.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/grafeo-engine/src/query/optimizer/cardinality.rs crates/grafeo-engine/src/query/optimizer/cost.rs
+git commit -m "feat(optimizer): add TextScan cardinality estimation and cost formula
+
+estimate_text_scan returns k for top-k queries, 10% selectivity for
+threshold. Cost uses 5x cpu_tuple_cost for BM25 scoring overhead."
+```
+
+---
+
+### Task 11: End-to-end integration tests
+
+**Files:**
+- Create: `crates/grafeo-engine/tests/hybrid_query.rs`
+
+These tests run actual Cypher/GQL queries through the full pipeline and verify correct results with index acceleration.
+
+- [ ] **Step 1: Create integration test file**
+
+```rust
+//! Integration tests for unified hybrid queries (graph + vector + text).
+//!
+//! Tests the full pipeline: Cypher/GQL parsing → planning → pushdown → execution.
+
+#![cfg(all(feature = "hybrid-search", feature = "gql"))]
+
+use grafeo_engine::GrafeoDB;
+use grafeo_common::types::Value;
+
+fn setup_article_db() -> GrafeoDB {
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+
+    // Create articles with embeddings and text
+    let a1 = session.create_node_with_props(
+        &["Article"],
+        [
+            ("title", Value::String("Graph Neural Networks".into())),
+            ("body", Value::String("attention mechanisms in graph neural networks for node classification".into())),
+            ("embedding", Value::Vector(vec![0.9, 0.1, 0.0].into())),
+        ],
+    );
+    let a2 = session.create_node_with_props(
+        &["Article"],
+        [
+            ("title", Value::String("Rust Database Internals".into())),
+            ("body", Value::String("building a database engine in rust with MVCC transactions".into())),
+            ("embedding", Value::Vector(vec![0.1, 0.9, 0.0].into())),
+        ],
+    );
+    let a3 = session.create_node_with_props(
+        &["Article"],
+        [
+            ("title", Value::String("Transformer Architectures".into())),
+            ("body", Value::String("attention mechanisms and transformer models for natural language".into())),
+            ("embedding", Value::Vector(vec![0.8, 0.2, 0.1].into())),
+        ],
+    );
+
+    // Create user with follows/wrote relationships
+    let user = session.create_node_with_props(
+        &["User"],
+        [("name", Value::String("Alice".into()))],
+    );
+    let friend = session.create_node_with_props(
+        &["User"],
+        [("name", Value::String("Bob".into()))],
+    );
+    session.create_edge(user, friend, "FOLLOWS");
+    session.create_edge(friend, a1, "WROTE");
+    session.create_edge(friend, a2, "WROTE");
+
+    // Create indexes
+    db.create_vector_index("Article", "embedding", Some(3), Some("cosine"), None, None, None)
+        .expect("create vector index");
+    db.create_text_index("Article", "body").expect("create text index");
+
+    db
+}
+
+#[test]
+fn test_vector_where_with_pushdown() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // This should use VectorScan (bare label scan with vector predicate)
+    let result = session.execute(
+        "MATCH (doc:Article) \
+         WHERE cosine_similarity(doc.embedding, [0.85, 0.15, 0.05]) > 0.5 \
+         RETURN doc.title"
+    ).unwrap();
+
+    // Articles 1 and 3 have embeddings similar to [0.85, 0.15, 0.05]
+    assert!(result.row_count() >= 1);
+    let titles: Vec<String> = result.rows().iter()
+        .filter_map(|r| r[0].as_string().map(|s| s.to_string()))
+        .collect();
+    assert!(titles.contains(&"Graph Neural Networks".to_string()));
+}
+
+#[test]
+fn test_text_score_where() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    let result = session.execute(
+        "MATCH (doc:Article) \
+         WHERE text_score(doc.body, 'attention mechanisms') > 0.0 \
+         RETURN doc.title, text_score(doc.body, 'attention mechanisms') AS score"
+    ).unwrap();
+
+    // Articles 1 and 3 mention "attention mechanisms"
+    assert_eq!(result.row_count(), 2);
+}
+
+#[test]
+fn test_text_match_where() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    let result = session.execute(
+        "MATCH (doc:Article) \
+         WHERE text_match(doc.body, 'rust database') \
+         RETURN doc.title"
+    ).unwrap();
+
+    assert_eq!(result.row_count(), 1);
+    assert_eq!(result.rows()[0][0], Value::String("Rust Database Internals".into()));
+}
+
+#[test]
+fn test_topk_order_by_vector() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // ORDER BY + LIMIT should use VectorScan top-K (no full scan)
+    let result = session.execute(
+        "MATCH (doc:Article) \
+         RETURN doc.title, cosine_similarity(doc.embedding, [0.85, 0.15, 0.05]) AS sim \
+         ORDER BY sim DESC LIMIT 2"
+    ).unwrap();
+
+    assert_eq!(result.row_count(), 2);
+    // First result should be the most similar article
+}
+
+#[test]
+fn test_topk_order_by_text() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    let result = session.execute(
+        "MATCH (doc:Article) \
+         RETURN doc.title, text_score(doc.body, 'attention mechanisms') AS rank \
+         ORDER BY rank DESC LIMIT 1"
+    ).unwrap();
+
+    assert_eq!(result.row_count(), 1);
+}
+
+#[test]
+fn test_compound_vector_and_text() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // Both vector similarity AND text match
+    let result = session.execute(
+        "MATCH (doc:Article) \
+         WHERE cosine_similarity(doc.embedding, [0.85, 0.15, 0.05]) > 0.3 \
+           AND text_match(doc.body, 'attention mechanisms') \
+         RETURN doc.title"
+    ).unwrap();
+
+    // Only Article 1 and 3 mention "attention" AND are similar to the query vector
+    // Article 2 (rust database) doesn't mention attention
+    assert!(result.row_count() >= 1);
+}
+
+#[test]
+fn test_graph_plus_vector_per_row_eval() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // Graph traversal narrows candidates → per-row eval, not pushdown
+    let result = session.execute(
+        "MATCH (u:User {name: 'Alice'})-[:FOLLOWS]->(friend)-[:WROTE]->(doc:Article) \
+         WHERE cosine_similarity(doc.embedding, [0.85, 0.15, 0.05]) > 0.3 \
+         RETURN doc.title"
+    ).unwrap();
+
+    // Alice follows Bob, Bob wrote articles 1 and 2
+    // Only article 1 is similar to the query vector
+    assert!(result.row_count() >= 1);
+}
+
+#[test]
+fn test_text_score_without_index_errors() {
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+
+    session.create_node_with_props(
+        &["Article"],
+        [("body", Value::String("hello world".into()))],
+    );
+
+    // No text index created → should error
+    let result = session.execute(
+        "MATCH (doc:Article) \
+         WHERE text_score(doc.body, 'hello') > 0.0 \
+         RETURN doc.title"
+    );
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_vector_without_index_brute_force() {
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+
+    session.create_node_with_props(
+        &["Article"],
+        [("embedding", Value::Vector(vec![1.0, 0.0, 0.0].into()))],
+    );
+
+    // No vector index → should still work (brute-force eval)
+    let result = session.execute(
+        "MATCH (doc:Article) \
+         WHERE cosine_similarity(doc.embedding, [1.0, 0.0, 0.0]) > 0.9 \
+         RETURN doc"
+    ).unwrap();
+
+    assert_eq!(result.row_count(), 1);
+}
+
+#[test]
+fn test_score_projection_no_double_compute() {
+    let db = setup_article_db();
+    let session = db.session();
+
+    // Same function in WHERE and RETURN — score should be computed once
+    let result = session.execute(
+        "MATCH (doc:Article) \
+         WHERE cosine_similarity(doc.embedding, [0.85, 0.15, 0.05]) > 0.3 \
+         RETURN doc.title, cosine_similarity(doc.embedding, [0.85, 0.15, 0.05]) AS sim"
+    ).unwrap();
+
+    // Verify scores are present and valid
+    for row in result.rows() {
+        let score = &row[1];
+        assert!(matches!(score, Value::Float64(s) if *s > 0.3));
+    }
+}
+```
+
+**Note:** The exact API for `session.execute()`, `session.create_node_with_props()`, `db.create_vector_index()`, and result inspection depends on the actual Grafeo public API. The implementer must adapt to match the real API by checking existing integration tests in `crates/grafeo-engine/tests/query_correctness.rs` and `crates/grafeo-engine/tests/search_operations.rs`.
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `cargo test -p grafeo-engine --features hybrid-search,gql --test hybrid_query`
+Expected: All tests PASS. If any fail, debug by checking EXPLAIN output and verifying the planner produces the expected operators.
+
+- [ ] **Step 3: Run the full test suite for regressions**
+
+Run: `cargo test -p grafeo-engine --features full`
+Run: `cargo test -p grafeo-core --features full`
+Expected: No regressions in existing tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/grafeo-engine/tests/hybrid_query.rs
+git commit -m "test(hybrid): end-to-end integration tests for unified hybrid queries
+
+Tests vector pushdown, text pushdown, top-K recognition, compound AND,
+graph+vector per-row eval, score projection, error on missing text index,
+and brute-force fallback without vector index."
+```
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (InvertedIndex API)
+  ├── Task 2 (TextScanOperator)
+  │     └── Task 4 (TextScanOp + planner dispatch)
+  │           ├── Task 6 (text pushdown)
+  │           └── Task 8 (top-K)
+  └── Task 3 (eval_text_fn)
+        └── Task 6 (text pushdown)
+
+Task 5 (vector pushdown) ← independent, can run in parallel with 2-4
+
+Task 7 (compound hybrid) ← depends on 5 + 6
+Task 9 (score projection) ← depends on 5 + 6 + 8
+Task 10 (cost model) ← depends on 4
+Task 11 (integration tests) ← depends on everything
+```
+
+## Parallel execution opportunities
+
+Tasks 1-4 and Task 5 are independent branches. An agent could work on Task 5 (vector pushdown) while another works on Tasks 1-4 (text pipeline). They converge at Task 7 (compound hybrid).

--- a/docs/superpowers/specs/2026-04-14-unified-hybrid-queries-design.md
+++ b/docs/superpowers/specs/2026-04-14-unified-hybrid-queries-design.md
@@ -1,0 +1,409 @@
+# Unified Hybrid Queries: Graph + Vector + Text in One Query
+
+**Date:** 2026-04-14
+**Status:** Draft
+**Scope:** Shape B — composable WHERE/ORDER BY predicates with index acceleration
+
+## Problem
+
+Grafeo has three search engines — graph traversal, HNSW vector similarity, and BM25 full-text — but they can't compose in a single query. Users must make three separate API calls and join results in application code. This is the same "duct tape" problem CoordiNode markets against, except Grafeo already has all three engines built. The missing piece is planner integration.
+
+**Today (three API calls, application-side glue):**
+
+```python
+related = db.query("""
+    MATCH (me:User {id: $uid})-[:FOLLOWS*1..2]->(friend)
+    MATCH (friend)-[:WROTE]->(doc:Article)
+    RETURN doc
+""", uid=user_id)
+
+similar = db.vector_search("Article", "embedding", query_vec, k=100)
+text_hits = db.text_search("Article", "body", "graph databases", k=100)
+
+# Application code: intersect, rank, handle ID mismatches,
+# lose transactional consistency between the three calls
+```
+
+**After this feature (one query, one transaction):**
+
+```cypher
+MATCH (me:User {id: $uid})-[:FOLLOWS*1..2]->(friend)
+MATCH (friend)-[:WROTE]->(doc:Article)
+WHERE cosine_similarity(doc.embedding, $query_vec) > 0.7
+  AND text_score(doc.body, "graph databases") > 2.0
+RETURN doc.title,
+       cosine_similarity(doc.embedding, $query_vec) AS relevance,
+       text_score(doc.body, "graph databases") AS text_rank
+ORDER BY relevance DESC LIMIT 20
+```
+
+## Competitive context
+
+Researched from [structured-world/coordinode](https://github.com/structured-world/coordinode) (v0.3-alpha, ~53K LOC, Rust, AGPL-3.0). CoordiNode's entire pitch is "graph + vector + text in one query." They have it. But they're server-only — no embedded mode, no WASM. Grafeo already has embedded + WASM + all three engines. This feature makes Grafeo the only embeddable database where graph, vector, and text compose in a single query.
+
+| | Grafeo after this | CoordiNode | Neo4j | SQLite+vec+FTS5 |
+|---|---|---|---|---|
+| Graph + vector + text in one query | Yes | Yes | No | No graph |
+| Embedded / WASM | Yes | No | No | Yes (no graph) |
+| Index-accelerated (not post-filter) | Yes | Yes | N/A | Partial |
+
+## Design decisions
+
+### D1: No new syntax
+
+The four existing vector functions (`cosine_similarity`, `euclidean_distance`, `dot_product`, `manhattan_distance`) already parse and evaluate in WHERE clauses. They keep working everywhere. This feature makes them faster by teaching the planner to use HNSW indexes when available.
+
+### D2: Two new text functions, require index
+
+| Function | Returns | Requires text index |
+|---|---|---|
+| `text_score(n.prop, "query")` | `Float64` (BM25 score) | Yes — errors without one |
+| `text_match(n.prop, "query")` | `Bool` (`text_score > 0.0`) | Yes — errors without one |
+
+**Why text functions require an index but vector functions don't:** Vector distance is a pure function of two vectors — give it inputs, get a number. BM25 is corpus-relative — it needs document frequency (IDF), average document length, and total document count. These statistics live in the `InvertedIndex` (`inverted_index.rs` lines 163-175). Without the index, there is no correct BM25 score. A "fallback" that returns different results than the indexed path is a bug.
+
+Vector functions keep their current behavior: work anywhere as pure functions, index just makes them faster (sublinear HNSW instead of linear brute-force).
+
+### D3: Score projection — compute once, use everywhere
+
+When the planner pushes a predicate into an index scan, it assigns a synthetic column name (e.g., `_vscore_0`, `_tscore_0`) for the score. It then scans downstream expressions (RETURN, ORDER BY, further WHERE) for function calls matching the same function + variable + property + query argument, and rewrites them to column references.
+
+**Why mandatory:** VectorScanOperator already outputs `(NodeId, f32 score)` in its DataChunk (`scan_vector.rs` lines 307-335). Without projection, the RETURN clause hits `eval_vector_fn`, which loads the embedding from the store and recomputes cosine distance. For 10K results with 1536-dim embeddings, that's ~60MB of unnecessary memory reads and redundant dot products for a number we already have.
+
+### D4: Top-K recognition — ORDER BY + LIMIT eliminates Sort
+
+The planner recognizes:
+
+```
+Sort(key = vector_fn(n.prop, $vec)) → Limit(k) → NodeScan(label)
+```
+
+and rewrites to:
+
+```
+VectorScan(prop, $vec, k, metric)  // Sort and Limit eliminated
+```
+
+Same for text:
+
+```
+Sort(key = text_score(n.prop, "q"), DESC) → Limit(k) → NodeScan(label)
+```
+
+rewrites to:
+
+```
+TextScan(prop, "q", k)  // Sort and Limit eliminated
+```
+
+**Why mandatory, not deferred:** `ORDER BY cosine_similarity(...) LIMIT 20` is the most natural vector query pattern. It's how every vector database tutorial works. If this does a full scan, the feature is half-useful.
+
+Both HNSW and BM25 already return results in score order. Eliminating Sort is free.
+
+### D5: Compound predicates — run both indexes, join
+
+For `WHERE vector_pred AND text_pred`:
+1. Run VectorScan with threshold → candidate set A with scores
+2. Run TextScan with threshold → candidate set B with scores
+3. Hash-join intersect on NodeId → only nodes passing both, both scores attached
+
+For `WHERE vector_pred OR text_pred`:
+- Same two scans, hash-join union instead of intersect.
+
+**Why not "pick the more selective index":** We evaluated a selectivity heuristic and rejected it. At plan time, available statistics are:
+- HNSW: `len()` only. No distribution info, no way to estimate how many vectors pass a distance threshold.
+- InvertedIndex: `len()`, `term_count()`. Posting lists are private. Can't get df for a term without running the search.
+- Cardinality estimator: hard-codes `0.7` selectivity for vector thresholds (`cardinality.rs` line 940-956).
+
+Any heuristic built on this will guess. A wrong guess picks the less selective index, producing a bigger candidate set and more residual work than the other choice. Since both indexes are in-memory and both lookups are fast (HNSW: O(log n); BM25: O(df) per term), running both and joining is simpler, more predictable, and eliminates a class of plan quality bugs.
+
+### D6: Shape C eliminated — B subsumes it
+
+We considered `CALL hybrid_search("Article", "embedding", "body", $vec, "query", 20) YIELD node, score` as Shape C. It was eliminated because:
+
+1. It doesn't compose with graph traversal — the CALL results join awkwardly with MATCH patterns.
+2. Shape B's compound WHERE predicates with both scores projected cover the same queries.
+3. Users who want combined ranking write it in the query: `ORDER BY 0.7 * cosine_similarity(...) + 0.3 * text_score(...)`.
+4. The standalone search case (`ORDER BY ... LIMIT k` with no MATCH) works naturally with top-K recognition.
+
+## Architecture
+
+### New components
+
+**`TextScanOperator`** — New physical operator in `crates/grafeo-core/src/execution/operators/scan_text.rs`. Parallel to `VectorScanOperator`. Takes: store ref, text index ref, query string, optional threshold, optional k. Outputs: `DataChunk` with `(NodeId, Float64)` schema.
+
+- For WHERE threshold: calls `InvertedIndex.search_with_threshold(query, threshold)`
+- For ORDER BY + LIMIT top-k: calls `InvertedIndex.search(query, k)`
+
+**`TextScanOp`** — New logical operator variant in `plan.rs`, parallel to existing `VectorScanOp`.
+
+### InvertedIndex API additions
+
+Two new methods on `InvertedIndex` (`crates/grafeo-core/src/index/text/inverted_index.rs`):
+
+```rust
+/// Score a single document against a query using BM25.
+/// Looks up each query term in its posting list, finds the entry for this node_id,
+/// computes BM25 with corpus statistics already in the index.
+/// O(query_terms) per call. Returns 0.0 if document has no matching terms.
+pub fn score_document(&self, id: NodeId, query: &str) -> f64
+```
+
+Needed for `eval_text_fn` — per-row text scoring when text is a residual filter (e.g., vector was the primary scan, text is evaluated on candidates).
+
+```rust
+/// Return all documents scoring above threshold.
+/// Same internal loop as search(), but filters by score instead of taking top-k.
+pub fn search_with_threshold(&self, query: &str, threshold: f64) -> Vec<(NodeId, f64)>
+```
+
+Needed for `TextScanOperator` when the predicate is `text_score(...) > threshold`.
+
+### eval_text_fn in filter.rs
+
+New function evaluation category in the `eval_function` cascade (`crates/grafeo-core/src/execution/operators/filter.rs`):
+
+```rust
+fn eval_text_fn(&self, name: &str, args: &[FilterExpression], chunk: &DataChunk, row: usize) -> Option<Value> {
+    match name {
+        "text_score" => {
+            // Extract property access → get node_id from chunk
+            // Get node's label from store
+            // Look up text index via store.get_text_index(label, property)
+            // Call index.score_document(node_id, query_string)
+            // Return Value::Float64(score)
+        }
+        "text_match" => {
+            // Same as text_score, return Value::Bool(score > 0.0)
+        }
+        _ => None,
+    }
+}
+```
+
+Added to the cascade after `eval_vector_fn`:
+```rust
+.or_else(|| self.eval_vector_fn(name, args, chunk, row))
+.or_else(|| self.eval_text_fn(name, args, chunk, row))  // NEW
+.or_else(|| self.eval_session_fn(name, args, chunk, row))
+```
+
+### Planner changes
+
+All in `crates/grafeo-engine/src/query/planner/lpg/filter.rs`, following the established pattern of `try_plan_filter_with_property_index()` (line 819) and `try_plan_filter_with_range_index()` (line 1066).
+
+**`try_plan_filter_with_vector_index()`** — Pattern matches on:
+- `cosine_similarity(n.prop, $vec) > threshold` → VectorScan with `min_similarity=threshold`, metric=Cosine
+- `euclidean_distance(n.prop, $vec) < threshold` → VectorScan with `max_distance=threshold`, metric=Euclidean
+- `manhattan_distance(n.prop, $vec) < threshold` → VectorScan with `max_distance=threshold`, metric=Manhattan
+- `dot_product(n.prop, $vec) > threshold` → VectorScan with `min_similarity=threshold`, metric=DotProduct
+- Note the operator inversion: similarity functions use `>`, distance functions use `<`. If the user writes `cosine_similarity(...) < 0.3` (unusual but valid), no pushdown — falls through to per-row eval.
+- Validates: one arg is property access on a bound variable with known label, other arg resolves to vector literal/parameter
+- **Only fires when input is a NodeScan** (full label scan). If the input is already narrowed by graph traversal (Expand, Join), per-row `eval_vector_fn` is faster for the typically small candidate set.
+- Checks: `store.get_vector_index(label, property)` exists
+- Produces: `VectorScanOperator` with threshold, score projected as `_vscore_N`
+- Falls through if: no label, both args are property accesses (node-to-node), no index exists, input is not NodeScan
+
+**`try_plan_filter_with_text_index()`** — Pattern matches on:
+- `text_score(n.prop, "query") > threshold` or `text_match(n.prop, "query")`
+- Validates: first arg is property access with known label, second arg resolves to string
+- **Only fires when input is a NodeScan** (same rationale as vector: if graph already narrowed, per-row `eval_text_fn` with `score_document()` is faster)
+- Checks: `store.get_text_index(label, property)` exists
+- Produces: `TextScanOperator` with threshold, score projected as `_tscore_N`
+- Errors if: no text index exists (D2)
+
+**`try_plan_filter_compound_hybrid()`** — When both vector and text predicates are extracted:
+- Runs both scan operators
+- Hash-join intersect (AND) or union (OR) on NodeId
+- Both scores available as projected columns
+- Remaining scalar predicates become residual FilterOperator on top
+
+**Top-K recognition** — In `crates/grafeo-engine/src/query/planner/lpg/mod.rs`:
+- After building the initial plan, inspect for `Sort → Limit → NodeScan` where sort key is a vector or text function
+- Rewrite to VectorScan(k) or TextScan(k), eliminate Sort and Limit operators
+
+**Score projection** — When creating a scan operator from a predicate:
+1. Assign synthetic column name (`_vscore_0`, `_tscore_0`)
+2. Walk downstream LogicalOperators (Project, Sort, Filter)
+3. Pattern-match FunctionCall expressions with identical function name + args
+4. Rewrite matching expressions to column references
+
+### Call order in plan_filter()
+
+```
+plan_filter(filter):
+    1. extract_complex_exists()        // existing
+    2. extract_exists_from_or()        // existing
+    3. extract_count_comparison()      // existing
+    4. check_zone_map_for_predicate()  // existing
+    5. try_plan_filter_with_property_index()   // existing
+    6. try_plan_filter_with_range_index()      // existing
+    7. try_plan_filter_with_vector_index()     // NEW
+    8. try_plan_filter_with_text_index()       // NEW
+    9. try_plan_filter_compound_hybrid()       // NEW (if both 7 and 8 found predicates)
+   10. generic FilterOperator fallback         // existing
+```
+
+### Optimizer and cost model additions
+
+**`cardinality.rs`:** Add `estimate_text_scan()` — returns `k` for top-k queries, or `index.len() * selectivity` for threshold queries (use 0.1 default selectivity for text — most queries match a small fraction of the corpus).
+
+**`cost.rs`:** Add TextScan cost formula — `cpu = doc_frequency_sum * cpu_tuple_cost * 5` (BM25 scoring is ~5x a simple tuple comparison). For threshold queries where df is unknown at plan time, use `index.len() * 0.1 * cpu_tuple_cost * 5`.
+
+## What doesn't get pushdown
+
+| Case | Why | What happens |
+|---|---|---|
+| No label on the variable | Can't look up index by `(label, property)` | Vector: brute-force `eval_vector_fn`. Text: error (needs index). |
+| Node-to-node similarity `cosine_similarity(a.emb, b.emb)` | Neither arg is a literal/parameter vector | `eval_vector_fn` per-row |
+| Function in WITH alias `WITH doc, cosine_similarity(...) AS sim WHERE sim > 0.7` | Would need to trace through pipeline barrier | `eval_vector_fn` per-row |
+| No index exists for the property | Nothing to push into | Vector: brute-force per-row. Text: error. |
+| Input narrowed by graph traversal (Expand/Join before Filter) | Per-row eval on small candidate set is faster than full index scan + join | `eval_vector_fn` + `eval_text_fn` (via `score_document`) per-row |
+| Inverted comparison (`cosine_similarity(...) < 0.3`, `euclidean_distance(...) > 5.0`) | Unusual semantics — "find dissimilar" — not worth optimizing | `eval_vector_fn` per-row |
+
+## Example queries — full execution trace
+
+### Simple vector with pushdown
+
+```cypher
+MATCH (doc:Article)
+WHERE cosine_similarity(doc.embedding, $vec) > 0.7
+RETURN doc.title, cosine_similarity(doc.embedding, $vec) AS sim
+```
+
+Execution:
+1. Planner sees `cosine_similarity(doc.embedding, $vec) > 0.7` in WHERE
+2. `try_plan_filter_with_vector_index()`: label=Article, property=embedding, finds HNSW index
+3. Creates `VectorScanOperator` with `min_similarity=0.7`, projects score as `_vscore_0`
+4. Scans RETURN: `cosine_similarity(doc.embedding, $vec)` matches → rewritten to `_vscore_0`
+5. Physical plan: `VectorScan(HNSW) → Project(doc.title, _vscore_0 AS sim)`
+6. No redundant computation.
+
+### Top-K without WHERE
+
+```cypher
+MATCH (doc:Article)
+RETURN doc.title, cosine_similarity(doc.embedding, $vec) AS sim
+ORDER BY sim DESC LIMIT 20
+```
+
+Execution:
+1. No WHERE to push down
+2. Top-K recognizer sees: `Sort(cosine_similarity(doc.embedding, $vec) DESC) → Limit(20) → NodeScan(Article)`
+3. HNSW index exists on (Article, embedding)
+4. Rewrite to: `VectorScan(embedding, $vec, k=20, metric=Cosine)` → score projected as `_vscore_0`
+5. Sort and Limit eliminated
+6. Physical plan: `VectorScan(HNSW, k=20) → Project(doc.title, _vscore_0 AS sim)`
+
+### Compound graph + vector + text
+
+```cypher
+MATCH (me:User {id: $uid})-[:FOLLOWS*1..2]->(friend)
+MATCH (friend)-[:WROTE]->(doc:Article)
+WHERE cosine_similarity(doc.embedding, $vec) > 0.6
+  AND text_score(doc.body, "attention mechanisms") > 1.5
+RETURN doc.title,
+       cosine_similarity(doc.embedding, $vec) AS relevance,
+       text_score(doc.body, "attention mechanisms") AS text_rank
+ORDER BY relevance DESC LIMIT 10
+```
+
+Execution:
+1. Graph traversal: User→FOLLOWS*1..2→friend→WROTE→doc produces candidate Articles
+2. Input to filter is Expand (graph traversal), NOT a NodeScan → **no index pushdown**
+3. Per-row evaluation on each candidate:
+   - `eval_vector_fn("cosine_similarity", doc.embedding, $vec)` → loads vector, computes cosine, O(dims) per doc
+   - `eval_text_fn("text_score", doc.body, "attention mechanisms")` → calls `index.score_document(doc_id, query)`, O(query_terms) per doc
+4. Both scores are available in the DataChunk for RETURN and ORDER BY
+5. Filter by thresholds (> 0.6 AND > 1.5), sort by cosine DESC, limit 10
+6. Physical plan: `Expand(User→FOLLOWS→friend→WROTE→doc) → Filter(cosine_similarity > 0.6 AND text_score > 1.5) → Sort(cosine DESC) → Limit(10) → Project`
+
+**Why no pushdown here:** The graph traversal typically narrows to a small candidate set (say 50-500 articles reachable from the user). Running two full index scans over all Articles and then joining back would do more work, not less. Per-row eval with `score_document()` is O(candidates * query_terms) — fast for reasonable candidate sets.
+
+**When pushdown DOES fire:** When the MATCH is a bare label scan with no prior graph narrowing:
+
+```cypher
+MATCH (doc:Article)
+WHERE cosine_similarity(doc.embedding, $vec) > 0.6
+  AND text_score(doc.body, "attention mechanisms") > 1.5
+RETURN doc.title
+```
+
+Here the input is NodeScan(Article) → `try_plan_filter_compound_hybrid()` fires:
+1. VectorScan on (Article, embedding) with threshold 0.6 → set A with `_vscore_0`
+2. TextScan on (Article, body) with threshold 1.5 → set B with `_tscore_0`
+3. Hash-join intersect A ∩ B on NodeId → both scores projected
+4. Physical plan: `HybridScan(VectorScan ∩ TextScan) → Project(doc.title)`
+
+### OR predicate
+
+```cypher
+MATCH (doc:Article)
+WHERE cosine_similarity(doc.embedding, $vec) > 0.8
+   OR text_match(doc.body, "graph neural networks")
+RETURN doc.title
+```
+
+Execution:
+1. Compound OR detected
+2. VectorScan with threshold 0.8 → set A
+3. TextScan with threshold 0.0 (text_match = score > 0.0) → set B
+4. Hash-join union A ∪ B
+5. Physical plan: `HybridScan(VectorScan ∪ TextScan) → Project(doc.title)`
+
+## Files changed
+
+| File | Change | Size estimate |
+|---|---|---|
+| `crates/grafeo-core/src/index/text/inverted_index.rs` | Add `score_document()`, `search_with_threshold()` | ~50 lines |
+| `crates/grafeo-core/src/execution/operators/scan_text.rs` | New `TextScanOperator` (modeled on `scan_vector.rs`) | ~300 lines |
+| `crates/grafeo-core/src/execution/operators/mod.rs` | Export `TextScanOperator` | ~2 lines |
+| `crates/grafeo-core/src/execution/operators/filter.rs` | Add `eval_text_fn` to function cascade | ~40 lines |
+| `crates/grafeo-engine/src/query/plan.rs` | Add `TextScan` to `LogicalOperator`, `TextScanOp` struct | ~40 lines |
+| `crates/grafeo-engine/src/query/planner/lpg/filter.rs` | `try_plan_filter_with_vector_index()`, `try_plan_filter_with_text_index()`, `try_plan_filter_compound_hybrid()` | ~400 lines |
+| `crates/grafeo-engine/src/query/planner/lpg/mod.rs` | Top-K recognition, score projection + expression rewriting | ~200 lines |
+| `crates/grafeo-engine/src/query/optimizer/cardinality.rs` | `estimate_text_scan()` | ~20 lines |
+| `crates/grafeo-engine/src/query/optimizer/cost.rs` | TextScan cost formula | ~30 lines |
+| **Tests** | Unit + integration for each component | ~600 lines |
+| **Total** | | **~1,680 lines** |
+
+## Test plan
+
+### Unit tests
+
+- `InvertedIndex.score_document()`: known corpus, verify BM25 score matches `search()` for same document
+- `InvertedIndex.search_with_threshold()`: verify returns all docs above threshold, none below
+- `TextScanOperator`: threshold mode, top-k mode, empty index, no matches
+- `eval_text_fn`: text_score returns correct BM25, text_match returns bool, errors without index, non-string property returns error
+- Score projection: verify downstream expressions rewritten correctly, verify non-matching expressions left alone
+- Top-K recognition: Sort+Limit on vector fn → VectorScan, Sort+Limit on text fn → TextScan, Sort+Limit on non-index fn → no rewrite
+
+### Integration tests (Cypher queries via grafeo-engine)
+
+- `WHERE cosine_similarity(...) > threshold` → uses HNSW, correct results
+- `WHERE text_score(...) > threshold` → uses inverted index, correct results
+- `WHERE text_match(...)` → correct boolean semantics
+- `WHERE vector AND text` → intersect, both scores in RETURN
+- `WHERE vector OR text` → union, correct results
+- `ORDER BY cosine_similarity(...) LIMIT k` → top-K, no full scan
+- `ORDER BY text_score(...) LIMIT k` → top-K from BM25
+- Compound: `MATCH (doc:Article) WHERE vector AND text` (bare label scan) → both index scans, intersect
+- Compound: `MATCH (graph traversal)->(doc:Article) WHERE vector AND text` → per-row eval on candidates (no pushdown)
+- Score in RETURN matches score from WHERE (no double computation)
+- `euclidean_distance(...) < 2.0` → pushes down with `max_distance=2.0` (operator inversion)
+- `cosine_similarity(...) < 0.3` (inverted) → no pushdown, per-row eval
+- No index on property → vector falls back to brute-force, text errors
+- No label in MATCH → no pushdown, correct results via eval fallback
+- Node-to-node similarity → no pushdown, correct via eval_vector_fn
+- Null/missing vector property → excluded from results
+- Dimension mismatch → excluded from results
+- Empty query string → text_score returns 0.0, text_match returns false
+- text_score on non-string property → error
+
+## Non-goals
+
+- **Shape C (`CALL hybrid_search`)**: Eliminated. B's compound WHERE predicates subsume it.
+- **RRF/weighted fusion in query language**: Stays in the `hybrid_search()` API. Users write their own ranking formulas in ORDER BY.
+- **WITH clause alias tracing**: Functions behind a WITH pipeline barrier fall back to per-row eval. Optimizing through WITH is a general planner problem, not specific to this feature.
+- **Selectivity-based index selection**: Both indexes run for compound predicates. No heuristic, no guessing.
+- **HNSW ef parameter in queries**: Uses index default. Power users tune via API or future session parameter.


### PR DESCRIPTION
## Summary

Calling `create_vector_index`, `vector_search`, `create_text_index`, `text_search`, or any of the ~26 index/search methods after `compact()` panics with *"no built-in LpgStore"* because `compact()` sets `self.store = None`. Additionally, even if that panic is avoided, vector properties are silently lost during compaction (no f32 vector column codec existed), so index builds produce zero entries.

**Repro:** `GrafeoDB::new_in_memory()` → insert nodes with vector embeddings → `compact()` → `create_vector_index()` → panic. If the panic is patched naively, `vector_search()` returns nothing because the index was built from an empty overlay.

## What changed

### 1. Keep `self.store` populated after compact/recompact

`compact()` and `recompact()` now set `self.store = Some(Arc::clone(layered.overlay_store()))` instead of `None`. This makes `lpg_store()` return the overlay — which is where index registrations (add/get/remove for vector, text, and property indexes) live. All ~26 existing callers in `database/index.rs` and `database/search.rs` continue to work without modification for registry operations.

A new `graph_store_ref()` helper provides `&dyn GraphStore` tied to the database lifetime (borrowing from the LayeredStore in layered mode, or the LpgStore otherwise) — needed by accessors that hold `&'a dyn GraphStore`.

### 2. Forward index-aware GraphStore trait methods on LayeredStore

`LayeredStore` now implements the six methods introduced by the unified hybrid queries feature (`has_vector_index`, `get_vector_index_handle`, `has_text_index`, `score_text`, `text_search`, `text_search_with_threshold`), forwarding to `self.overlay` with matching feature gates. This lets the query planner see indexes through the LayeredStore.

### 3. Iterate the merged view for index building

`create_vector_index`, `create_text_index`, and `rebuild_vector_index` previously iterated nodes via `self.lpg_store()` (the overlay, which is empty after compaction). Now they iterate through `self.graph_store()` (the LayeredStore), which merges base + overlay and sees all pre-compaction data.

`PropertyVectorAccessor`, `SpillableVectorAccessor`, and `compute_filter_allowlist` in `database/search.rs` similarly switched from `lpg_store()` to `graph_store_ref()` so vector reads and property filters during search see the merged view, not just the overlay.

### 4. Float32Vector column codec for CompactStore

Added `ColumnCodec::Float32Vector` (discriminant 5) — a flat `Vec<f32>` with stride, analogous to the existing `Int8Vector` codec. `from_graph_store` now recognizes `Value::Vector` properties and stores them natively. Without this, vectors were stringified via the Dict fallback during compaction, breaking any downstream index build.

## Files changed

| File | Change |
|------|--------|
| `database/mod.rs` | `self.store = Some(overlay)` in compact/recompact; `graph_store_ref()` helper |
| `compact/layered.rs` | 6 trait method impls forwarding to overlay |
| `database/index.rs` | Node iteration via `graph_store()`, accessor via `graph_store_ref()` |
| `database/search.rs` | Accessors and filter allowlist via `graph_store_ref()` |
| `compact/column.rs` | `Float32Vector` variant: get, len, heap_bytes, write_to, read_from |
| `compact/builder.rs` | `Float32Vector` inference, encoding for node + edge tables |
| `compact/schema.rs` | `ColumnType::Float32Vector` |
| `compact/section.rs` | Section codec type mapping for Float32Vector |

## Test plan

- [x] New test: insert → compact → create_vector_index → vector_search returns all pre-compact nodes
- [x] New test: nearest-neighbor correctness after compact (distance ≈ 0 for exact match)
- [x] New test: rebuild_vector_index after compact
- [x] New test: vector_search with property filters after compact
- [x] New test: create_text_index → text_search after compact
- [x] New test: export_snapshot → import_snapshot → compact → create_vector_index → vector_search
- [x] New test: LayeredStore.has_vector_index / get_vector_index_handle forwards to overlay
- [x] New test: LayeredStore.has_text_index forwards to overlay
- [x] Full existing test suite passes (1382+ tests, zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes panics and empty results after compact() for index/search calls, and adds BM25 text search with planner pushdown and top‑K rewrite to speed up hybrid queries. Improves safety across text/vector scans and compaction.

- **New Features**
  - BM25 full‑text search with `TextScanOperator` (top‑K and threshold); per‑row scoring via `text_score`/`text_match` and `score_document`.
  - Planner/optimizer: pushdown for text/vector predicates, hybrid AND/OR index joins, ORDER BY+LIMIT → top‑K, score projection; cardinality/cost models for text scans; vector scan metric override.
  - `GraphStore` adds text APIs; `LpgStore` implements them; `LayeredStore` forwards and filters deleted base nodes. Design/spec docs and 20+ e2e hybrid tests added.

- **Bug Fixes**
  - Post‑`compact()`: keep using overlay for index registries and iterate merged base+overlay via `graph_store()`/`graph_store_ref()` so builds/searches see all data.
  - Compaction codecs: add `Float32Vector` and `Float64`; mixed vector+scalar columns fall back to Dict; validate vector bytes on read.
  - Robustness: cap VectorScan fallback k at 10k; clamp `with_chunk_capacity(0)` to 1 (text/vector); use saturating mul in HNSW; `u16::try_from` for dims; text functions scan all labels.

<sup>Written for commit ec5d52e003938758e30e47d7efebaa06d36c9325. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

