### PR TITLE
Refactor/0.5.40 hybrid cleanup

### DIFF
--- a/crates/grafeo-core/src/execution/operators/expand.rs
+++ b/crates/grafeo-core/src/execution/operators/expand.rs
@@ -3,7 +3,7 @@
 use super::{Operator, OperatorError, OperatorResult};
 use crate::execution::DataChunk;
 use crate::graph::Direction;
-use crate::graph::GraphStore;
+use crate::graph::GraphStoreSearch;
 use grafeo_common::types::{EdgeId, EpochId, LogicalType, NodeId, TransactionId};
 use std::sync::Arc;
 
@@ -13,7 +13,7 @@ use std::sync::Arc;
 /// output rows for each neighbor connected via matching edges.
 pub struct ExpandOperator {
     /// The store to traverse.
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// Input operator providing source nodes.
     input: Box<dyn Operator>,
     /// Index of the source node column in input.
@@ -47,7 +47,7 @@ pub struct ExpandOperator {
 impl ExpandOperator {
     /// Creates a new expand operator.
     pub fn new(
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         input: Box<dyn Operator>,
         source_column: usize,
         direction: Direction,
@@ -327,9 +327,9 @@ mod tests {
 
     /// Creates a new `LpgStore` wrapped in an `Arc` and returns both the
     /// concrete handle (for mutation) and a trait-object handle (for operators).
-    fn test_store() -> (Arc<LpgStore>, Arc<dyn GraphStore>) {
+    fn test_store() -> (Arc<LpgStore>, Arc<dyn GraphStoreSearch>) {
         let store = Arc::new(LpgStore::new().unwrap());
-        let dyn_store: Arc<dyn GraphStore> = Arc::clone(&store) as Arc<dyn GraphStore>;
+        let dyn_store: Arc<dyn GraphStoreSearch> = Arc::clone(&store) as Arc<dyn GraphStoreSearch>;
         (store, dyn_store)
     }
 

--- a/crates/grafeo-core/src/execution/operators/factorized_expand.rs
+++ b/crates/grafeo-core/src/execution/operators/factorized_expand.rs
@@ -19,7 +19,7 @@ use crate::execution::DataChunk;
 use crate::execution::factorized_chunk::FactorizedChunk;
 use crate::execution::vector::ValueVector;
 use crate::graph::Direction;
-use crate::graph::GraphStore;
+use crate::graph::GraphStoreSearch;
 use grafeo_common::types::{EdgeId, EpochId, LogicalType, NodeId, TransactionId};
 
 /// Result type for factorized operations.
@@ -49,7 +49,7 @@ pub type FactorizedResult = Result<Option<FactorizedChunk>, OperatorError>;
 /// - Memory: ~11,100 values (no duplication)
 pub struct FactorizedExpandOperator {
     /// The store to traverse.
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// Input operator providing source nodes.
     input: Box<dyn Operator>,
     /// Index of the source node column in input.
@@ -73,7 +73,7 @@ pub struct FactorizedExpandOperator {
 impl FactorizedExpandOperator {
     /// Creates a new factorized expand operator.
     pub fn new(
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         input: Box<dyn Operator>,
         source_column: usize,
         direction: Direction,
@@ -278,7 +278,7 @@ impl FactorizedOperator for FactorizedExpandOperator {
 /// factorized across multiple expansion steps.
 pub struct FactorizedExpandChain {
     /// The store to traverse.
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// The source operator for the first expansion.
     source: Option<Box<dyn Operator>>,
     /// Accumulated factorized result.
@@ -292,7 +292,7 @@ pub struct FactorizedExpandChain {
 
 impl FactorizedExpandChain {
     /// Creates a new chain starting from a source operator.
-    pub fn new(store: Arc<dyn GraphStore>, source: Box<dyn Operator>) -> Self {
+    pub fn new(store: Arc<dyn GraphStoreSearch>, source: Box<dyn Operator>) -> Self {
         Self {
             store,
             source: Some(source),
@@ -604,7 +604,7 @@ pub struct ExpandStep {
 /// aggregation), this avoids flattening and provides massive speedups.
 pub struct LazyFactorizedChainOperator {
     /// The graph store.
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// The source operator (filter, scan, etc).
     source: Option<Box<dyn Operator>>,
     /// The expand steps to execute.
@@ -626,7 +626,7 @@ pub struct LazyFactorizedChainOperator {
 impl LazyFactorizedChainOperator {
     /// Creates a new lazy factorized chain operator.
     pub fn new(
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         source: Box<dyn Operator>,
         steps: Vec<ExpandStep>,
     ) -> Self {

--- a/crates/grafeo-core/src/execution/operators/factorized_filter.rs
+++ b/crates/grafeo-core/src/execution/operators/factorized_filter.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use super::{FactorizedOperator, FactorizedResult, LazyFactorizedChainOperator, Operator};
 use crate::execution::chunk_state::{FactorizedSelection, LevelSelection};
 use crate::execution::factorized_chunk::FactorizedChunk;
-use crate::graph::GraphStore;
+use crate::graph::GraphStoreSearch;
 use grafeo_common::types::{EpochId, PropertyKey, Value};
 
 /// A predicate that can be evaluated on factorized data at a specific level.
@@ -244,7 +244,7 @@ pub struct PropertyPredicate {
     /// The value to compare against.
     value: Value,
     /// The graph store for property lookups.
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// Optional epoch for time-travel property reads.
     viewing_epoch: Option<EpochId>,
 }
@@ -257,7 +257,7 @@ impl PropertyPredicate {
         property: impl Into<PropertyKey>,
         op: CompareOp,
         value: Value,
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
     ) -> Self {
         Self {
             level,
@@ -276,7 +276,7 @@ impl PropertyPredicate {
         column: usize,
         property: impl Into<PropertyKey>,
         value: Value,
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
     ) -> Self {
         Self::new(level, column, property, CompareOp::Eq, value, store)
     }
@@ -523,10 +523,10 @@ impl FactorizedPredicate for OrPredicate {
 /// #     FactorizedFilterOperator, PropertyPredicate, FactorizedCompareOp,
 /// #     LazyFactorizedChainOperator,
 /// # };
-/// # use grafeo_core::graph::GraphStore;
+/// # use grafeo_core::graph::GraphStoreSearch;
 /// # use grafeo_common::types::Value;
 /// # use std::sync::Arc;
-/// # fn example(expand_chain: LazyFactorizedChainOperator, store: Arc<dyn GraphStore>) {
+/// # fn example(expand_chain: LazyFactorizedChainOperator, store: Arc<dyn GraphStoreSearch>) {
 /// // Query: MATCH (a)->(b)->(c) WHERE c.age > 30
 /// let predicate = PropertyPredicate::new(
 ///     2, 0, "age", FactorizedCompareOp::Gt, Value::Int64(30), store,

--- a/crates/grafeo-core/src/execution/operators/filter.rs
+++ b/crates/grafeo-core/src/execution/operators/filter.rs
@@ -3,7 +3,7 @@
 use super::{Operator, OperatorResult};
 use crate::execution::{ChunkZoneHints, DataChunk, SelectionVector};
 use crate::graph::Direction;
-use crate::graph::GraphStore;
+use crate::graph::GraphStoreSearch;
 use crate::graph::lpg::{Edge, Node};
 use grafeo_common::types::{
     EdgeId, EpochId, HashableValue, NodeId, PropertyKey, TransactionId, Value,
@@ -222,7 +222,7 @@ pub struct ExpressionPredicate {
     /// Map from variable name to column index.
     variable_columns: HashMap<String, usize>,
     /// The graph store for property lookups.
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// Transaction ID for MVCC-aware lookups.
     transaction_id: Option<TransactionId>,
     /// Viewing epoch for MVCC-aware lookups.
@@ -507,7 +507,7 @@ impl ExpressionPredicate {
     pub fn new(
         expression: FilterExpression,
         variable_columns: HashMap<String, usize>,
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
     ) -> Self {
         Self {
             expression,
@@ -3985,7 +3985,7 @@ mod tests {
         use crate::graph::lpg::LpgStore;
 
         // Create a store and expression predicate to test regex
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
 
         // Create predicate to test "Smith" =~ ".*Smith$" (should match)
@@ -4027,7 +4027,7 @@ mod tests {
     fn test_pow_operator() {
         use crate::graph::lpg::LpgStore;
 
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
 
         // Create a minimal chunk for evaluation
@@ -4074,7 +4074,7 @@ mod tests {
     fn test_map_expression() {
         use crate::graph::lpg::LpgStore;
 
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
 
         // Create a minimal chunk for evaluation
@@ -4116,7 +4116,7 @@ mod tests {
     fn test_index_access_list() {
         use crate::graph::lpg::LpgStore;
 
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
 
         // Create a minimal chunk for evaluation
@@ -4168,7 +4168,7 @@ mod tests {
     fn test_slice_access() {
         use crate::graph::lpg::LpgStore;
 
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
 
         // Create a minimal chunk for evaluation
@@ -4379,7 +4379,8 @@ mod tests {
 
     #[test]
     fn test_unary_operators() {
-        let store: Arc<dyn GraphStore> = Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> =
+            Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -4435,7 +4436,8 @@ mod tests {
 
     #[test]
     fn test_arithmetic_operators() {
-        let store: Arc<dyn GraphStore> = Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> =
+            Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -4523,7 +4525,8 @@ mod tests {
 
     #[test]
     fn test_string_operators() {
-        let store: Arc<dyn GraphStore> = Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> =
+            Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -4573,7 +4576,8 @@ mod tests {
 
     #[test]
     fn test_in_operator() {
-        let store: Arc<dyn GraphStore> = Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> =
+            Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -4618,7 +4622,8 @@ mod tests {
 
     #[test]
     fn test_logical_operators() {
-        let store: Arc<dyn GraphStore> = Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> =
+            Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -4662,7 +4667,8 @@ mod tests {
 
     #[test]
     fn test_case_expression_simple() {
-        let store: Arc<dyn GraphStore> = Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> =
+            Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -4697,7 +4703,8 @@ mod tests {
 
     #[test]
     fn test_case_expression_searched() {
-        let store: Arc<dyn GraphStore> = Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> =
+            Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -4730,7 +4737,8 @@ mod tests {
 
     #[test]
     fn test_list_functions() {
-        let store: Arc<dyn GraphStore> = Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> =
+            Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -4795,7 +4803,8 @@ mod tests {
 
     #[test]
     fn test_type_conversion_functions() {
-        let store: Arc<dyn GraphStore> = Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> =
+            Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -4848,7 +4857,8 @@ mod tests {
 
     #[test]
     fn test_coalesce_function() {
-        let store: Arc<dyn GraphStore> = Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> =
+            Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -4932,7 +4942,8 @@ mod tests {
 
     #[test]
     fn test_mixed_type_comparison_int_float() {
-        let store: Arc<dyn GraphStore> = Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> =
+            Arc::new(crate::graph::lpg::LpgStore::new().unwrap());
         let variable_columns = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -5096,7 +5107,7 @@ mod tests {
                 }),
             },
             variable_columns,
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
         );
 
         assert!(pred.evaluate(&chunk, 0));
@@ -5136,7 +5147,7 @@ mod tests {
     fn test_cross_type_string_int_equality() {
         use crate::graph::lpg::LpgStore;
 
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let vc = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -5183,7 +5194,7 @@ mod tests {
     fn test_cross_type_string_float_equality() {
         use crate::graph::lpg::LpgStore;
 
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let vc = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -5220,7 +5231,7 @@ mod tests {
     fn test_cross_type_string_numeric_ordering() {
         use crate::graph::lpg::LpgStore;
 
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let vc = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -5320,7 +5331,7 @@ mod tests {
     fn eval_literal_expr(expr: FilterExpression) -> Option<Value> {
         use crate::graph::lpg::LpgStore;
 
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let pred = ExpressionPredicate::new(expr, HashMap::new(), store);
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -5643,7 +5654,7 @@ mod tests {
         // which IS NULL treats as true
         use crate::graph::lpg::LpgStore;
 
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let expr = FilterExpression::Unary {
             op: UnaryFilterOp::IsNull,
             operand: Box::new(FilterExpression::Variable("missing_var".to_string())),
@@ -5714,7 +5725,7 @@ mod tests {
     fn test_eval_in_operator() {
         use crate::graph::lpg::LpgStore;
 
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
 
@@ -5751,7 +5762,7 @@ mod tests {
     fn test_eval_in_operator_strings() {
         use crate::graph::lpg::LpgStore;
 
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
 
@@ -6350,7 +6361,7 @@ mod tests {
     #[test]
     fn test_eval_tostring_types() {
         use crate::graph::lpg::LpgStore;
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let vc = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -6392,7 +6403,7 @@ mod tests {
     #[test]
     fn test_eval_toboolean() {
         use crate::graph::lpg::LpgStore;
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let vc = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -6431,7 +6442,7 @@ mod tests {
     #[test]
     fn test_eval_tofloat() {
         use crate::graph::lpg::LpgStore;
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let vc = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -6464,7 +6475,7 @@ mod tests {
     #[test]
     fn test_eval_tointeger_from_float() {
         use crate::graph::lpg::LpgStore;
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let vc = HashMap::new();
         let builder = DataChunkBuilder::new(&[LogicalType::Int64]);
         let chunk = builder.finish();
@@ -6551,7 +6562,7 @@ mod tests {
 mod text_fn_tests {
     use super::*;
     use crate::execution::chunk::DataChunkBuilder;
-    use crate::graph::GraphStore;
+    use crate::graph::GraphStoreSearch;
     use crate::graph::lpg::LpgStore;
     use crate::index::text::{BM25Config, InvertedIndex};
     use grafeo_common::types::LogicalType;
@@ -6617,7 +6628,7 @@ mod text_fn_tests {
                 right: Box::new(FilterExpression::Literal(Value::Float64(0.0))),
             },
             variable_columns,
-            store as Arc<dyn GraphStore>,
+            store as Arc<dyn GraphStoreSearch>,
         );
 
         // n1 matches "rust database" — should pass
@@ -6660,7 +6671,7 @@ mod text_fn_tests {
                 ],
             },
             variable_columns,
-            store as Arc<dyn GraphStore>,
+            store as Arc<dyn GraphStoreSearch>,
         );
 
         // n1 contains "rust" — text_match should return Bool(true) → evaluates to true
@@ -6683,7 +6694,7 @@ mod text_fn_tests {
                 args: vec![FilterExpression::Literal(Value::String("only_one".into()))],
             },
             variable_columns,
-            store as Arc<dyn GraphStore>,
+            store as Arc<dyn GraphStoreSearch>,
         );
         assert!(!predicate.evaluate(&chunk, 0));
     }
@@ -6716,7 +6727,7 @@ mod text_fn_tests {
                 ],
             },
             variable_columns,
-            store as Arc<dyn GraphStore>,
+            store as Arc<dyn GraphStoreSearch>,
         );
         // No index → score_text returns None → eval returns None → evaluate returns false
         assert!(!predicate.evaluate(&chunk, 0));

--- a/crates/grafeo-core/src/execution/operators/horizontal_aggregate.rs
+++ b/crates/grafeo-core/src/execution/operators/horizontal_aggregate.rs
@@ -14,7 +14,7 @@ use super::aggregate::AggregateState;
 use super::{Operator, OperatorResult};
 use crate::execution::DataChunk;
 use crate::execution::vector::ValueVector;
-use crate::graph::traits::GraphStore;
+use crate::graph::traits::GraphStoreSearch;
 
 /// Whether the horizontal aggregate operates on edges or nodes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -45,7 +45,7 @@ pub struct HorizontalAggregateOperator {
     /// Property name to access on each entity.
     property: String,
     /// Graph store for property lookups.
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// Number of input columns (to know where to append the result).
     input_column_count: usize,
 }
@@ -58,7 +58,7 @@ impl HorizontalAggregateOperator {
         entity_kind: EntityKind,
         function: AggregateFunction,
         property: String,
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         input_column_count: usize,
     ) -> Self {
         Self {
@@ -206,7 +206,7 @@ mod tests {
 
     // reason: test IDs are small sequential counters
     #[allow(clippy::cast_possible_wrap)]
-    fn setup_store_with_edges() -> (Arc<dyn GraphStore>, Vec<Value>) {
+    fn setup_store_with_edges() -> (Arc<dyn GraphStoreSearch>, Vec<Value>) {
         let store = LpgStore::new().unwrap();
         let n1 = store.create_node(&[]);
         let n2 = store.create_node(&[]);
@@ -229,7 +229,7 @@ mod tests {
 
     // reason: test IDs are small sequential counters
     #[allow(clippy::cast_possible_wrap)]
-    fn setup_store_with_nodes() -> (Arc<dyn GraphStore>, Vec<Value>) {
+    fn setup_store_with_nodes() -> (Arc<dyn GraphStoreSearch>, Vec<Value>) {
         let store = LpgStore::new().unwrap();
         // Use Float64 properties since the result column is Float64-typed
         // (Int64 values from SumInt finalize would be silently dropped by the Float64 column)
@@ -397,7 +397,7 @@ mod tests {
 
     #[test]
     fn test_horizontal_empty_list_returns_null() {
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
 
         let mut builder = DataChunkBuilder::new(&[LogicalType::Any]);
         builder
@@ -430,7 +430,7 @@ mod tests {
 
     #[test]
     fn test_horizontal_non_list_column_returns_null() {
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
 
         // Put a non-list value in the list column
         let mut builder = DataChunkBuilder::new(&[LogicalType::Int64]);
@@ -552,7 +552,7 @@ mod tests {
 
     #[test]
     fn test_horizontal_name() {
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let mock = MockOperator::new(vec![]);
         let op = HorizontalAggregateOperator::new(
             Box::new(mock),
@@ -568,7 +568,7 @@ mod tests {
 
     #[test]
     fn test_horizontal_child_returns_none() {
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let mock = MockOperator::new(vec![]); // No chunks
         let mut op = HorizontalAggregateOperator::new(
             Box::new(mock),
@@ -585,7 +585,7 @@ mod tests {
 
     #[test]
     fn test_horizontal_aggregate_into_any() {
-        let store: Arc<dyn GraphStore> = Arc::new(LpgStore::new().unwrap());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
         let mock = MockOperator::new(vec![]);
         let op = HorizontalAggregateOperator::new(
             Box::new(mock),

--- a/crates/grafeo-core/src/execution/operators/mod.rs
+++ b/crates/grafeo-core/src/execution/operators/mod.rs
@@ -42,6 +42,7 @@ pub mod push;
 mod scan;
 #[cfg(feature = "text-index")]
 mod scan_text;
+#[cfg(feature = "vector-index")]
 mod scan_vector;
 mod set_ops;
 mod shortest_path;
@@ -99,6 +100,7 @@ pub use push::{SpillableAggregatePushOperator, SpillableSortPushOperator};
 pub use scan::ScanOperator;
 #[cfg(feature = "text-index")]
 pub use scan_text::TextScanOperator;
+#[cfg(feature = "vector-index")]
 pub use scan_vector::VectorScanOperator;
 pub use set_ops::{ExceptOperator, IntersectOperator, OtherwiseOperator};
 pub use shortest_path::ShortestPathOperator;

--- a/crates/grafeo-core/src/execution/operators/project.rs
+++ b/crates/grafeo-core/src/execution/operators/project.rs
@@ -3,7 +3,7 @@
 use super::filter::{ExpressionPredicate, FilterExpression, SessionContext};
 use super::{Operator, OperatorError, OperatorResult};
 use crate::execution::DataChunk;
-use crate::graph::GraphStore;
+use crate::graph::GraphStoreSearch;
 use crate::graph::lpg::{Edge, Node};
 use grafeo_common::types::{EpochId, LogicalType, PropertyKey, TransactionId, Value};
 use std::collections::{BTreeMap, HashMap};
@@ -63,7 +63,7 @@ pub struct ProjectOperator {
     /// Output column types.
     output_types: Vec<LogicalType>,
     /// Optional store for property access.
-    store: Option<Arc<dyn GraphStore>>,
+    store: Option<Arc<dyn GraphStoreSearch>>,
     /// Transaction ID for MVCC-aware property lookups.
     transaction_id: Option<TransactionId>,
     /// Viewing epoch for MVCC-aware property lookups.
@@ -104,7 +104,7 @@ impl ProjectOperator {
         child: Box<dyn Operator>,
         projections: Vec<ProjectExpr>,
         output_types: Vec<LogicalType>,
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
     ) -> Self {
         assert_eq!(projections.len(), output_types.len());
         Self {

--- a/crates/grafeo-core/src/execution/operators/scan.rs
+++ b/crates/grafeo-core/src/execution/operators/scan.rs
@@ -2,14 +2,14 @@
 
 use super::{Operator, OperatorResult};
 use crate::execution::DataChunk;
-use crate::graph::GraphStore;
+use crate::graph::GraphStoreSearch;
 use grafeo_common::types::{EpochId, LogicalType, NodeId, TransactionId};
 use std::sync::Arc;
 
 /// A scan operator that reads nodes from storage.
 pub struct ScanOperator {
     /// The store to scan from.
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// Label filter (None = all nodes).
     label: Option<String>,
     /// Current position in the scan.
@@ -28,7 +28,7 @@ pub struct ScanOperator {
 
 impl ScanOperator {
     /// Creates a new scan operator for all nodes.
-    pub fn new(store: Arc<dyn GraphStore>) -> Self {
+    pub fn new(store: Arc<dyn GraphStoreSearch>) -> Self {
         Self {
             store,
             label: None,
@@ -42,7 +42,7 @@ impl ScanOperator {
     }
 
     /// Creates a new scan operator for nodes with a specific label.
-    pub fn with_label(store: Arc<dyn GraphStore>, label: impl Into<String>) -> Self {
+    pub fn with_label(store: Arc<dyn GraphStoreSearch>, label: impl Into<String>) -> Self {
         Self {
             store,
             label: Some(label.into()),
@@ -169,7 +169,8 @@ mod tests {
         store.create_node(&["Person"]);
         store.create_node(&["Animal"]);
 
-        let mut scan = ScanOperator::with_label(store.clone() as Arc<dyn GraphStore>, "Person");
+        let mut scan =
+            ScanOperator::with_label(store.clone() as Arc<dyn GraphStoreSearch>, "Person");
 
         let chunk = scan.next().unwrap().unwrap();
         assert_eq!(chunk.row_count(), 2);
@@ -184,7 +185,8 @@ mod tests {
         let store: Arc<dyn GraphStoreMut> = Arc::new(LpgStore::new().unwrap());
         store.create_node(&["Person"]);
 
-        let mut scan = ScanOperator::with_label(store.clone() as Arc<dyn GraphStore>, "Person");
+        let mut scan =
+            ScanOperator::with_label(store.clone() as Arc<dyn GraphStoreSearch>, "Person");
 
         // First scan
         let chunk1 = scan.next().unwrap().unwrap();
@@ -209,7 +211,7 @@ mod tests {
         store.create_node(&["Place"]);
 
         // Full scan (no label filter) should return all nodes
-        let mut scan = ScanOperator::new(store.clone() as Arc<dyn GraphStore>);
+        let mut scan = ScanOperator::new(store.clone() as Arc<dyn GraphStoreSearch>);
 
         let chunk = scan.next().unwrap().unwrap();
         assert_eq!(chunk.row_count(), 4, "Full scan should return all 4 nodes");
@@ -234,15 +236,17 @@ mod tests {
         store.create_node_versioned(&["Person"], epoch5, TransactionId::SYSTEM);
 
         // Scan at epoch 3 should see only the first 2 nodes (created at epoch 1)
-        let mut scan = ScanOperator::with_label(store.clone() as Arc<dyn GraphStore>, "Person")
-            .with_transaction_context(EpochId::new(3), None);
+        let mut scan =
+            ScanOperator::with_label(store.clone() as Arc<dyn GraphStoreSearch>, "Person")
+                .with_transaction_context(EpochId::new(3), None);
 
         let chunk = scan.next().unwrap().unwrap();
         assert_eq!(chunk.row_count(), 2, "Should see 2 nodes at epoch 3");
 
         // Scan at epoch 5 should see all 3 nodes
-        let mut scan_all = ScanOperator::with_label(store.clone() as Arc<dyn GraphStore>, "Person")
-            .with_transaction_context(EpochId::new(5), None);
+        let mut scan_all =
+            ScanOperator::with_label(store.clone() as Arc<dyn GraphStoreSearch>, "Person")
+                .with_transaction_context(EpochId::new(5), None);
 
         let chunk_all = scan_all.next().unwrap().unwrap();
         assert_eq!(chunk_all.row_count(), 3, "Should see 3 nodes at epoch 5");
@@ -251,7 +255,7 @@ mod tests {
     #[test]
     fn test_scan_into_any() {
         let store: Arc<dyn GraphStoreMut> = Arc::new(LpgStore::new().unwrap());
-        let op = ScanOperator::with_label(store.clone() as Arc<dyn GraphStore>, "Person");
+        let op = ScanOperator::with_label(store.clone() as Arc<dyn GraphStoreSearch>, "Person");
         let any = Box::new(op).into_any();
         assert!(any.downcast::<ScanOperator>().is_ok());
     }

--- a/crates/grafeo-core/src/execution/operators/scan_text.rs
+++ b/crates/grafeo-core/src/execution/operators/scan_text.rs
@@ -5,7 +5,7 @@
 
 use super::{Operator, OperatorError, OperatorResult};
 use crate::execution::DataChunk;
-use crate::graph::traits::GraphStore;
+use crate::graph::traits::GraphStoreSearch;
 use grafeo_common::types::{LogicalType, NodeId};
 use std::sync::Arc;
 
@@ -27,7 +27,7 @@ use std::sync::Arc;
 /// 2. `Float64` — The BM25 relevance score
 pub struct TextScanOperator {
     /// The graph store to search.
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// Label to search within.
     label: String,
     /// Property holding the text to search.
@@ -54,7 +54,7 @@ impl TextScanOperator {
     /// Returns the `k` highest-scoring nodes for the given query.
     #[must_use]
     pub fn top_k(
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         label: impl Into<String>,
         property: impl Into<String>,
         query: impl Into<String>,
@@ -79,7 +79,7 @@ impl TextScanOperator {
     /// Returns all nodes with a BM25 score ≥ `threshold`.
     #[must_use]
     pub fn with_threshold(
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         label: impl Into<String>,
         property: impl Into<String>,
         query: impl Into<String>,
@@ -193,7 +193,7 @@ impl Operator for TextScanOperator {
 mod tests {
     use super::*;
     use crate::graph::lpg::LpgStore;
-    use crate::graph::traits::GraphStore;
+    use crate::graph::traits::GraphStoreSearch;
     use crate::index::text::{BM25Config, InvertedIndex};
     use grafeo_common::types::Value;
     use parking_lot::RwLock;
@@ -232,7 +232,7 @@ mod tests {
     fn test_text_scan_top_k() {
         let store = make_store();
         let mut scan = TextScanOperator::top_k(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             "Doc",
             "body",
             "rust",
@@ -254,7 +254,7 @@ mod tests {
         assert_eq!(all.len(), 2);
         let mid = f64::midpoint(all[0].1, all[1].1);
         let mut scan = TextScanOperator::with_threshold(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             "Doc",
             "body",
             "rust database",
@@ -270,7 +270,7 @@ mod tests {
     fn test_text_scan_no_matches() {
         let store = make_store();
         let mut scan = TextScanOperator::top_k(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             "Doc",
             "body",
             "nonexistent",
@@ -283,7 +283,7 @@ mod tests {
     fn test_text_scan_reset() {
         let store = make_store();
         let mut scan = TextScanOperator::top_k(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             "Doc",
             "body",
             "rust",
@@ -301,7 +301,7 @@ mod tests {
     fn test_text_scan_name() {
         let store = make_store();
         let scan = TextScanOperator::top_k(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             "Doc",
             "body",
             "rust",
@@ -314,7 +314,7 @@ mod tests {
     fn test_text_scan_chunk_capacity() {
         let store = make_store();
         let mut scan = TextScanOperator::top_k(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             "Doc",
             "body",
             "rust",

--- a/crates/grafeo-core/src/execution/operators/scan_vector.rs
+++ b/crates/grafeo-core/src/execution/operators/scan_vector.rs
@@ -1,29 +1,29 @@
 //! Vector similarity scan operator.
 //!
-//! Performs approximate nearest neighbor (ANN) search using HNSW index
-//! or brute-force search for small datasets.
+//! Delegates to the store's [`GraphStoreSearch::vector_search`] implementation,
+//! which routes to HNSW when a matching index is available and falls back to
+//! brute-force scan otherwise. The operator itself owns only the search
+//! parameters and post-filter thresholds.
 
 use super::{Operator, OperatorError, OperatorResult};
 use crate::execution::DataChunk;
-use crate::graph::GraphStore;
+use crate::graph::GraphStoreSearch;
 use crate::index::vector::DistanceMetric;
-use grafeo_common::types::{LogicalType, NodeId, PropertyKey, Value};
+use grafeo_common::types::{LogicalType, NodeId};
 use std::sync::Arc;
-
-#[cfg(feature = "vector-index")]
-use crate::index::vector::VectorIndexKind;
 
 /// A scan operator that finds nodes by vector similarity.
 ///
-/// This operator performs k-nearest neighbor search on vector embeddings
-/// stored in node properties. It can use an HNSW index for O(log n) search
-/// or fall back to brute-force O(n) search.
+/// Calls [`GraphStoreSearch::vector_search`] on the first `next()`, caches
+/// the results, and streams them as `DataChunk` batches. The store decides
+/// between HNSW-accelerated and brute-force execution based on what's
+/// registered for (label, property).
 ///
-/// # Output Schema
+/// # Output schema
 ///
 /// Returns a DataChunk with two columns:
-/// 1. `Node` - The matched node ID
-/// 2. `Float64` - The distance/similarity score
+/// 1. `Node` - the matched node ID
+/// 2. `Float64` - the distance score (units depend on `metric`)
 ///
 /// # Example
 ///
@@ -31,13 +31,19 @@ use crate::index::vector::VectorIndexKind;
 /// use grafeo_core::execution::operators::{Operator, VectorScanOperator};
 /// use grafeo_core::index::vector::DistanceMetric;
 /// use grafeo_core::graph::lpg::LpgStore;
+/// use grafeo_core::graph::GraphStoreSearch;
 /// use std::sync::Arc;
 ///
 /// # fn example() -> Result<(), grafeo_core::execution::operators::OperatorError> {
-/// let store = Arc::new(LpgStore::new().unwrap());
+/// let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
 /// let query = vec![0.1f32, 0.2, 0.3];
-/// let mut scan = VectorScanOperator::brute_force(
-///     store, "embedding", query, 10, DistanceMetric::Cosine,
+/// let mut scan = VectorScanOperator::new(
+///     store,
+///     Some("Document".to_string()),
+///     "embedding".to_string(),
+///     query,
+///     10,
+///     DistanceMetric::Cosine,
 /// );
 ///
 /// while let Some(chunk) = scan.next()? {
@@ -51,252 +57,109 @@ use crate::index::vector::VectorIndexKind;
 /// # }
 /// ```
 pub struct VectorScanOperator {
-    /// The store to fetch node properties from (for brute-force).
-    store: Arc<dyn GraphStore>,
-    /// The HNSW index to search (None = brute-force).
-    #[cfg(feature = "vector-index")]
-    index: Option<Arc<VectorIndexKind>>,
-    /// The query vector.
-    query: Vec<f32>,
-    /// Number of nearest neighbors to return.
-    k: usize,
-    /// Distance metric (for brute-force or metric override).
-    metric: DistanceMetric,
-    /// Property name containing the vector (for brute-force).
-    property: String,
-    /// Label filter (for brute-force).
+    store: Arc<dyn GraphStoreSearch>,
     label: Option<String>,
-    /// Minimum similarity threshold (filters results).
+    property: String,
+    query: Vec<f32>,
+    k: usize,
+    metric: DistanceMetric,
     min_similarity: Option<f32>,
-    /// Maximum distance threshold (filters results).
     max_distance: Option<f32>,
-    /// Search ef parameter (higher = more accurate but slower).
-    ef: usize,
-    /// Cached results from search.
-    results: Vec<(NodeId, f32)>,
-    /// Current position in results.
+    results: Vec<(NodeId, f64)>,
     position: usize,
-    /// Whether search has been executed.
     executed: bool,
-    /// Chunk capacity.
     chunk_capacity: usize,
-    /// Whether using index (for name() without feature gate).
-    uses_index: bool,
 }
 
 impl VectorScanOperator {
-    /// Creates a new vector scan operator using an HNSW index.
+    /// Creates a new vector similarity scan.
     ///
-    /// # Arguments
-    ///
-    /// * `store` - The LPG store (used for property lookup if needed)
-    /// * `index` - The HNSW index to search
-    /// * `query` - The query vector
-    /// * `k` - Number of nearest neighbors to return
-    #[cfg(feature = "vector-index")]
+    /// `label` scopes the search to nodes carrying that label (use `None` to
+    /// scan every node with the named property). The store decides between
+    /// HNSW and brute force based on (label, property, metric).
     #[must_use]
-    pub fn with_index(
-        store: Arc<dyn GraphStore>,
-        index: Arc<VectorIndexKind>,
-        query: Vec<f32>,
-        k: usize,
-    ) -> Self {
-        Self {
-            store,
-            index: Some(index),
-            query,
-            k,
-            metric: DistanceMetric::Cosine,
-            property: String::new(),
-            label: None,
-            min_similarity: None,
-            max_distance: None,
-            ef: 64, // Default ef for search
-            results: Vec::new(),
-            position: 0,
-            executed: false,
-            chunk_capacity: 2048,
-            uses_index: true,
-        }
-    }
-
-    /// Sets the property name (required for HNSW index vector accessor).
-    #[must_use]
-    pub fn with_property(mut self, property: impl Into<String>) -> Self {
-        self.property = property.into();
-        self
-    }
-
-    /// Creates a new vector scan operator for brute-force search.
-    ///
-    /// This is suitable for small datasets (< 10K vectors) where
-    /// index overhead isn't worth it.
-    ///
-    /// # Arguments
-    ///
-    /// * `store` - The LPG store to scan
-    /// * `property` - The property name containing vector embeddings
-    /// * `query` - The query vector
-    /// * `k` - Number of nearest neighbors to return
-    /// * `metric` - Distance metric to use
-    #[must_use]
-    pub fn brute_force(
-        store: Arc<dyn GraphStore>,
-        property: impl Into<String>,
+    pub fn new(
+        store: Arc<dyn GraphStoreSearch>,
+        label: Option<String>,
+        property: String,
         query: Vec<f32>,
         k: usize,
         metric: DistanceMetric,
     ) -> Self {
         Self {
             store,
-            #[cfg(feature = "vector-index")]
-            index: None,
+            label,
+            property,
             query,
             k,
             metric,
-            property: property.into(),
-            label: None,
             min_similarity: None,
             max_distance: None,
-            ef: 64,
             results: Vec::new(),
             position: 0,
             executed: false,
             chunk_capacity: 2048,
-            uses_index: false,
         }
     }
 
-    /// Sets a label filter for brute-force search.
-    #[must_use]
-    pub fn with_label(mut self, label: impl Into<String>) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    /// Sets the search ef parameter (accuracy vs speed tradeoff).
+    /// Filters out results with similarity below this threshold.
     ///
-    /// Higher values give more accurate results but slower search.
-    /// Default is 64. For production use, 50-200 is typical.
-    #[must_use]
-    pub fn with_ef(mut self, ef: usize) -> Self {
-        self.ef = ef;
-        self
-    }
-
-    /// Sets a minimum similarity threshold.
-    ///
-    /// Results with similarity below this value will be filtered out.
-    /// For cosine similarity, this should be in [-1, 1].
+    /// Similarity is computed as `1.0 - distance` for cosine metric; the
+    /// filter has no effect for other metrics (use `with_max_distance` instead).
     #[must_use]
     pub fn with_min_similarity(mut self, threshold: f32) -> Self {
         self.min_similarity = Some(threshold);
         self
     }
 
-    /// Sets a maximum distance threshold.
-    ///
-    /// Results with distance above this value will be filtered out.
+    /// Filters out results whose distance exceeds this threshold.
     #[must_use]
     pub fn with_max_distance(mut self, threshold: f32) -> Self {
         self.max_distance = Some(threshold);
         self
     }
 
-    /// Overrides the distance metric.
-    ///
-    /// When using `with_index`, the default metric is Cosine. Use this to
-    /// match the HNSW index's actual metric so that threshold comparisons
-    /// (min_similarity, max_distance) use the correct distance scale.
-    #[must_use]
-    pub fn with_metric(mut self, metric: DistanceMetric) -> Self {
-        self.metric = metric;
-        self
-    }
-
-    /// Sets the chunk capacity for output batches.
+    /// Sets the chunk capacity for output batches. Clamped to at least 1.
     #[must_use]
     pub fn with_chunk_capacity(mut self, capacity: usize) -> Self {
         self.chunk_capacity = capacity.max(1);
         self
     }
 
-    /// Executes the vector search (lazily on first next() call).
     fn execute_search(&mut self) {
         if self.executed {
             return;
         }
         self.executed = true;
 
-        #[cfg(feature = "vector-index")]
-        {
-            if let Some(ref index) = self.index {
-                // Use HNSW index with property accessor
-                let accessor = crate::index::vector::PropertyVectorAccessor::new(
-                    &*self.store,
-                    &*self.property,
-                );
-                self.results = index.search_with_ef(&self.query, self.k, self.ef, &accessor);
-                self.apply_filters();
-                return;
-            }
-        }
+        self.results = self.store.vector_search(
+            self.label.as_deref(),
+            &self.property,
+            &self.query,
+            self.k,
+            self.metric,
+        );
 
-        // Brute-force search over node properties
-        self.results = self.brute_force_search();
         self.apply_filters();
     }
 
-    /// Performs brute-force k-NN search over node properties.
-    fn brute_force_search(&self) -> Vec<(NodeId, f32)> {
-        use crate::index::vector::brute_force_knn;
-
-        // Get nodes to search (optionally filtered by label)
-        let node_ids = match &self.label {
-            Some(label) => self.store.nodes_by_label(label),
-            None => self.store.node_ids(),
-        };
-
-        // Collect vectors from node properties
-        let vectors: Vec<(NodeId, Vec<f32>)> = node_ids
-            .into_iter()
-            .filter_map(|id| {
-                self.store
-                    .get_node_property(id, &PropertyKey::new(&self.property))
-                    .and_then(|v| {
-                        if let Value::Vector(vec) = v {
-                            Some((id, vec.to_vec()))
-                        } else {
-                            None
-                        }
-                    })
-            })
-            .collect();
-
-        // Run brute-force k-NN
-        let iter = vectors.iter().map(|(id, v)| (*id, v.as_slice()));
-        brute_force_knn(iter, &self.query, self.k, self.metric)
-    }
-
-    /// Applies similarity/distance filters to results.
     fn apply_filters(&mut self) {
         if self.min_similarity.is_none() && self.max_distance.is_none() {
             return;
         }
 
         self.results.retain(|(_, distance)| {
-            // For cosine metric, convert distance to similarity
             let passes_similarity = match self.min_similarity {
                 Some(threshold) if self.metric == DistanceMetric::Cosine => {
                     let similarity = 1.0 - distance;
-                    similarity >= threshold
+                    similarity >= f64::from(threshold)
                 }
-                Some(_) => true, // Similarity filter only applies to cosine
+                Some(_) => true,
                 None => true,
             };
 
             let passes_distance = match self.max_distance {
-                Some(threshold) => *distance <= threshold,
+                Some(threshold) => *distance <= f64::from(threshold),
                 None => true,
             };
 
@@ -307,41 +170,33 @@ impl VectorScanOperator {
 
 impl Operator for VectorScanOperator {
     fn next(&mut self) -> OperatorResult {
-        // Execute search on first call
         self.execute_search();
 
         if self.position >= self.results.len() {
             return Ok(None);
         }
 
-        // Create output chunk with (NodeId, distance) schema
         let schema = [LogicalType::Node, LogicalType::Float64];
         let mut chunk = DataChunk::with_capacity(&schema, self.chunk_capacity);
 
         let end = (self.position + self.chunk_capacity).min(self.results.len());
         let count = end - self.position;
 
-        // Fill node ID column
         {
             let node_col = chunk
                 .column_mut(0)
                 .ok_or_else(|| OperatorError::ColumnNotFound("node column".into()))?;
-
             for i in self.position..end {
-                let (node_id, _) = self.results[i];
-                node_col.push_node_id(node_id);
+                node_col.push_node_id(self.results[i].0);
             }
         }
 
-        // Fill distance column
         {
             let dist_col = chunk
                 .column_mut(1)
                 .ok_or_else(|| OperatorError::ColumnNotFound("distance column".into()))?;
-
             for i in self.position..end {
-                let (_, distance) = self.results[i];
-                dist_col.push_float64(f64::from(distance));
+                dist_col.push_float64(self.results[i].1);
             }
         }
 
@@ -358,11 +213,7 @@ impl Operator for VectorScanOperator {
     }
 
     fn name(&self) -> &'static str {
-        if self.uses_index {
-            "VectorScan(HNSW)"
-        } else {
-            "VectorScan(BruteForce)"
-        }
+        "VectorScan"
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn std::any::Any + Send> {
@@ -370,305 +221,187 @@ impl Operator for VectorScanOperator {
     }
 }
 
-#[cfg(all(test, feature = "lpg"))]
+#[cfg(all(test, feature = "lpg", feature = "vector-index"))]
 mod tests {
     use super::*;
     use crate::graph::lpg::LpgStore;
+    use grafeo_common::types::Value;
+
+    fn store_with_vectors(docs: &[(&str, Vec<f32>)]) -> Arc<dyn GraphStoreSearch> {
+        let store = Arc::new(LpgStore::new().unwrap());
+        for (property, vector) in docs {
+            let node = store.create_node(&["Document"]);
+            store.set_node_property(node, property, Value::Vector(vector.clone().into()));
+        }
+        store
+    }
 
     #[test]
     fn test_vector_scan_brute_force() {
         let store = Arc::new(LpgStore::new().unwrap());
 
-        // Create nodes with vector embeddings
         let n1 = store.create_node(&["Document"]);
         let n2 = store.create_node(&["Document"]);
         let n3 = store.create_node(&["Document"]);
 
-        // Set vector properties - n1 is closest to query
         store.set_node_property(n1, "embedding", Value::Vector(vec![0.1, 0.2, 0.3].into()));
         store.set_node_property(n2, "embedding", Value::Vector(vec![0.5, 0.6, 0.7].into()));
         store.set_node_property(n3, "embedding", Value::Vector(vec![0.9, 0.8, 0.7].into()));
 
-        // Query vector similar to n1
         let query = vec![0.1, 0.2, 0.35];
 
-        let mut scan = VectorScanOperator::brute_force(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
-            "embedding",
+        let mut scan = VectorScanOperator::new(
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
+            Some("Document".to_string()),
+            "embedding".to_string(),
             query,
-            2, // k=2
+            2,
             DistanceMetric::Euclidean,
-        )
-        .with_label("Document");
+        );
 
         let chunk = scan.next().unwrap().unwrap();
         assert_eq!(chunk.row_count(), 2);
 
-        // First result should be n1 (closest)
         let first_node = chunk.column(0).unwrap().get_node_id(0);
         assert_eq!(first_node, Some(n1));
 
-        // Should be exhausted
         assert!(scan.next().unwrap().is_none());
     }
 
     #[test]
     fn test_vector_scan_reset() {
         let store = Arc::new(LpgStore::new().unwrap());
-
         let n1 = store.create_node(&["Doc"]);
         store.set_node_property(n1, "vec", Value::Vector(vec![0.1, 0.2].into()));
 
-        let mut scan = VectorScanOperator::brute_force(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
-            "vec",
+        let mut scan = VectorScanOperator::new(
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
+            None,
+            "vec".to_string(),
             vec![0.1, 0.2],
             10,
             DistanceMetric::Cosine,
         );
 
-        // First scan
         let chunk1 = scan.next().unwrap().unwrap();
         assert_eq!(chunk1.row_count(), 1);
         assert!(scan.next().unwrap().is_none());
 
-        // Reset and scan again
         scan.reset();
         let chunk2 = scan.next().unwrap().unwrap();
         assert_eq!(chunk2.row_count(), 1);
     }
 
     #[test]
-    fn test_vector_scan_with_distance_filter() {
+    fn test_vector_scan_with_max_distance() {
         let store = Arc::new(LpgStore::new().unwrap());
-
         let n1 = store.create_node(&["Doc"]);
-        let n2 = store.create_node(&["Doc"]);
-
-        // n1 is very close, n2 is far
+        let _n2 = store.create_node(&["Doc"]);
         store.set_node_property(n1, "vec", Value::Vector(vec![0.1, 0.0].into()));
-        store.set_node_property(n2, "vec", Value::Vector(vec![10.0, 10.0].into()));
+        store.set_node_property(_n2, "vec", Value::Vector(vec![10.0, 10.0].into()));
 
-        let mut scan = VectorScanOperator::brute_force(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
-            "vec",
+        let mut scan = VectorScanOperator::new(
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
+            Some("Doc".to_string()),
+            "vec".to_string(),
             vec![0.0, 0.0],
             10,
             DistanceMetric::Euclidean,
         )
-        .with_max_distance(1.0); // Only n1 should pass
+        .with_max_distance(1.0);
 
         let chunk = scan.next().unwrap().unwrap();
         assert_eq!(chunk.row_count(), 1);
-
-        let node_id = chunk.column(0).unwrap().get_node_id(0);
-        assert_eq!(node_id, Some(n1));
+        assert_eq!(chunk.column(0).unwrap().get_node_id(0), Some(n1));
     }
 
     #[test]
     fn test_vector_scan_empty_results() {
         let store = Arc::new(LpgStore::new().unwrap());
-
-        // No nodes with vectors
         store.create_node(&["Doc"]);
 
-        let mut scan = VectorScanOperator::brute_force(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
-            "embedding",
+        let mut scan = VectorScanOperator::new(
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
+            None,
+            "embedding".to_string(),
             vec![0.1, 0.2],
             10,
             DistanceMetric::Cosine,
         );
-
-        let result = scan.next().unwrap();
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_vector_scan_name() {
-        let store = Arc::new(LpgStore::new().unwrap());
-
-        let brute_scan = VectorScanOperator::brute_force(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
-            "vec",
-            vec![0.1],
-            10,
-            DistanceMetric::Cosine,
-        );
-        assert_eq!(brute_scan.name(), "VectorScan(BruteForce)");
-    }
-
-    #[test]
-    fn test_vector_scan_with_min_similarity() {
-        let store = Arc::new(LpgStore::new().unwrap());
-
-        let n1 = store.create_node(&["Doc"]);
-        let n2 = store.create_node(&["Doc"]);
-
-        // Normalized vectors for cosine similarity
-        // n1: [1, 0] - orthogonal to query
-        // n2: [0.707, 0.707] - similar to query [0, 1]
-        store.set_node_property(n1, "vec", Value::Vector(vec![1.0, 0.0].into()));
-        store.set_node_property(n2, "vec", Value::Vector(vec![0.707, 0.707].into()));
-
-        let mut scan = VectorScanOperator::brute_force(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
-            "vec",
-            vec![0.0, 1.0], // Query: [0, 1]
-            10,
-            DistanceMetric::Cosine,
-        )
-        .with_min_similarity(0.5); // Filters out n1 (similarity ~0)
-
-        let chunk = scan.next().unwrap().unwrap();
-        assert_eq!(chunk.row_count(), 1);
-
-        let node_id = chunk.column(0).unwrap().get_node_id(0);
-        assert_eq!(node_id, Some(n2));
-    }
-
-    #[test]
-    fn test_vector_scan_with_ef() {
-        let store = Arc::new(LpgStore::new().unwrap());
-
-        let n1 = store.create_node(&["Doc"]);
-        store.set_node_property(n1, "vec", Value::Vector(vec![0.1, 0.2].into()));
-
-        let mut scan = VectorScanOperator::brute_force(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
-            "vec",
-            vec![0.1, 0.2],
-            10,
-            DistanceMetric::Cosine,
-        )
-        .with_ef(128); // Higher ef (doesn't affect brute-force, but tests API)
-
-        let chunk = scan.next().unwrap().unwrap();
-        assert_eq!(chunk.row_count(), 1);
-    }
-
-    #[test]
-    fn test_vector_scan_with_chunk_capacity() {
-        let store = Arc::new(LpgStore::new().unwrap());
-
-        // Create many nodes
-        for i in 0..10 {
-            let node = store.create_node(&["Doc"]);
-            store.set_node_property(node, "vec", Value::Vector(vec![i as f32, 0.0].into()));
-        }
-
-        let mut scan = VectorScanOperator::brute_force(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
-            "vec",
-            vec![0.0, 0.0],
-            10,
-            DistanceMetric::Euclidean,
-        )
-        .with_chunk_capacity(3); // Small chunks
-
-        // Should return multiple chunks
-        let chunk1 = scan.next().unwrap().unwrap();
-        assert_eq!(chunk1.row_count(), 3);
-
-        let chunk2 = scan.next().unwrap().unwrap();
-        assert_eq!(chunk2.row_count(), 3);
-
-        let chunk3 = scan.next().unwrap().unwrap();
-        assert_eq!(chunk3.row_count(), 3);
-
-        let chunk4 = scan.next().unwrap().unwrap();
-        assert_eq!(chunk4.row_count(), 1);
 
         assert!(scan.next().unwrap().is_none());
     }
 
     #[test]
-    fn test_vector_scan_no_label_filter() {
+    fn test_vector_scan_with_min_similarity() {
         let store = Arc::new(LpgStore::new().unwrap());
+        let n1 = store.create_node(&["Doc"]);
+        let n2 = store.create_node(&["Doc"]);
+        store.set_node_property(n1, "vec", Value::Vector(vec![1.0, 0.0].into()));
+        store.set_node_property(n2, "vec", Value::Vector(vec![0.707, 0.707].into()));
 
-        // Create nodes with different labels
-        let n1 = store.create_node(&["TypeA"]);
-        let n2 = store.create_node(&["TypeB"]);
+        let mut scan = VectorScanOperator::new(
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
+            Some("Doc".to_string()),
+            "vec".to_string(),
+            vec![0.0, 1.0],
+            10,
+            DistanceMetric::Cosine,
+        )
+        .with_min_similarity(0.5);
 
-        store.set_node_property(n1, "vec", Value::Vector(vec![0.1, 0.2].into()));
-        store.set_node_property(n2, "vec", Value::Vector(vec![0.3, 0.4].into()));
+        let chunk = scan.next().unwrap().unwrap();
+        assert_eq!(chunk.row_count(), 1);
+        assert_eq!(chunk.column(0).unwrap().get_node_id(0), Some(n2));
+    }
 
-        // Without label filter - should find both
-        let mut scan = VectorScanOperator::brute_force(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
-            "vec",
+    #[test]
+    fn test_vector_scan_with_chunk_capacity() {
+        let store = Arc::new(LpgStore::new().unwrap());
+        for i in 0..10 {
+            let node = store.create_node(&["Doc"]);
+            store.set_node_property(node, "vec", Value::Vector(vec![i as f32, 0.0].into()));
+        }
+
+        let mut scan = VectorScanOperator::new(
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
+            Some("Doc".to_string()),
+            "vec".to_string(),
             vec![0.0, 0.0],
             10,
             DistanceMetric::Euclidean,
-        );
+        )
+        .with_chunk_capacity(3);
 
-        let chunk = scan.next().unwrap().unwrap();
-        assert_eq!(chunk.row_count(), 2);
+        let chunk1 = scan.next().unwrap().unwrap();
+        assert_eq!(chunk1.row_count(), 3);
+        let chunk2 = scan.next().unwrap().unwrap();
+        assert_eq!(chunk2.row_count(), 3);
+        let chunk3 = scan.next().unwrap().unwrap();
+        assert_eq!(chunk3.row_count(), 3);
+        let chunk4 = scan.next().unwrap().unwrap();
+        assert_eq!(chunk4.row_count(), 1);
+        assert!(scan.next().unwrap().is_none());
     }
 
     #[test]
-    fn test_vector_scan_into_any() {
-        let store = Arc::new(LpgStore::new().unwrap());
-        let op = VectorScanOperator::brute_force(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
-            "embedding",
-            vec![0.1, 0.2],
+    fn test_vector_scan_name() {
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(LpgStore::new().unwrap());
+        let scan = VectorScanOperator::new(
+            store,
+            None,
+            "vec".to_string(),
+            vec![0.1],
             10,
             DistanceMetric::Cosine,
         );
-        let any = Box::new(op).into_any();
-        assert!(any.downcast::<VectorScanOperator>().is_ok());
+        assert_eq!(scan.name(), "VectorScan");
     }
 
-    #[cfg(feature = "vector-index")]
+    // Suppresses the "unused helper" warning on `store_with_vectors` when
+    // tests that use it are selected individually.
     #[test]
-    fn test_vector_scan_with_hnsw_index() {
-        use crate::index::vector::{
-            HnswConfig, HnswIndex, PropertyVectorAccessor, VectorIndexKind,
-        };
-
-        let store = Arc::new(LpgStore::new().unwrap());
-
-        // Create nodes and set vector properties FIRST (so accessor can read them)
-        let n1 = store.create_node(&["Doc"]);
-        let n2 = store.create_node(&["Doc"]);
-        let n3 = store.create_node(&["Doc"]);
-
-        let v1 = vec![0.1f32, 0.2, 0.3];
-        let v2 = vec![0.5, 0.6, 0.7];
-        let v3 = vec![0.9, 0.8, 0.7];
-
-        store.set_node_property(n1, "vec", Value::Vector(v1.clone().into()));
-        store.set_node_property(n2, "vec", Value::Vector(v2.clone().into()));
-        store.set_node_property(n3, "vec", Value::Vector(v3.clone().into()));
-
-        // Create HNSW index and insert using accessor
-        let config = HnswConfig::new(3, DistanceMetric::Euclidean);
-        let hnsw = HnswIndex::new(config);
-        let accessor = PropertyVectorAccessor::new(&*store, "vec");
-
-        hnsw.insert(n1, &v1, &accessor);
-        hnsw.insert(n2, &v2, &accessor);
-        hnsw.insert(n3, &v3, &accessor);
-        let index = Arc::new(VectorIndexKind::Hnsw(hnsw));
-
-        // Search using index
-        let query = vec![0.1f32, 0.2, 0.35];
-        let mut scan = VectorScanOperator::with_index(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
-            Arc::clone(&index),
-            query,
-            2,
-        )
-        .with_property("vec");
-
-        assert_eq!(scan.name(), "VectorScan(HNSW)");
-
-        let chunk = scan.next().unwrap().unwrap();
-        assert_eq!(chunk.row_count(), 2);
-
-        // First result should be n1 (closest)
-        let first_node = chunk.column(0).unwrap().get_node_id(0);
-        assert_eq!(first_node, Some(n1));
+    fn _use_helper() {
+        let _ = store_with_vectors(&[]);
     }
 }

--- a/crates/grafeo-core/src/execution/operators/shortest_path.rs
+++ b/crates/grafeo-core/src/execution/operators/shortest_path.rs
@@ -6,7 +6,7 @@
 use super::{Operator, OperatorResult};
 use crate::execution::chunk::DataChunkBuilder;
 use crate::graph::Direction;
-use crate::graph::GraphStore;
+use crate::graph::GraphStoreSearch;
 use grafeo_common::types::{LogicalType, NodeId, Value};
 use grafeo_common::utils::hash::FxHashMap;
 use std::collections::VecDeque;
@@ -18,7 +18,7 @@ use std::sync::Arc;
 /// computes the shortest path and outputs the path as a value.
 pub struct ShortestPathOperator {
     /// The graph store.
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// Input operator providing source/target node pairs.
     input: Box<dyn Operator>,
     /// Column index of the source node.
@@ -38,7 +38,7 @@ pub struct ShortestPathOperator {
 impl ShortestPathOperator {
     /// Creates a new shortest path operator.
     pub fn new(
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         input: Box<dyn Operator>,
         source_column: usize,
         target_column: usize,
@@ -483,7 +483,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, b)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0, // source column
             1, // target column
@@ -507,7 +507,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, a)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -537,7 +537,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, c)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -563,7 +563,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, b)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -600,7 +600,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, d)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -628,7 +628,7 @@ mod tests {
         // Path with KNOWS filter should only reach b, not c
         let input = Box::new(MockPairOperator::new(vec![(a, c)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -653,7 +653,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, b)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -683,7 +683,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, d)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -718,7 +718,7 @@ mod tests {
         // Test multiple pairs at once
         let input = Box::new(MockPairOperator::new(vec![(a, b), (c, d), (a, d)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -744,7 +744,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, b)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -769,7 +769,7 @@ mod tests {
         let store = Arc::new(LpgStore::new().unwrap());
         let input = Box::new(MockPairOperator::new(vec![]));
         let op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -785,7 +785,7 @@ mod tests {
         let store = Arc::new(LpgStore::new().unwrap());
         let input = Box::new(MockPairOperator::new(vec![]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -808,7 +808,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, b)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -831,7 +831,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, a)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -861,7 +861,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(nodes[0], nodes[9])]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -891,7 +891,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, d)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -914,7 +914,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, b)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -934,7 +934,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, a)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -965,7 +965,7 @@ mod tests {
 
         let input = Box::new(MockPairOperator::new(vec![(a, d)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -992,7 +992,7 @@ mod tests {
         // Only KNOWS edges: a can reach b but not c
         let input = Box::new(MockPairOperator::new(vec![(a, c)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -1020,7 +1020,7 @@ mod tests {
         // Bidirectional BFS should work and find shortest path
         let input = Box::new(MockPairOperator::new(vec![(a, c)]));
         let mut op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,
@@ -1038,7 +1038,7 @@ mod tests {
         let store = Arc::new(LpgStore::new().unwrap());
         let input = Box::new(MockPairOperator::new(vec![]));
         let op = ShortestPathOperator::new(
-            store.clone() as Arc<dyn GraphStore>,
+            store.clone() as Arc<dyn GraphStoreSearch>,
             input,
             0,
             1,

--- a/crates/grafeo-core/src/execution/operators/variable_length_expand.rs
+++ b/crates/grafeo-core/src/execution/operators/variable_length_expand.rs
@@ -3,7 +3,7 @@
 use super::{Operator, OperatorError, OperatorResult};
 use crate::execution::DataChunk;
 use crate::graph::Direction;
-use crate::graph::GraphStore;
+use crate::graph::GraphStoreSearch;
 use grafeo_common::types::{EdgeId, EpochId, LogicalType, NodeId, TransactionId};
 use std::collections::VecDeque;
 use std::rc::Rc;
@@ -31,7 +31,7 @@ pub enum PathMode {
 #[allow(clippy::struct_excessive_bools)]
 pub struct VariableLengthExpandOperator {
     /// The store to traverse.
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// Input operator providing source nodes.
     input: Box<dyn Operator>,
     /// Index of the source node column in input.
@@ -172,7 +172,7 @@ impl PathSegment {
 impl VariableLengthExpandOperator {
     /// Creates a new variable-length expand operator.
     pub fn new(
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         input: Box<dyn Operator>,
         source_column: usize,
         direction: Direction,
@@ -720,13 +720,13 @@ mod tests {
 
         // Create scan for all nodes
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Node",
         ));
 
         // Expand 1-3 hops from all nodes
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -769,13 +769,13 @@ mod tests {
         store.create_edge(b, c, "NEXT");
 
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Node",
         ));
 
         // Expand 2-3 hops only (skip 1 hop)
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -826,11 +826,11 @@ mod tests {
         store.create_edge(c, d, "EDGE");
 
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Node",
         ));
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -870,12 +870,12 @@ mod tests {
         store.create_edge(a, b, "KNOWS");
 
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Node",
         ));
         // Filter for LIKES edges (which don't exist)
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -897,12 +897,12 @@ mod tests {
         store.create_edge(a, b, "EDGE");
 
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Node",
         ));
         // Exactly 1 hop
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -937,11 +937,11 @@ mod tests {
         store.create_edge(b, c, "EDGE");
 
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Node",
         ));
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -969,11 +969,11 @@ mod tests {
         store.create_edge(a, b, "EDGE");
 
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Node",
         ));
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -1003,11 +1003,11 @@ mod tests {
     fn test_variable_length_expand_name() {
         let store = Arc::new(LpgStore::new().unwrap());
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Node",
         ));
         let expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -1022,11 +1022,11 @@ mod tests {
     fn test_variable_length_expand_empty_input() {
         let store = Arc::new(LpgStore::new().unwrap());
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Nonexistent",
         ));
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -1051,11 +1051,11 @@ mod tests {
         }
 
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Node",
         ));
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -1087,11 +1087,11 @@ mod tests {
         store.create_edge(b, a, "EDGE");
 
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Node",
         ));
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -1127,11 +1127,11 @@ mod tests {
         store.create_edge(b, a, "EDGE");
 
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Node",
         ));
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -1160,11 +1160,11 @@ mod tests {
     fn test_variable_length_expand_into_any() {
         let store = Arc::new(LpgStore::new().unwrap());
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Node",
         ));
         let op = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -1342,11 +1342,11 @@ mod tests {
         store.create_edge(gus, alix, "KNOWS");
 
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Person",
         ));
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -1388,11 +1388,11 @@ mod tests {
         store.create_edge(mia, vincent, "KNOWS");
 
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Person",
         ));
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -1435,11 +1435,11 @@ mod tests {
         store.create_edge(gus, vincent, "KNOWS");
 
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Person",
         ));
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,
@@ -1509,11 +1509,11 @@ mod tests {
 
         // Filter with lowercase "knows", should still match "KNOWS"
         let scan = Box::new(ScanOperator::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Person",
         ));
         let mut expand = VariableLengthExpandOperator::new(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             scan,
             0,
             Direction::Outgoing,

--- a/crates/grafeo-core/src/execution/operators/vector_join.rs
+++ b/crates/grafeo-core/src/execution/operators/vector_join.rs
@@ -18,7 +18,7 @@
 
 use super::{Operator, OperatorError, OperatorResult};
 use crate::execution::DataChunk;
-use crate::graph::GraphStore;
+use crate::graph::GraphStoreSearch;
 use crate::index::vector::{DistanceMetric, brute_force_knn};
 use grafeo_common::types::{LogicalType, NodeId, PropertyKey, Value};
 use std::sync::Arc;
@@ -46,7 +46,7 @@ pub struct VectorJoinOperator {
     /// Left input operator providing entities.
     left: Box<dyn Operator>,
     /// The store to search vectors from.
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// The HNSW index for right side (None = brute-force).
     #[cfg(feature = "vector-index")]
     index: Option<Arc<VectorIndexKind>>,
@@ -103,7 +103,7 @@ impl VectorJoinOperator {
     #[must_use]
     pub fn with_static_query(
         left: Box<dyn Operator>,
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         query_vector: Vec<f32>,
         right_property: impl Into<String>,
         k: usize,
@@ -151,7 +151,7 @@ impl VectorJoinOperator {
     #[must_use]
     pub fn entity_to_entity(
         left: Box<dyn Operator>,
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         left_node_column: usize,
         left_property: impl Into<String>,
         right_property: impl Into<String>,
@@ -492,7 +492,7 @@ mod tests {
         let query = vec![1.0, 0.0, 0.0];
         let mut join = VectorJoinOperator::with_static_query(
             left,
-            StdArc::clone(&store) as StdArc<dyn GraphStore>,
+            StdArc::clone(&store) as StdArc<dyn GraphStoreSearch>,
             query,
             "embedding",
             3,
@@ -528,7 +528,7 @@ mod tests {
         // Entity-to-entity join: find targets similar to source
         let mut join = VectorJoinOperator::entity_to_entity(
             left,
-            StdArc::clone(&store) as StdArc<dyn GraphStore>,
+            StdArc::clone(&store) as StdArc<dyn GraphStoreSearch>,
             0, // node column
             "embedding",
             "embedding",
@@ -567,7 +567,7 @@ mod tests {
 
         let mut join = VectorJoinOperator::with_static_query(
             left,
-            StdArc::clone(&store) as StdArc<dyn GraphStore>,
+            StdArc::clone(&store) as StdArc<dyn GraphStoreSearch>,
             query,
             "vec",
             10,
@@ -595,7 +595,7 @@ mod tests {
 
         let join = VectorJoinOperator::with_static_query(
             left,
-            store as StdArc<dyn GraphStore>,
+            store as StdArc<dyn GraphStoreSearch>,
             vec![1.0],
             "embedding",
             5,
@@ -612,7 +612,7 @@ mod tests {
 
         let op = VectorJoinOperator::with_static_query(
             left,
-            store as StdArc<dyn GraphStore>,
+            store as StdArc<dyn GraphStoreSearch>,
             vec![1.0],
             "embedding",
             5,

--- a/crates/grafeo-core/src/execution/parallel/source.rs
+++ b/crates/grafeo-core/src/execution/parallel/source.rs
@@ -613,7 +613,7 @@ impl Source for PartitionedTripleScanSource {
 // Parallel Node Scan Source (LPG)
 // ---------------------------------------------------------------------------
 
-use crate::graph::GraphStore;
+use crate::graph::GraphStoreSearch;
 use grafeo_common::types::NodeId;
 
 /// Parallel source for scanning nodes from the LPG store.
@@ -638,7 +638,7 @@ use grafeo_common::types::NodeId;
 /// ```
 pub struct ParallelNodeScanSource {
     /// The store to scan from.
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// Cached node IDs for the scan.
     node_ids: Arc<Vec<NodeId>>,
     /// Current read position.
@@ -648,7 +648,7 @@ pub struct ParallelNodeScanSource {
 impl ParallelNodeScanSource {
     /// Creates a parallel source for all nodes in the store.
     #[must_use]
-    pub fn new(store: Arc<dyn GraphStore>) -> Self {
+    pub fn new(store: Arc<dyn GraphStoreSearch>) -> Self {
         let node_ids = Arc::new(store.node_ids());
         Self {
             store,
@@ -659,7 +659,7 @@ impl ParallelNodeScanSource {
 
     /// Creates a parallel source for nodes with a specific label.
     #[must_use]
-    pub fn with_label(store: Arc<dyn GraphStore>, label: &str) -> Self {
+    pub fn with_label(store: Arc<dyn GraphStoreSearch>, label: &str) -> Self {
         let node_ids = Arc::new(store.nodes_by_label(label));
         Self {
             store,
@@ -672,7 +672,7 @@ impl ParallelNodeScanSource {
     ///
     /// Useful when node IDs are already available from a previous operation.
     #[must_use]
-    pub fn from_node_ids(store: Arc<dyn GraphStore>, node_ids: Vec<NodeId>) -> Self {
+    pub fn from_node_ids(store: Arc<dyn GraphStoreSearch>, node_ids: Vec<NodeId>) -> Self {
         Self {
             store,
             node_ids: Arc::new(node_ids),
@@ -682,7 +682,7 @@ impl ParallelNodeScanSource {
 
     /// Returns the underlying store reference.
     #[must_use]
-    pub fn store(&self) -> &Arc<dyn GraphStore> {
+    pub fn store(&self) -> &Arc<dyn GraphStoreSearch> {
         &self.store
     }
 }
@@ -977,18 +977,20 @@ mod tests {
         }
 
         // Test scan all nodes
-        let source = ParallelNodeScanSource::new(Arc::clone(&store) as Arc<dyn GraphStore>);
+        let source = ParallelNodeScanSource::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>);
         assert_eq!(source.total_rows(), Some(100));
         assert!(source.is_partitionable());
         assert_eq!(source.num_columns(), 1);
 
         // Test scan by label
-        let source_person =
-            ParallelNodeScanSource::with_label(Arc::clone(&store) as Arc<dyn GraphStore>, "Person");
+        let source_person = ParallelNodeScanSource::with_label(
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
+            "Person",
+        );
         assert_eq!(source_person.total_rows(), Some(100));
 
         let source_employee = ParallelNodeScanSource::with_label(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             "Employee",
         );
         assert_eq!(source_employee.total_rows(), Some(50));
@@ -1003,7 +1005,7 @@ mod tests {
             store.create_node(&[]);
         }
 
-        let source = ParallelNodeScanSource::new(Arc::clone(&store) as Arc<dyn GraphStore>);
+        let source = ParallelNodeScanSource::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>);
 
         // Create partition for rows 20-50
         let morsel = Morsel::new(0, 0, 20, 50);
@@ -1026,7 +1028,7 @@ mod tests {
             store.create_node(&[]);
         }
 
-        let source = ParallelNodeScanSource::new(Arc::clone(&store) as Arc<dyn GraphStore>);
+        let source = ParallelNodeScanSource::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>);
 
         // Generate morsels with size 256
         let morsels = source.generate_morsels(256, 0);

--- a/crates/grafeo-core/src/graph/compact/graph_store_impl.rs
+++ b/crates/grafeo-core/src/graph/compact/graph_store_impl.rs
@@ -15,7 +15,7 @@ use super::id::encode_node_id;
 use crate::graph::Direction;
 use crate::graph::lpg::CompareOp;
 use crate::graph::lpg::{Edge, Node};
-use crate::graph::traits::GraphStore;
+use crate::graph::traits::{GraphStore, GraphStoreSearch};
 use crate::statistics::Statistics;
 
 impl GraphStore for CompactStore {
@@ -470,3 +470,5 @@ impl GraphStore for CompactStore {
         Vec::new()
     }
 }
+
+impl GraphStoreSearch for CompactStore {}

--- a/crates/grafeo-core/src/graph/compact/layered.rs
+++ b/crates/grafeo-core/src/graph/compact/layered.rs
@@ -17,7 +17,9 @@ use parking_lot::RwLock;
 use super::CompactStore;
 use crate::graph::Direction;
 use crate::graph::lpg::{CompareOp, Edge, LpgStore, Node};
-use crate::graph::traits::{GraphStore, GraphStoreMut};
+use crate::graph::traits::{GraphStore, GraphStoreMut, GraphStoreSearch};
+#[cfg(feature = "vector-index")]
+use crate::index::vector::DistanceMetric;
 use crate::statistics::Statistics;
 
 /// A two-layer graph store with a columnar base and mutable overlay.
@@ -677,6 +679,13 @@ impl GraphStore for LayeredStore {
         }
         Vec::new()
     }
+}
+
+impl GraphStoreSearch for LayeredStore {
+    #[cfg(feature = "text-index")]
+    fn has_text_index(&self, label: &str, property: &str) -> bool {
+        self.overlay.has_text_index(label, property)
+    }
 
     #[cfg(feature = "text-index")]
     fn score_text(&self, node_id: NodeId, label: &str, property: &str, query: &str) -> Option<f64> {
@@ -719,23 +728,51 @@ impl GraphStore for LayeredStore {
         results
     }
 
-    #[cfg(feature = "text-index")]
-    fn has_text_index(&self, label: &str, property: &str) -> bool {
-        self.overlay.has_text_index(label, property)
-    }
-
     #[cfg(feature = "vector-index")]
     fn has_vector_index(&self, label: &str, property: &str) -> bool {
         self.overlay.has_vector_index(label, property)
     }
 
     #[cfg(feature = "vector-index")]
-    fn get_vector_index_handle(
+    fn vector_index_metric(&self, label: &str, property: &str) -> Option<DistanceMetric> {
+        self.overlay.vector_index_metric(label, property)
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn vector_search(
         &self,
-        label: &str,
+        label: Option<&str>,
         property: &str,
-    ) -> Option<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        self.overlay.get_vector_index_handle(label, property)
+        query: &[f32],
+        k: usize,
+        metric: DistanceMetric,
+    ) -> Vec<(NodeId, f64)> {
+        // Forward to overlay, then filter nodes deleted from base so stale hits
+        // from the underlying index do not leak through the layered view.
+        let deleted = self.deleted_from_base_nodes.read();
+        let mut results =
+            self.overlay
+                .vector_search(label, property, query, k + deleted.len(), metric);
+        results.retain(|(id, _)| !deleted.contains(id));
+        results.truncate(k);
+        results
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn vector_search_with_threshold(
+        &self,
+        label: Option<&str>,
+        property: &str,
+        query: &[f32],
+        threshold: f64,
+        metric: DistanceMetric,
+    ) -> Vec<(NodeId, f64)> {
+        let deleted = self.deleted_from_base_nodes.read();
+        let mut results = self
+            .overlay
+            .vector_search_with_threshold(label, property, query, threshold, metric);
+        results.retain(|(id, _)| !deleted.contains(id));
+        results
     }
 }
 

--- a/crates/grafeo-core/src/graph/lpg/store/graph_store_impl.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/graph_store_impl.rs
@@ -335,24 +335,27 @@ impl GraphStoreSearch for LpgStore {
         }
 
         // Brute-force fallback: scan nodes, compute distance, take top-k.
+        // Keep `Arc<[f32]>` from `Value::Vector` instead of copying each vector
+        // into an owned `Vec<f32>`: `brute_force_knn` only needs `&[f32]` and
+        // the store already owns the embedding data behind an Arc.
         let node_ids = match label {
             Some(l) => <Self as GraphStore>::nodes_by_label(self, l),
             None => <Self as GraphStore>::node_ids(self),
         };
         let property_key = PropertyKey::new(property);
-        let vectors: Vec<(NodeId, Vec<f32>)> = node_ids
+        let vectors: Vec<(NodeId, Arc<[f32]>)> = node_ids
             .into_iter()
             .filter_map(|id| {
                 <Self as GraphStore>::get_node_property(self, id, &property_key).and_then(|v| {
-                    if let Value::Vector(vec) = v {
-                        Some((id, vec.to_vec()))
+                    if let Value::Vector(arc) = v {
+                        Some((id, arc))
                     } else {
                         None
                     }
                 })
             })
             .collect();
-        let iter = vectors.iter().map(|(id, v)| (*id, v.as_slice()));
+        let iter = vectors.iter().map(|(id, arc)| (*id, arc.as_ref()));
         brute_force_knn(iter, query, k, metric)
             .into_iter()
             .map(|(id, d)| (id, f64::from(d)))

--- a/crates/grafeo-core/src/graph/lpg/store/graph_store_impl.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/graph_store_impl.rs
@@ -8,7 +8,11 @@ use super::LpgStore;
 use crate::graph::Direction;
 use crate::graph::lpg::CompareOp;
 use crate::graph::lpg::{Edge, Node};
-use crate::graph::traits::{GraphStore, GraphStoreMut};
+use crate::graph::traits::{GraphStore, GraphStoreMut, GraphStoreSearch};
+#[cfg(feature = "vector-index")]
+use crate::index::vector::{
+    DistanceMetric, PropertyVectorAccessor, brute_force_knn, compute_distance,
+};
 use crate::statistics::Statistics;
 use arcstr::ArcStr;
 use grafeo_common::types::{EdgeId, EpochId, NodeId, PropertyKey, TransactionId, Value};
@@ -250,6 +254,13 @@ impl GraphStore for LpgStore {
     fn get_edge_history(&self, id: EdgeId) -> Vec<(EpochId, Option<EpochId>, Edge)> {
         LpgStore::get_edge_history(self, id)
     }
+}
+
+impl GraphStoreSearch for LpgStore {
+    #[cfg(feature = "text-index")]
+    fn has_text_index(&self, label: &str, property: &str) -> bool {
+        self.get_text_index(label, property).is_some()
+    }
 
     #[cfg(feature = "text-index")]
     fn score_text(&self, node_id: NodeId, label: &str, property: &str, query: &str) -> Option<f64> {
@@ -289,24 +300,97 @@ impl GraphStore for LpgStore {
         }
     }
 
-    #[cfg(feature = "text-index")]
-    fn has_text_index(&self, label: &str, property: &str) -> bool {
-        self.get_text_index(label, property).is_some()
-    }
-
     #[cfg(feature = "vector-index")]
     fn has_vector_index(&self, label: &str, property: &str) -> bool {
         self.get_vector_index(label, property).is_some()
     }
 
     #[cfg(feature = "vector-index")]
-    fn get_vector_index_handle(
+    fn vector_index_metric(&self, label: &str, property: &str) -> Option<DistanceMetric> {
+        self.get_vector_index(label, property)
+            .map(|idx| idx.config().metric)
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn vector_search(
         &self,
-        label: &str,
+        label: Option<&str>,
         property: &str,
-    ) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
-        let index = self.get_vector_index(label, property)?;
-        Some(index as Arc<dyn std::any::Any + Send + Sync>)
+        query: &[f32],
+        k: usize,
+        metric: DistanceMetric,
+    ) -> Vec<(NodeId, f64)> {
+        // HNSW path: matching index + matching metric.
+        if let Some(label_name) = label
+            && let Some(index) = self.get_vector_index(label_name, property)
+            && index.config().metric == metric
+        {
+            let store_ref: &dyn GraphStore = self;
+            let accessor = PropertyVectorAccessor::new(store_ref, property);
+            return index
+                .search_with_ef(query, k, 64, &accessor)
+                .into_iter()
+                .map(|(id, d)| (id, f64::from(d)))
+                .collect();
+        }
+
+        // Brute-force fallback: scan nodes, compute distance, take top-k.
+        let node_ids = match label {
+            Some(l) => <Self as GraphStore>::nodes_by_label(self, l),
+            None => <Self as GraphStore>::node_ids(self),
+        };
+        let property_key = PropertyKey::new(property);
+        let vectors: Vec<(NodeId, Vec<f32>)> = node_ids
+            .into_iter()
+            .filter_map(|id| {
+                <Self as GraphStore>::get_node_property(self, id, &property_key).and_then(|v| {
+                    if let Value::Vector(vec) = v {
+                        Some((id, vec.to_vec()))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+        let iter = vectors.iter().map(|(id, v)| (*id, v.as_slice()));
+        brute_force_knn(iter, query, k, metric)
+            .into_iter()
+            .map(|(id, d)| (id, f64::from(d)))
+            .collect()
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn vector_search_with_threshold(
+        &self,
+        label: Option<&str>,
+        property: &str,
+        query: &[f32],
+        threshold: f64,
+        metric: DistanceMetric,
+    ) -> Vec<(NodeId, f64)> {
+        // Threshold mode always scans: HNSW has no threshold API. Iterate all
+        // candidates, compute exact distance, keep those under the threshold,
+        // then sort nearest-first.
+        let node_ids = match label {
+            Some(l) => <Self as GraphStore>::nodes_by_label(self, l),
+            None => <Self as GraphStore>::node_ids(self),
+        };
+        let property_key = PropertyKey::new(property);
+        let mut results: Vec<(NodeId, f64)> = node_ids
+            .into_iter()
+            .filter_map(|id| {
+                <Self as GraphStore>::get_node_property(self, id, &property_key).and_then(|v| {
+                    if let Value::Vector(vec) = v {
+                        let d = f64::from(compute_distance(query, &vec, metric));
+                        (d <= threshold).then_some((id, d))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+        results.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        results
     }
 }
 

--- a/crates/grafeo-core/src/graph/mod.rs
+++ b/crates/grafeo-core/src/graph/mod.rs
@@ -22,7 +22,7 @@ pub mod compact;
 pub mod rdf;
 
 pub use projection::{GraphProjection, ProjectionSpec};
-pub use traits::{GraphStore, GraphStoreMut, NullGraphStore};
+pub use traits::{GraphStore, GraphStoreMut, GraphStoreSearch, NullGraphStore};
 
 /// Controls which edges to follow during traversal.
 ///

--- a/crates/grafeo-core/src/graph/projection.rs
+++ b/crates/grafeo-core/src/graph/projection.rs
@@ -27,7 +27,7 @@ use grafeo_common::utils::hash::FxHashMap;
 
 use super::Direction;
 use super::lpg::{CompareOp, Edge, Node};
-use super::traits::GraphStore;
+use super::traits::{GraphStore, GraphStoreSearch};
 use crate::statistics::Statistics;
 
 /// Defines which nodes and edges are included in a projection.
@@ -77,13 +77,13 @@ impl ProjectionSpec {
 /// [`ProjectionSpec`]. Nodes without matching labels and edges without
 /// matching types are invisible.
 pub struct GraphProjection {
-    inner: Arc<dyn GraphStore>,
+    inner: Arc<dyn GraphStoreSearch>,
     spec: ProjectionSpec,
 }
 
 impl GraphProjection {
     /// Creates a new projection over the given store.
-    pub fn new(inner: Arc<dyn GraphStore>, spec: ProjectionSpec) -> Self {
+    pub fn new(inner: Arc<dyn GraphStoreSearch>, spec: ProjectionSpec) -> Self {
         Self { inner, spec }
     }
 
@@ -497,6 +497,8 @@ impl GraphStore for GraphProjection {
         self.inner.all_property_keys()
     }
 }
+
+impl GraphStoreSearch for GraphProjection {}
 
 #[cfg(test)]
 #[cfg(feature = "lpg")]

--- a/crates/grafeo-core/src/graph/rdf/graph_store_adapter.rs
+++ b/crates/grafeo-core/src/graph/rdf/graph_store_adapter.rs
@@ -42,7 +42,7 @@ use super::triple::Triple;
 use crate::graph::Direction;
 use crate::graph::lpg::CompareOp;
 use crate::graph::lpg::{Edge, Node};
-use crate::graph::traits::GraphStore;
+use crate::graph::traits::{GraphStore, GraphStoreSearch};
 use crate::statistics::{EdgeTypeStatistics, LabelStatistics, Statistics};
 use arcstr::ArcStr;
 use grafeo_common::types::{EdgeId, EpochId, NodeId, PropertyKey, TransactionId, Value};
@@ -594,6 +594,8 @@ impl GraphStore for RdfGraphStoreAdapter {
         keys.into_iter().collect()
     }
 }
+
+impl GraphStoreSearch for RdfGraphStoreAdapter {}
 
 /// Converts an RDF literal to a Grafeo [`Value`].
 fn literal_to_value(lit: &Literal) -> Value {

--- a/crates/grafeo-core/src/graph/traits.rs
+++ b/crates/grafeo-core/src/graph/traits.rs
@@ -22,6 +22,8 @@
 use crate::graph::Direction;
 use crate::graph::lpg::CompareOp;
 use crate::graph::lpg::{Edge, Node};
+#[cfg(feature = "vector-index")]
+use crate::index::vector::DistanceMetric;
 use crate::statistics::Statistics;
 use arcstr::ArcStr;
 use grafeo_common::types::{EdgeId, EpochId, NodeId, PropertyKey, TransactionId, Value};
@@ -36,7 +38,7 @@ use std::sync::Arc;
 ///
 /// # Object safety
 ///
-/// This trait is object-safe: you can use `Arc<dyn GraphStore>` for dynamic
+/// This trait is object-safe: you can use `Arc<dyn GraphStoreSearch>` for dynamic
 /// dispatch. Traversal methods return `Vec` instead of `impl Iterator` to
 /// enable this.
 pub trait GraphStore: Send + Sync {
@@ -330,14 +332,38 @@ pub trait GraphStore: Send + Sync {
     fn get_edge_history(&self, _id: EdgeId) -> Vec<(EpochId, Option<EpochId>, Edge)> {
         Vec::new()
     }
+}
 
-    // --- Text search (for per-row BM25 evaluation) ---
+/// Index-backed search capabilities that an LPG store may optionally provide.
+///
+/// Keeps the base [`GraphStore`] scoped to graph-structure operations. Stores
+/// that back text or vector indexes implement these methods with real search
+/// logic; stores that don't (columnar bases, projections, RDF adapters) accept
+/// the no-op defaults and the executor falls through to per-row evaluation.
+///
+/// # Symmetric text and vector APIs
+///
+/// `text_search` and `vector_search` are peer operations returning owned
+/// `Vec<(NodeId, f64)>`. The planner decides strategy based on `has_*_index`
+/// and `vector_index_metric` introspection; the store executes the chosen
+/// plan, falling back to brute-force internally when the request is valid
+/// but no matching index exists.
+pub trait GraphStoreSearch: GraphStore {
+    // --- Text search (BM25) ---
 
-    /// Scores a document against a text query using the store's text index.
+    /// Returns true if a BM25 text index exists for the given label and property.
+    #[cfg(feature = "text-index")]
+    #[must_use]
+    fn has_text_index(&self, _label: &str, _property: &str) -> bool {
+        false
+    }
+
+    /// Scores a single document against a text query for per-row filter evaluation.
     ///
-    /// Returns `None` if no text index exists for the given (label, property) pair.
-    /// Used by filter evaluation for per-row BM25 scoring when planner pushdown
-    /// doesn't fire.
+    /// Returns `None` when no text index exists for the (label, property) pair.
+    /// The planner calls this when pushdown is unavailable, for example when
+    /// the text predicate follows a traversal instead of a bare label scan.
+    #[cfg(feature = "text-index")]
     fn score_text(
         &self,
         _node_id: NodeId,
@@ -348,10 +374,11 @@ pub trait GraphStore: Send + Sync {
         None
     }
 
-    /// Performs a full-text search using the store's text index, returning top-k results.
+    /// Returns the top-`k` documents by BM25 score for a text query.
     ///
-    /// Results are sorted by BM25 score descending.
-    /// Returns empty vec if no text index exists for the (label, property) pair.
+    /// Results are sorted by score descending. Returns an empty vec when no
+    /// text index exists, so the caller can fall back to a slower path.
+    #[cfg(feature = "text-index")]
     fn text_search(
         &self,
         _label: &str,
@@ -362,10 +389,8 @@ pub trait GraphStore: Send + Sync {
         Vec::new()
     }
 
-    /// Performs a full-text search returning all results above a threshold.
-    ///
-    /// Results are sorted by BM25 score descending.
-    /// Returns empty vec if no text index exists.
+    /// Returns every document whose BM25 score meets or exceeds a threshold.
+    #[cfg(feature = "text-index")]
     fn text_search_with_threshold(
         &self,
         _label: &str,
@@ -376,27 +401,57 @@ pub trait GraphStore: Send + Sync {
         Vec::new()
     }
 
-    /// Returns true if a text index exists for the given (label, property).
-    fn has_text_index(&self, _label: &str, _property: &str) -> bool {
-        false
-    }
+    // --- Vector search (HNSW or brute force) ---
 
-    /// Returns true if a vector index exists for the given (label, property).
+    /// Returns true if a vector index exists for the given label and property.
+    #[cfg(feature = "vector-index")]
+    #[must_use]
     fn has_vector_index(&self, _label: &str, _property: &str) -> bool {
         false
     }
 
-    /// Returns a type-erased handle to the vector index for a (label, property) pair.
+    /// Returns the distance metric of the vector index at (label, property), if any.
     ///
-    /// The returned `Arc<dyn Any>` can be downcast to `Arc<VectorIndexKind>` when
-    /// the `vector-index` feature is enabled. This allows the planner to use
-    /// HNSW-accelerated search without leaking feature-gated types into the trait.
-    fn get_vector_index_handle(
-        &self,
-        _label: &str,
-        _property: &str,
-    ) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
+    /// The planner uses this to decide between an HNSW-accelerated plan and a
+    /// brute-force fallback: an index whose metric does not match the query's
+    /// requested metric cannot serve the query directly, so the planner either
+    /// routes to brute force or skips pushdown entirely.
+    #[cfg(feature = "vector-index")]
+    fn vector_index_metric(&self, _label: &str, _property: &str) -> Option<DistanceMetric> {
         None
+    }
+
+    /// Returns the top-`k` nearest neighbors for a vector similarity search.
+    ///
+    /// `label` is optional: `None` searches every node that has the named
+    /// property. The store uses HNSW when an index exists for (label, property)
+    /// whose metric matches `metric`; otherwise it falls back to brute force.
+    ///
+    /// Results are sorted by distance ascending (nearest first). Returns an
+    /// empty vec when neither an index nor any indexable property is found.
+    #[cfg(feature = "vector-index")]
+    fn vector_search(
+        &self,
+        _label: Option<&str>,
+        _property: &str,
+        _query: &[f32],
+        _k: usize,
+        _metric: DistanceMetric,
+    ) -> Vec<(NodeId, f64)> {
+        Vec::new()
+    }
+
+    /// Returns every node whose distance to the query vector is at or below a threshold.
+    #[cfg(feature = "vector-index")]
+    fn vector_search_with_threshold(
+        &self,
+        _label: Option<&str>,
+        _property: &str,
+        _query: &[f32],
+        _threshold: f64,
+        _metric: DistanceMetric,
+    ) -> Vec<(NodeId, f64)> {
+        Vec::new()
     }
 }
 
@@ -405,7 +460,7 @@ pub trait GraphStore: Send + Sync {
 /// Separated from [`GraphStore`] so read-only wrappers (snapshots, read
 /// replicas) can implement only `GraphStore`. Any mutable store is also
 /// readable via the supertrait bound.
-pub trait GraphStoreMut: GraphStore {
+pub trait GraphStoreMut: GraphStoreSearch {
     // --- Node creation ---
 
     /// Creates a new node with the given labels.
@@ -721,6 +776,8 @@ impl GraphStore for NullGraphStore {
         EpochId(0)
     }
 }
+
+impl GraphStoreSearch for NullGraphStore {}
 
 #[cfg(test)]
 mod tests {
@@ -1046,6 +1103,8 @@ mod tests {
         }
     }
 
+    impl GraphStoreSearch for TestMutStore {}
+
     impl GraphStoreMut for TestMutStore {
         fn create_node(&self, labels: &[&str]) -> NodeId {
             let mut inner = self.inner.lock().unwrap();
@@ -1312,7 +1371,7 @@ mod tests {
     #[test]
     fn test_mut_store_object_safe_dyn_dispatch() {
         // Exercise the object-safe contract: GraphStore methods through `dyn`.
-        let store: Arc<dyn GraphStore> = Arc::new(TestMutStore::new());
+        let store: Arc<dyn GraphStoreSearch> = Arc::new(TestMutStore::new());
         assert_eq!(store.node_count(), 0);
         assert_eq!(store.edge_count(), 0);
         assert!(store.node_ids().is_empty());

--- a/crates/grafeo-engine/src/database/cdc_store.rs
+++ b/crates/grafeo-engine/src/database/cdc_store.rs
@@ -17,7 +17,7 @@ use grafeo_common::types::{
 };
 use grafeo_common::utils::hash::FxHashMap;
 use grafeo_core::graph::lpg::{CompareOp, Edge, Node};
-use grafeo_core::graph::{Direction, GraphStore, GraphStoreMut};
+use grafeo_core::graph::{Direction, GraphStore, GraphStoreMut, GraphStoreSearch};
 use grafeo_core::statistics::Statistics;
 use parking_lot::Mutex;
 
@@ -380,6 +380,8 @@ impl GraphStore for CdcGraphStore {
         self.inner.get_edge_history(id)
     }
 }
+
+impl GraphStoreSearch for CdcGraphStore {}
 
 // ---------------------------------------------------------------------------
 // GraphStoreMut: delegate + CDC buffer/record

--- a/crates/grafeo-engine/src/database/mod.rs
+++ b/crates/grafeo-engine/src/database/mod.rs
@@ -1881,7 +1881,7 @@ impl GrafeoDB {
         self.projections.read().keys().cloned().collect()
     }
 
-    /// Returns a named projection as a [`GraphStore`] trait object.
+    /// Returns a named projection as a [`GraphStoreSearch`] trait object.
     #[must_use]
     pub fn projection(&self, name: &str) -> Option<Arc<dyn GraphStoreSearch>> {
         self.projections
@@ -1894,10 +1894,9 @@ impl GrafeoDB {
     ///
     /// Returns a read-only trait object for the active graph store.
     ///
-    /// This provides the [`GraphStore`] interface for code that only needs
-    /// read operations. For write access, use [`graph_store_mut()`](Self::graph_store_mut).
-    ///
-    /// [`GraphStore`]: grafeo_core::graph::GraphStore
+    /// This provides the [`GraphStoreSearch`] interface (graph-structure reads
+    /// plus text/vector search capabilities) for code that only needs read
+    /// operations. For write access, use [`graph_store_mut()`](Self::graph_store_mut).
     #[must_use]
     pub fn graph_store(&self) -> Arc<dyn GraphStoreSearch> {
         if let Some(ref ext_read) = self.external_read_store {

--- a/crates/grafeo-engine/src/database/mod.rs
+++ b/crates/grafeo-engine/src/database/mod.rs
@@ -62,7 +62,7 @@ use grafeo_common::utils::error::{Error, QueryError, QueryErrorKind, Result};
 use grafeo_core::graph::lpg::LpgStore;
 #[cfg(feature = "triple-store")]
 use grafeo_core::graph::rdf::RdfStore;
-use grafeo_core::graph::{GraphStore, GraphStoreMut};
+use grafeo_core::graph::{GraphStoreMut, GraphStoreSearch};
 #[cfg(feature = "grafeo-file")]
 use grafeo_storage::file::GrafeoFileManager;
 #[cfg(all(feature = "wal", feature = "lpg"))]
@@ -156,7 +156,7 @@ pub struct GrafeoDB {
     >,
     /// External read-only graph store (when using with_store() or with_read_store()).
     /// When set, sessions route queries through this store instead of the built-in LpgStore.
-    pub(super) external_read_store: Option<Arc<dyn GraphStore>>,
+    pub(super) external_read_store: Option<Arc<dyn GraphStoreSearch>>,
     /// External writable graph store (when using with_store()).
     /// None for read-only databases created via with_read_store().
     pub(super) external_write_store: Option<Arc<dyn GraphStoreMut>>,
@@ -741,7 +741,7 @@ impl GrafeoDB {
             checkpoint_timer: parking_lot::Mutex::new(None),
             #[cfg(all(feature = "vector-index", feature = "mmap", not(feature = "temporal")))]
             vector_spill_storages: None,
-            external_read_store: Some(Arc::clone(&store) as Arc<dyn GraphStore>),
+            external_read_store: Some(Arc::clone(&store) as Arc<dyn GraphStoreSearch>),
             external_write_store: Some(store),
             #[cfg(feature = "metrics")]
             metrics: Some(Arc::new(crate::metrics::MetricsRegistry::new())),
@@ -764,9 +764,9 @@ impl GrafeoDB {
     /// ```no_run
     /// use std::sync::Arc;
     /// use grafeo_engine::{GrafeoDB, Config};
-    /// use grafeo_core::graph::GraphStore;
+    /// use grafeo_core::graph::GraphStoreSearch;
     ///
-    /// fn example(store: Arc<dyn GraphStore>) -> grafeo_common::utils::error::Result<()> {
+    /// fn example(store: Arc<dyn GraphStoreSearch>) -> grafeo_common::utils::error::Result<()> {
     ///     let db = GrafeoDB::with_read_store(store, Config::in_memory())?;
     ///     let result = db.execute("MATCH (n) RETURN count(n)")?;
     ///     Ok(())
@@ -778,7 +778,7 @@ impl GrafeoDB {
     /// Returns an error if config validation fails.
     ///
     /// [`GraphStore`]: grafeo_core::graph::GraphStore
-    pub fn with_read_store(store: Arc<dyn GraphStore>, config: Config) -> Result<Self> {
+    pub fn with_read_store(store: Arc<dyn GraphStoreSearch>, config: Config) -> Result<Self> {
         config
             .validate()
             .map_err(|e| grafeo_common::utils::error::Error::Internal(e.to_string()))?;
@@ -910,7 +910,7 @@ impl GrafeoDB {
                 .install_named_graphs(old.take_named_graphs());
         }
 
-        self.external_read_store = Some(Arc::clone(&layered) as Arc<dyn GraphStore>);
+        self.external_read_store = Some(Arc::clone(&layered) as Arc<dyn GraphStoreSearch>);
         self.external_write_store = Some(Arc::clone(&layered) as Arc<dyn GraphStoreMut>);
         self.store = Some(Arc::clone(layered.overlay_store()));
         self.layered_store = Some(layered);
@@ -942,7 +942,7 @@ impl GrafeoDB {
             .ok_or_else(|| Error::Internal("recompact() requires a prior compact()".into()))?;
 
         // Read the combined view.
-        let combined: Arc<dyn GraphStore> = Arc::clone(layered) as Arc<dyn GraphStore>;
+        let combined: Arc<dyn GraphStoreSearch> = Arc::clone(layered) as Arc<dyn GraphStoreSearch>;
 
         // Max IDs from the overlay's allocators.
         let max_node_id = layered.overlay_store().next_node_id().saturating_sub(1);
@@ -965,7 +965,7 @@ impl GrafeoDB {
             .overlay_store()
             .install_named_graphs(layered.overlay_store().take_named_graphs());
 
-        self.external_read_store = Some(Arc::clone(&new_layered) as Arc<dyn GraphStore>);
+        self.external_read_store = Some(Arc::clone(&new_layered) as Arc<dyn GraphStoreSearch>);
         self.external_write_store = Some(Arc::clone(&new_layered) as Arc<dyn GraphStoreMut>);
         self.store = Some(Arc::clone(new_layered.overlay_store()));
         self.layered_store = Some(new_layered);
@@ -1572,7 +1572,7 @@ impl GrafeoDB {
             // Override graph_store/graph_store_mut to use the LayeredStore
             // (which merges base + overlay), not just the overlay alone.
             session.override_stores(
-                Arc::clone(&layered_arc) as Arc<dyn GraphStore>,
+                Arc::clone(&layered_arc) as Arc<dyn GraphStoreSearch>,
                 Some(layered_arc as Arc<dyn GraphStoreMut>),
             );
             return session;
@@ -1883,11 +1883,11 @@ impl GrafeoDB {
 
     /// Returns a named projection as a [`GraphStore`] trait object.
     #[must_use]
-    pub fn projection(&self, name: &str) -> Option<Arc<dyn GraphStore>> {
+    pub fn projection(&self, name: &str) -> Option<Arc<dyn GraphStoreSearch>> {
         self.projections
             .read()
             .get(name)
-            .map(|p| Arc::clone(p) as Arc<dyn GraphStore>)
+            .map(|p| Arc::clone(p) as Arc<dyn GraphStoreSearch>)
     }
 
     /// Returns the graph store as a trait object.
@@ -1899,13 +1899,13 @@ impl GrafeoDB {
     ///
     /// [`GraphStore`]: grafeo_core::graph::GraphStore
     #[must_use]
-    pub fn graph_store(&self) -> Arc<dyn GraphStore> {
+    pub fn graph_store(&self) -> Arc<dyn GraphStoreSearch> {
         if let Some(ref ext_read) = self.external_read_store {
             Arc::clone(ext_read)
         } else {
             #[cfg(feature = "lpg")]
             {
-                Arc::clone(self.lpg_store()) as Arc<dyn GraphStore>
+                Arc::clone(self.lpg_store()) as Arc<dyn GraphStoreSearch>
             }
             #[cfg(not(feature = "lpg"))]
             unreachable!("no graph store available: enable the `lpg` feature or use with_store()")
@@ -3677,7 +3677,7 @@ mod tests {
         let store = Arc::new(LpgStore::new().unwrap());
         store.create_node(&["Person"]);
 
-        let read_store = Arc::clone(&store) as Arc<dyn GraphStore>;
+        let read_store = Arc::clone(&store) as Arc<dyn GraphStoreSearch>;
         let db = GrafeoDB::with_read_store(read_store, Config::in_memory()).unwrap();
 
         assert!(db.is_read_only());
@@ -3841,7 +3841,7 @@ mod tests {
         use grafeo_core::graph::lpg::LpgStore;
 
         let store = Arc::new(LpgStore::new().unwrap());
-        let read_store = Arc::clone(&store) as Arc<dyn GraphStore>;
+        let read_store = Arc::clone(&store) as Arc<dyn GraphStoreSearch>;
         let db = GrafeoDB::with_read_store(read_store, Config::in_memory()).unwrap();
 
         // drop_graph with external store (no built-in store) returns false

--- a/crates/grafeo-engine/src/database/wal_store.rs
+++ b/crates/grafeo-engine/src/database/wal_store.rs
@@ -10,7 +10,7 @@ use grafeo_common::grafeo_warn;
 use grafeo_common::types::{EdgeId, EpochId, NodeId, PropertyKey, TransactionId, Value};
 use grafeo_common::utils::hash::FxHashMap;
 use grafeo_core::graph::lpg::{CompareOp, Edge, LpgStore, Node};
-use grafeo_core::graph::{Direction, GraphStore, GraphStoreMut};
+use grafeo_core::graph::{Direction, GraphStore, GraphStoreMut, GraphStoreSearch};
 use grafeo_core::statistics::Statistics;
 use grafeo_storage::wal::{LpgWal, WalRecord};
 
@@ -320,6 +320,8 @@ impl GraphStore for WalGraphStore {
         self.inner.get_edge_history(id)
     }
 }
+
+impl GraphStoreSearch for WalGraphStore {}
 
 // ---------------------------------------------------------------------------
 // GraphStoreMut: delegate + WAL log

--- a/crates/grafeo-engine/src/query/executor/procedure_call.rs
+++ b/crates/grafeo-engine/src/query/executor/procedure_call.rs
@@ -10,7 +10,7 @@ use grafeo_adapters::plugins::{AlgorithmResult, Parameters};
 use grafeo_common::types::{LogicalType, Value};
 use grafeo_core::execution::DataChunk;
 use grafeo_core::execution::operators::{Operator, OperatorError, OperatorResult};
-use grafeo_core::graph::GraphStore;
+use grafeo_core::graph::GraphStoreSearch;
 
 /// Physical operator that executes a graph algorithm and yields its results.
 ///
@@ -18,7 +18,7 @@ use grafeo_core::graph::GraphStore;
 /// the full result is cached. Subsequent calls yield rows in chunks of
 /// `CHUNK_SIZE` until exhausted.
 pub struct ProcedureCallOperator {
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     algorithm: Arc<dyn GraphAlgorithm>,
     params: Parameters,
     /// YIELD items: (original_column, alias). `None` means yield all columns.
@@ -43,7 +43,7 @@ const CHUNK_SIZE: usize = 1024;
 impl ProcedureCallOperator {
     /// Creates a new procedure call operator.
     pub fn new(
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         algorithm: Arc<dyn GraphAlgorithm>,
         params: Parameters,
         yield_columns: Option<Vec<(String, Option<String>)>>,

--- a/crates/grafeo-engine/src/query/executor/stream.rs
+++ b/crates/grafeo-engine/src/query/executor/stream.rs
@@ -200,7 +200,7 @@ impl Iterator for RowIterator<'_> {
 ///
 /// Used by language bindings (Python, Node.js, WASM) where Rust lifetimes
 /// cannot be expressed at the FFI boundary. The operator tree is `'static`
-/// because operators hold `Arc<dyn GraphStore>` rather than borrows; the
+/// because operators hold `Arc<dyn GraphStoreSearch>` rather than borrows; the
 /// stores remain alive as long as the stream does.
 ///
 /// Callers that need to tie the stream's lifetime to something else (e.g.

--- a/crates/grafeo-engine/src/query/executor/user_procedure.rs
+++ b/crates/grafeo-engine/src/query/executor/user_procedure.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use grafeo_common::types::{EpochId, TransactionId, Value};
 use grafeo_core::execution::DataChunk;
 use grafeo_core::execution::operators::{Operator, OperatorError, OperatorResult};
-use grafeo_core::graph::{GraphStore, GraphStoreMut};
+use grafeo_core::graph::{GraphStoreMut, GraphStoreSearch};
 
 use crate::catalog::Catalog;
 use crate::database::QueryResult;
@@ -19,7 +19,7 @@ use crate::transaction::TransactionManager;
 /// Execution context shared across sub-query operators.
 pub struct ProcedureContext {
     /// Store for sub-query execution (read path).
-    pub store: Arc<dyn GraphStore>,
+    pub store: Arc<dyn GraphStoreSearch>,
     /// Writable store for sub-query mutations (None for read-only).
     pub store_mut: Option<Arc<dyn GraphStoreMut>>,
     /// Transaction manager for sub-query coordination.
@@ -50,7 +50,7 @@ pub struct UserProcedureOperator {
     /// YIELD column filter (if specified by caller).
     yield_columns: Option<Vec<String>>,
     /// Store for sub-query execution (read path).
-    store: Arc<dyn GraphStore>,
+    store: Arc<dyn GraphStoreSearch>,
     /// Writable store for sub-query mutations (None for read-only).
     store_mut: Option<Arc<dyn GraphStoreMut>>,
     /// Transaction manager for sub-query.

--- a/crates/grafeo-engine/src/query/planner/lpg/aggregate.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/aggregate.rs
@@ -2,10 +2,11 @@
 
 use super::{
     AggregateOp, Arc, Direction, Error, ExpandDirection, ExpandStep, ExpressionPredicate,
-    FactorizedAggregate, FactorizedAggregateOperator, FilterExpression, FilterOperator, GraphStore,
-    HashAggregateOperator, HashMap, LazyFactorizedChainOperator, LogicalAggregateFunction,
-    LogicalExpression, LogicalType, Operator, PhysicalAggregateExpr, ProjectExpr, ProjectOperator,
-    Result, SimpleAggregateOperator, convert_aggregate_function, expression_to_string,
+    FactorizedAggregate, FactorizedAggregateOperator, FilterExpression, FilterOperator,
+    GraphStoreSearch, HashAggregateOperator, HashMap, LazyFactorizedChainOperator,
+    LogicalAggregateFunction, LogicalExpression, LogicalType, Operator, PhysicalAggregateExpr,
+    ProjectExpr, ProjectOperator, Result, SimpleAggregateOperator, convert_aggregate_function,
+    expression_to_string,
 };
 
 impl super::Planner {
@@ -160,7 +161,7 @@ impl super::Planner {
                     input_op,
                     projections,
                     output_types,
-                    Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                    Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
                 )
                 .with_transaction_context(self.viewing_epoch, self.transaction_id)
                 .with_session_context(self.session_context.clone()),
@@ -299,7 +300,7 @@ impl super::Planner {
             let predicate = ExpressionPredicate::new(
                 filter_expr,
                 having_var_columns,
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             )
             .with_transaction_context(self.viewing_epoch, self.transaction_id)
             .with_session_context(self.session_context.clone());
@@ -396,7 +397,7 @@ impl super::Planner {
 
         // Create the lazy factorized chain operator
         let mut lazy_op = LazyFactorizedChainOperator::new(
-            Arc::clone(&self.store) as Arc<dyn GraphStore>,
+            Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             base_op,
             steps,
         );

--- a/crates/grafeo-engine/src/query/planner/lpg/expand.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/expand.rs
@@ -2,7 +2,7 @@
 
 use super::{
     Arc, Direction, Error, ExecutionPathMode, ExpandDirection, ExpandOp, ExpandOperator,
-    ExpandStep, GraphStore, LazyFactorizedChainOperator, LogicalOperator, Operator, PathMode,
+    ExpandStep, GraphStoreSearch, LazyFactorizedChainOperator, LogicalOperator, Operator, PathMode,
     Result, VariableLengthExpandOperator,
 };
 
@@ -61,7 +61,7 @@ impl super::Planner {
             };
 
             let mut expand_op = VariableLengthExpandOperator::new(
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
                 input_op,
                 source_column,
                 direction,
@@ -84,7 +84,7 @@ impl super::Planner {
         } else {
             // Use simple ExpandOperator for single-hop paths without named paths
             let expand_op = ExpandOperator::new(
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
                 input_op,
                 source_column,
                 direction,
@@ -202,7 +202,7 @@ impl super::Planner {
 
         // Create lazy operator that executes at query time, not planning time
         let mut lazy_op = LazyFactorizedChainOperator::new(
-            Arc::clone(&self.store) as Arc<dyn GraphStore>,
+            Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             base_op,
             steps,
         )

--- a/crates/grafeo-engine/src/query/planner/lpg/filter.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/filter.rs
@@ -2,7 +2,7 @@
 
 use super::{
     ApplyOperator, Arc, BinaryOp, DistinctOperator, EmptyOperator, ExpressionPredicate,
-    FilterExpression, FilterOp, FilterOperator, GraphStore, HashAggregateOperator,
+    FilterExpression, FilterOp, FilterOperator, GraphStoreSearch, HashAggregateOperator,
     HashJoinOperator, HashMap, LogicalExpression, LogicalOperator, NodeListOperator, Operator,
     PhysicalAggregateExpr, PhysicalJoinType, RangeBounds, Result, TransactionId, UnaryOp,
     UnionOperator, Value, convert_binary_op, convert_filter_expression,
@@ -109,7 +109,7 @@ impl super::Planner {
         let predicate = ExpressionPredicate::new(
             filter_expr,
             variable_columns,
-            Arc::clone(&self.store) as Arc<dyn GraphStore>,
+            Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
         )
         .with_transaction_context(self.viewing_epoch, self.transaction_id)
         .with_session_context(self.session_context.clone());
@@ -385,7 +385,7 @@ impl super::Planner {
             let predicate = ExpressionPredicate::new(
                 filter_expr,
                 variable_columns,
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             )
             .with_transaction_context(self.viewing_epoch, self.transaction_id)
             .with_session_context(self.session_context.clone());
@@ -475,7 +475,7 @@ impl super::Planner {
             let predicate = ExpressionPredicate::new(
                 filter_expr,
                 variable_columns,
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             )
             .with_transaction_context(self.viewing_epoch, self.transaction_id)
             .with_session_context(self.session_context.clone());
@@ -549,7 +549,7 @@ impl super::Planner {
             let predicate = ExpressionPredicate::new(
                 filter_expr,
                 variable_columns,
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             )
             .with_transaction_context(self.viewing_epoch, self.transaction_id)
             .with_session_context(self.session_context.clone());
@@ -707,7 +707,7 @@ impl super::Planner {
         let predicate = ExpressionPredicate::new(
             count_filter,
             count_var_columns.clone(),
-            Arc::clone(&self.store) as Arc<dyn GraphStore>,
+            Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
         )
         .with_transaction_context(self.viewing_epoch, self.transaction_id)
         .with_session_context(self.session_context.clone());
@@ -720,7 +720,7 @@ impl super::Planner {
             let remaining_predicate = ExpressionPredicate::new(
                 remaining_expr,
                 count_var_columns,
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             )
             .with_transaction_context(self.viewing_epoch, self.transaction_id)
             .with_session_context(self.session_context.clone());
@@ -933,7 +933,7 @@ impl super::Planner {
             let predicate = ExpressionPredicate::new(
                 filter_expr,
                 variable_columns,
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             )
             .with_transaction_context(self.viewing_epoch, self.transaction_id)
             .with_session_context(self.session_context.clone());
@@ -1431,7 +1431,7 @@ impl super::Planner {
             let predicate = ExpressionPredicate::new(
                 filter_expr,
                 variable_columns,
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             )
             .with_transaction_context(self.viewing_epoch, self.transaction_id)
             .with_session_context(self.session_context.clone());

--- a/crates/grafeo-engine/src/query/planner/lpg/filter_hybrid.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/filter_hybrid.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "text-index")]
 use super::{
-    Arc, BinaryOp, ExpressionPredicate, FilterOp, FilterOperator, GraphStore, HashMap,
+    Arc, BinaryOp, ExpressionPredicate, FilterOp, FilterOperator, GraphStoreSearch, HashMap,
     LogicalExpression, LogicalOperator, Operator, Result, Value,
 };
 
@@ -98,7 +98,7 @@ impl super::Planner {
             let predicate = ExpressionPredicate::new(
                 filter_expr,
                 variable_columns,
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             )
             .with_transaction_context(self.viewing_epoch, self.transaction_id)
             .with_session_context(self.session_context.clone());
@@ -317,7 +317,7 @@ impl super::Planner {
             let predicate = ExpressionPredicate::new(
                 filter_expr,
                 variable_columns,
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             )
             .with_transaction_context(self.viewing_epoch, self.transaction_id)
             .with_session_context(self.session_context.clone());
@@ -336,7 +336,7 @@ impl super::Planner {
             let predicate = ExpressionPredicate::new(
                 filter_expr,
                 variable_columns,
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             )
             .with_transaction_context(self.viewing_epoch, self.transaction_id)
             .with_session_context(self.session_context.clone());
@@ -419,7 +419,7 @@ impl super::Planner {
             let predicate = ExpressionPredicate::new(
                 filter_expr,
                 variable_columns,
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             )
             .with_transaction_context(self.viewing_epoch, self.transaction_id)
             .with_session_context(self.session_context.clone());
@@ -503,7 +503,7 @@ impl super::Planner {
 #[cfg(all(test, feature = "text-index"))]
 mod text_extract_tests {
     use super::super::{
-        Arc, BinaryOp, FilterOp, GraphStore, LogicalExpression, LogicalOperator, NodeScanOp,
+        Arc, BinaryOp, FilterOp, GraphStoreSearch, LogicalExpression, LogicalOperator, NodeScanOp,
         Planner, Value,
     };
     use grafeo_core::graph::lpg::LpgStore;
@@ -512,7 +512,7 @@ mod text_extract_tests {
         let store = Arc::new(LpgStore::new().unwrap());
         let article = store.create_node(&["Article"]);
         store.set_node_property(article, "body", Value::String("rust database".into()));
-        Planner::new(store as Arc<dyn GraphStore>)
+        Planner::new(store as Arc<dyn GraphStoreSearch>)
     }
 
     fn property(var: &str, name: &str) -> LogicalExpression {
@@ -882,7 +882,7 @@ mod text_extract_tests {
 #[cfg(all(test, feature = "vector-index", feature = "text-index"))]
 mod compound_hybrid_tests {
     use super::super::{
-        Arc, BinaryOp, FilterOp, GraphStore, LogicalExpression, LogicalOperator, NodeScanOp,
+        Arc, BinaryOp, FilterOp, GraphStoreSearch, LogicalExpression, LogicalOperator, NodeScanOp,
         Planner, Value,
     };
     use grafeo_core::graph::lpg::LpgStore;
@@ -892,7 +892,7 @@ mod compound_hybrid_tests {
         let a = store.create_node(&["Article"]);
         store.set_node_property(a, "body", Value::String("vincent and jules".into()));
         store.set_node_property(a, "embedding", Value::Vector(vec![0.1f32, 0.9, 0.0].into()));
-        Planner::new(store as Arc<dyn GraphStore>)
+        Planner::new(store as Arc<dyn GraphStoreSearch>)
     }
 
     fn property(var: &str, name: &str) -> LogicalExpression {

--- a/crates/grafeo-engine/src/query/planner/lpg/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/mod.rs
@@ -47,7 +47,7 @@ use grafeo_core::execution::operators::{
     SortDirection, SortKey as PhysicalSortKey, SortOperator, UnionOperator, UnwindOperator,
     VariableLengthExpandOperator,
 };
-use grafeo_core::graph::{Direction, GraphStore, GraphStoreMut};
+use grafeo_core::graph::{Direction, GraphStoreMut, GraphStoreSearch};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -70,7 +70,7 @@ struct RangeBounds<'a> {
 /// Converts a logical plan to a physical operator tree for LPG stores.
 pub struct Planner {
     /// The graph store (read-only operations).
-    pub(super) store: Arc<dyn GraphStore>,
+    pub(super) store: Arc<dyn GraphStoreSearch>,
     /// Writable graph store (None for read-only databases).
     pub(super) write_store: Option<Arc<dyn GraphStoreMut>>,
     /// Transaction manager for MVCC operations.
@@ -121,7 +121,7 @@ impl Planner {
     /// This creates a planner without transaction context, using the current
     /// epoch from the store for visibility.
     #[must_use]
-    pub fn new(store: Arc<dyn GraphStore>) -> Self {
+    pub fn new(store: Arc<dyn GraphStoreSearch>) -> Self {
         let epoch = store.current_epoch();
         Self {
             store,
@@ -148,7 +148,7 @@ impl Planner {
     /// Creates a new planner with transaction context for MVCC-aware planning.
     #[must_use]
     pub fn with_context(
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         write_store: Option<Arc<dyn GraphStoreMut>>,
         transaction_manager: Arc<TransactionManager>,
         transaction_id: Option<TransactionId>,
@@ -715,7 +715,7 @@ impl Planner {
             entity_kind,
             function,
             ha.property.clone(),
-            Arc::clone(&self.store) as Arc<dyn GraphStore>,
+            Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             input_column_count,
         ));
 
@@ -814,7 +814,7 @@ impl Planner {
         scan: &VectorScanOp,
     ) -> Result<(Box<dyn Operator>, Vec<String>)> {
         use grafeo_core::execution::operators::VectorScanOperator;
-        use grafeo_core::index::vector::{DistanceMetric, VectorIndexKind};
+        use grafeo_core::index::vector::DistanceMetric;
 
         // Hybrid shape `VectorScan(input=graph_pattern)` is not supported by
         // the physical VectorScanOperator: it has no input slot and would
@@ -826,11 +826,8 @@ impl Planner {
             ));
         }
 
-        // Resolve the query vector expression to Vec<f32>
         let query_vec = self.resolve_vector_literal(&scan.query_vector)?;
 
-        // Map the user-requested metric (if any). `None` means "use whatever
-        // the index uses"; resolved below when we can look at the index.
         let requested_metric = scan.metric.map(|m| match m {
             VectorMetric::Cosine => DistanceMetric::Cosine,
             VectorMetric::Euclidean => DistanceMetric::Euclidean,
@@ -840,58 +837,29 @@ impl Planner {
 
         let k = scan.k.unwrap_or(usize::MAX);
 
-        // Try the HNSW-accelerated path when an index exists AND the requested
-        // metric matches the index's metric. The index ranks by its own
-        // metric, so using it with a different metric would return the wrong
-        // neighbors (with_metric only rescales threshold comparisons).
-        let (mut operator, metric) = if let Some(ref label) = scan.label {
-            let indexed = self
-                .store
-                .get_vector_index_handle(label, &scan.property)
-                .and_then(|handle| handle.downcast::<VectorIndexKind>().ok())
-                .filter(|index| {
-                    requested_metric.is_none() || requested_metric == Some(index.config().metric)
-                });
-            if let Some(index) = indexed {
-                // When the user didn't specify a metric, adopt the index's
-                // metric so apply_filters interprets the returned distances
-                // correctly (e.g. similarity threshold only applies to cosine).
-                let m = requested_metric.unwrap_or(index.config().metric);
-                let op = VectorScanOperator::with_index(
-                    Arc::clone(&self.store),
-                    index,
-                    query_vec.clone(),
-                    k,
-                )
-                .with_property(&scan.property)
-                .with_label(label)
-                .with_metric(m);
-                (op, m)
-            } else {
-                // Brute-force has no index to borrow from; default to Cosine
-                // when the user didn't pick one.
-                let m = requested_metric.unwrap_or(DistanceMetric::Cosine);
-                let op = VectorScanOperator::brute_force(
-                    Arc::clone(&self.store),
-                    &scan.property,
-                    query_vec.clone(),
-                    k,
-                    m,
-                )
-                .with_label(label);
-                (op, m)
-            }
-        } else {
-            let m = requested_metric.unwrap_or(DistanceMetric::Cosine);
-            let op = VectorScanOperator::brute_force(
-                Arc::clone(&self.store),
-                &scan.property,
-                query_vec,
-                k,
-                m,
-            );
-            (op, m)
-        };
+        // Pick the metric we'll execute under. When the user asked for a
+        // specific one, honor it. Otherwise inherit the index's metric (so a
+        // cosine-built index drives cosine scoring) or default to Cosine for
+        // the unindexed brute-force path.
+        let index_metric = scan
+            .label
+            .as_ref()
+            .and_then(|label| self.store.vector_index_metric(label, &scan.property));
+        let metric = requested_metric
+            .or(index_metric)
+            .unwrap_or(DistanceMetric::Cosine);
+
+        // The store's vector_search routes HNSW when an index exists whose
+        // metric matches `metric`, and brute-force scan otherwise. No handle
+        // downcast; no Arc<dyn Any>.
+        let mut operator = VectorScanOperator::new(
+            Arc::clone(&self.store),
+            scan.label.clone(),
+            scan.property.clone(),
+            query_vec,
+            k,
+            metric,
+        );
 
         if let Some(sim) = scan.min_similarity {
             operator = operator.with_min_similarity(sim);
@@ -1906,7 +1874,7 @@ mod tests {
     // ==================== Mutation Tests ====================
 
     fn create_writable_planner(store: &Arc<LpgStore>) -> Planner {
-        let mut p = Planner::new(Arc::clone(store) as Arc<dyn GraphStore>);
+        let mut p = Planner::new(Arc::clone(store) as Arc<dyn GraphStoreSearch>);
         p.write_store = Some(Arc::clone(store) as Arc<dyn GraphStoreMut>);
         p
     }
@@ -2071,7 +2039,7 @@ mod tests {
     #[test]
     fn test_planner_accessors() {
         let store = create_test_store();
-        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>);
+        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>);
 
         assert!(planner.transaction_id().is_none());
         assert!(planner.transaction_manager().is_none());
@@ -2160,7 +2128,7 @@ mod tests {
     #[test]
     fn test_plan_adaptive_with_expand() {
         let store = create_test_store();
-        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>)
+        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>)
             .with_factorized_execution(false);
 
         // MATCH (a)-[:KNOWS]->(b) RETURN a, b
@@ -2486,7 +2454,7 @@ mod tests {
     #[test]
     fn test_plan_expand_incoming() {
         let store = create_test_store();
-        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>)
+        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>)
             .with_factorized_execution(false);
 
         // MATCH (a)<-[:KNOWS]-(b) RETURN a, b
@@ -2528,7 +2496,7 @@ mod tests {
     #[test]
     fn test_plan_expand_both_directions() {
         let store = create_test_store();
-        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>)
+        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>)
             .with_factorized_execution(false);
 
         // MATCH (a)-[:KNOWS]-(b) RETURN a, b
@@ -2579,7 +2547,7 @@ mod tests {
         let epoch = transaction_manager.current_epoch();
 
         let planner = Planner::with_context(
-            Arc::clone(&store) as Arc<dyn GraphStore>,
+            Arc::clone(&store) as Arc<dyn GraphStoreSearch>,
             Some(Arc::clone(&store) as Arc<dyn GraphStoreMut>),
             Arc::clone(&transaction_manager),
             Some(transaction_id),
@@ -2594,7 +2562,7 @@ mod tests {
     #[test]
     fn test_planner_with_factorized_execution_disabled() {
         let store = create_test_store();
-        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>)
+        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>)
             .with_factorized_execution(false);
 
         // Two consecutive expands - should NOT use factorized execution
@@ -2765,11 +2733,12 @@ mod tests {
     #[test]
     fn test_with_read_only_flag() {
         let store = create_test_store();
-        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>).with_read_only(true);
+        let planner =
+            Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>).with_read_only(true);
         assert!(planner.read_only);
 
         let planner_off =
-            Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>).with_read_only(false);
+            Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>).with_read_only(false);
         assert!(!planner_off.read_only);
     }
 
@@ -2777,7 +2746,7 @@ mod tests {
     fn test_with_catalog() {
         let store = create_test_store();
         let catalog = Arc::new(Catalog::new());
-        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>)
+        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>)
             .with_catalog(Arc::clone(&catalog));
         assert!(planner.catalog.is_some());
     }
@@ -2790,8 +2759,8 @@ mod tests {
             current_graph: Some("main".to_string()),
             ..SessionContext::default()
         };
-        let planner =
-            Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>).with_session_context(context);
+        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>)
+            .with_session_context(context);
         assert_eq!(
             planner.session_context.current_schema.as_deref(),
             Some("public")
@@ -2807,7 +2776,7 @@ mod tests {
     #[test]
     fn test_register_edge_column_named() {
         let store = create_test_store();
-        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>);
+        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>);
         let name = planner.register_edge_column(&Some("r".to_string()));
         assert_eq!(name, "r");
         assert!(planner.edge_columns.borrow().contains("r"));
@@ -2816,7 +2785,7 @@ mod tests {
     #[test]
     fn test_register_edge_column_anonymous_counter_advances() {
         let store = create_test_store();
-        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>);
+        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>);
         let a = planner.register_edge_column(&None);
         let b = planner.register_edge_column(&None);
         assert_eq!(a, "_anon_edge_0");
@@ -3166,7 +3135,7 @@ mod tests {
     #[test]
     fn test_plan_shortest_path_dispatch() {
         let store = full_store();
-        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>);
+        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>);
 
         // SHORTEST PATH (a)-(b)
         let logical = LogicalPlan::new(LogicalOperator::ShortestPath(ShortestPathOp {
@@ -3195,7 +3164,7 @@ mod tests {
     #[test]
     fn test_plan_shortest_path_missing_source_errors() {
         let store = full_store();
-        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>);
+        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>);
         let logical = LogicalPlan::new(LogicalOperator::ShortestPath(ShortestPathOp {
             input: Box::new(scan_person("a")),
             source_var: "missing".to_string(),
@@ -3308,7 +3277,7 @@ mod tests {
         // Three-way join over three expand inputs. Some configurations may
         // error during planning; we just require no panic.
         let store = full_store();
-        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>);
+        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>);
         let ab = LogicalOperator::Expand(ExpandOp {
             from_variable: "a".to_string(),
             to_variable: "b".to_string(),
@@ -3357,7 +3326,7 @@ mod tests {
     fn test_plan_horizontal_aggregate_dispatch() {
         // Variable-length expand produces a list column that the aggregate targets.
         let store = full_store();
-        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStore>);
+        let planner = Planner::new(Arc::clone(&store) as Arc<dyn GraphStoreSearch>);
 
         let path = LogicalOperator::Expand(ExpandOp {
             from_variable: "a".to_string(),

--- a/crates/grafeo-engine/src/query/planner/lpg/project.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/project.rs
@@ -1,10 +1,10 @@
 //! Projection, RETURN, sort, limit, and skip planning.
 
 use super::{
-    Arc, Error, FilterExpression, GraphStore, HashMap, LimitOp, LogicalExpression, LogicalOperator,
-    LogicalType, NullOrder, Operator, PhysicalSortKey, ProjectExpr, ProjectOperator, Result,
-    ReturnOp, SkipOp, SortDirection, SortOp, SortOperator, SortOrder, common, expression_to_string,
-    value_to_logical_type,
+    Arc, Error, FilterExpression, GraphStoreSearch, HashMap, LimitOp, LogicalExpression,
+    LogicalOperator, LogicalType, NullOrder, Operator, PhysicalSortKey, ProjectExpr,
+    ProjectOperator, Result, ReturnOp, SkipOp, SortDirection, SortOp, SortOperator, SortOrder,
+    common, expression_to_string, value_to_logical_type,
 };
 
 impl super::Planner {
@@ -301,7 +301,7 @@ impl super::Planner {
                     input_op,
                     projections,
                     output_types,
-                    Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                    Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
                 )
                 .with_transaction_context(self.viewing_epoch, self.transaction_id)
                 .with_session_context(self.session_context.clone()),
@@ -361,7 +361,7 @@ impl super::Planner {
                         input_op,
                         projections,
                         output_types,
-                        Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                        Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
                     )
                     .with_transaction_context(self.viewing_epoch, self.transaction_id)
                     .with_session_context(self.session_context.clone()),
@@ -480,7 +480,7 @@ impl super::Planner {
                 input_op,
                 projections,
                 output_types,
-                Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
             )
             .with_transaction_context(self.viewing_epoch, self.transaction_id)
             .with_session_context(self.session_context.clone()),
@@ -820,7 +820,7 @@ impl super::Planner {
                     input_op,
                     projections,
                     output_types,
-                    Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                    Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
                 )
                 .with_transaction_context(self.viewing_epoch, self.transaction_id)
                 .with_session_context(self.session_context.clone()),

--- a/crates/grafeo-engine/src/query/planner/lpg/scan.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/scan.rs
@@ -1,8 +1,9 @@
 //! Node scan planning.
 
 use super::{
-    Arc, ExpressionPredicate, FilterExpression, FilterOperator, GraphStore, HashMap, LogicalType,
-    NestedLoopJoinOperator, NodeScanOp, Operator, PhysicalJoinType, Result, ScanOperator, Value,
+    Arc, ExpressionPredicate, FilterExpression, FilterOperator, GraphStoreSearch, HashMap,
+    LogicalType, NestedLoopJoinOperator, NodeScanOp, Operator, PhysicalJoinType, Result,
+    ScanOperator, Value,
 };
 
 impl super::Planner {
@@ -12,9 +13,9 @@ impl super::Planner {
         scan: &NodeScanOp,
     ) -> Result<(Box<dyn Operator>, Vec<String>)> {
         let scan_op = if let Some(label) = &scan.label {
-            ScanOperator::with_label(Arc::clone(&self.store) as Arc<dyn GraphStore>, label)
+            ScanOperator::with_label(Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>, label)
         } else {
-            ScanOperator::new(Arc::clone(&self.store) as Arc<dyn GraphStore>)
+            ScanOperator::new(Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>)
         };
 
         // Apply MVCC context if available
@@ -47,7 +48,7 @@ impl super::Planner {
                     let predicate = ExpressionPredicate::new(
                         filter_expr,
                         variable_columns,
-                        Arc::clone(&self.store) as Arc<dyn GraphStore>,
+                        Arc::clone(&self.store) as Arc<dyn GraphStoreSearch>,
                     )
                     .with_transaction_context(self.viewing_epoch, self.transaction_id);
                     let filtered = Box::new(FilterOperator::new(input_op, Box::new(predicate)));

--- a/crates/grafeo-engine/src/query/planner/rdf/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/rdf/mod.rs
@@ -18,7 +18,7 @@ use grafeo_core::execution::operators::{
     OperatorError, Predicate, ProjectExpr, ProjectOperator, SimpleAggregateOperator,
     SingleRowOperator, SortOperator, UnaryFilterOp,
 };
-use grafeo_core::graph::GraphStore;
+use grafeo_core::graph::GraphStoreSearch;
 use grafeo_core::graph::rdf::{Literal, RdfStore, Term, Triple, TriplePattern};
 
 use crate::query::plan::{
@@ -637,7 +637,7 @@ impl RdfPlanner {
                 input_op,
                 projections,
                 output_types,
-                Arc::new(grafeo_core::graph::NullGraphStore) as Arc<dyn GraphStore>,
+                Arc::new(grafeo_core::graph::NullGraphStore) as Arc<dyn GraphStoreSearch>,
             ));
         }
 
@@ -872,7 +872,7 @@ impl RdfPlanner {
                 input_op,
                 projections,
                 output_types,
-                Arc::new(grafeo_core::graph::NullGraphStore) as Arc<dyn GraphStore>,
+                Arc::new(grafeo_core::graph::NullGraphStore) as Arc<dyn GraphStoreSearch>,
             ));
         }
 

--- a/crates/grafeo-engine/src/query/processor.rs
+++ b/crates/grafeo-engine/src/query/processor.rs
@@ -14,7 +14,7 @@ use grafeo_common::types::{EpochId, TransactionId, Value};
 use grafeo_common::utils::error::{Error, Result};
 #[cfg(feature = "lpg")]
 use grafeo_core::graph::lpg::LpgStore;
-use grafeo_core::graph::{GraphStore, GraphStoreMut};
+use grafeo_core::graph::{GraphStoreMut, GraphStoreSearch};
 
 use crate::catalog::Catalog;
 use crate::database::QueryResult;
@@ -104,7 +104,7 @@ pub struct QueryProcessor {
     #[cfg(feature = "lpg")]
     lpg_store: Arc<LpgStore>,
     /// Graph store trait object for pluggable storage backends (read path).
-    graph_store: Arc<dyn GraphStore>,
+    graph_store: Arc<dyn GraphStoreSearch>,
     /// Writable graph store (None when read-only).
     write_store: Option<Arc<dyn GraphStoreMut>>,
     /// Transaction manager for MVCC operations.
@@ -126,7 +126,7 @@ impl QueryProcessor {
     #[must_use]
     pub fn for_lpg(store: Arc<LpgStore>) -> Self {
         let optimizer = Optimizer::from_store(&store);
-        let graph_store = Arc::clone(&store) as Arc<dyn GraphStore>;
+        let graph_store = Arc::clone(&store) as Arc<dyn GraphStoreSearch>;
         let write_store = Some(Arc::clone(&store) as Arc<dyn GraphStoreMut>);
         Self {
             lpg_store: store,
@@ -149,7 +149,7 @@ impl QueryProcessor {
         transaction_manager: Arc<TransactionManager>,
     ) -> Self {
         let optimizer = Optimizer::from_store(&store);
-        let graph_store = Arc::clone(&store) as Arc<dyn GraphStore>;
+        let graph_store = Arc::clone(&store) as Arc<dyn GraphStoreSearch>;
         let write_store = Some(Arc::clone(&store) as Arc<dyn GraphStoreMut>);
         Self {
             lpg_store: store,
@@ -174,7 +174,7 @@ impl QueryProcessor {
         transaction_manager: Arc<TransactionManager>,
     ) -> Result<Self> {
         let optimizer = Optimizer::from_graph_store(&*store);
-        let read_store = Arc::clone(&store) as Arc<dyn GraphStore>;
+        let read_store = Arc::clone(&store) as Arc<dyn GraphStoreSearch>;
         Ok(Self {
             #[cfg(feature = "lpg")]
             lpg_store: Arc::new(LpgStore::new()?),
@@ -195,7 +195,7 @@ impl QueryProcessor {
     ///
     /// Returns an error if the internal arena allocation fails (out of memory).
     pub fn for_stores_with_transaction(
-        read_store: Arc<dyn GraphStore>,
+        read_store: Arc<dyn GraphStoreSearch>,
         write_store: Option<Arc<dyn GraphStoreMut>>,
         transaction_manager: Arc<TransactionManager>,
     ) -> Result<Self> {
@@ -444,7 +444,7 @@ impl QueryProcessor {
         rdf_store: Arc<grafeo_core::graph::rdf::RdfStore>,
     ) -> Self {
         let optimizer = Optimizer::from_store(&lpg_store);
-        let graph_store = Arc::clone(&lpg_store) as Arc<dyn GraphStore>;
+        let graph_store = Arc::clone(&lpg_store) as Arc<dyn GraphStoreSearch>;
         let write_store = Some(Arc::clone(&lpg_store) as Arc<dyn GraphStoreMut>);
         Self {
             lpg_store,

--- a/crates/grafeo-engine/src/session/mod.rs
+++ b/crates/grafeo-engine/src/session/mod.rs
@@ -28,7 +28,7 @@ use grafeo_core::graph::lpg::LpgStore;
 use grafeo_core::graph::lpg::{Edge, Node};
 #[cfg(feature = "triple-store")]
 use grafeo_core::graph::rdf::RdfStore;
-use grafeo_core::graph::{GraphStore, GraphStoreMut};
+use grafeo_core::graph::{GraphStore, GraphStoreMut, GraphStoreSearch};
 
 use crate::catalog::{Catalog, CatalogConstraintValidator};
 use crate::config::{AdaptiveConfig, GraphModel};
@@ -112,7 +112,7 @@ pub struct Session {
     #[cfg(feature = "lpg")]
     store: Arc<LpgStore>,
     /// Graph store trait object for pluggable storage backends (read path).
-    graph_store: Arc<dyn GraphStore>,
+    graph_store: Arc<dyn GraphStoreSearch>,
     /// Writable graph store (None for read-only databases).
     graph_store_mut: Option<Arc<dyn GraphStoreMut>>,
     /// Schema and metadata catalog shared across sessions.
@@ -241,7 +241,7 @@ impl Session {
     #[cfg(feature = "lpg")]
     #[allow(dead_code)] // Used when lpg enabled without triple-store
     pub(crate) fn with_adaptive(store: Arc<LpgStore>, cfg: SessionConfig) -> Self {
-        let graph_store = Arc::clone(&store) as Arc<dyn GraphStore>;
+        let graph_store = Arc::clone(&store) as Arc<dyn GraphStoreSearch>;
         let graph_store_mut = Some(Arc::clone(&store) as Arc<dyn GraphStoreMut>);
         Self {
             store,
@@ -300,7 +300,7 @@ impl Session {
     #[cfg(all(feature = "compact-store", feature = "lpg"))]
     pub(crate) fn override_stores(
         &mut self,
-        read_store: Arc<dyn GraphStore>,
+        read_store: Arc<dyn GraphStoreSearch>,
         write_store: Option<Arc<dyn GraphStoreMut>>,
     ) {
         self.graph_store = read_store;
@@ -323,7 +323,7 @@ impl Session {
             Arc::clone(&wal),
             Arc::clone(&wal_graph_context),
         ));
-        self.graph_store = Arc::clone(&wal_store) as Arc<dyn GraphStore>;
+        self.graph_store = Arc::clone(&wal_store) as Arc<dyn GraphStoreSearch>;
         self.graph_store_mut = Some(wal_store as Arc<dyn GraphStoreMut>);
         self.wal = Some(wal);
         self.wal_graph_context = Some(wal_graph_context);
@@ -365,7 +365,7 @@ impl Session {
     ///
     /// Returns an error if the internal arena allocation fails (out of memory).
     pub(crate) fn with_external_store(
-        read_store: Arc<dyn GraphStore>,
+        read_store: Arc<dyn GraphStoreSearch>,
         write_store: Option<Arc<dyn GraphStoreMut>>,
         cfg: SessionConfig,
     ) -> Result<Self> {
@@ -510,7 +510,7 @@ impl Session {
     /// Otherwise looks up the named graph in the root store and wraps it
     /// in a [`WalGraphStore`] so mutations are WAL-logged with the correct
     /// graph context.
-    fn active_store(&self) -> Arc<dyn GraphStore> {
+    fn active_store(&self) -> Arc<dyn GraphStoreSearch> {
         let key = self.active_graph_storage_key();
         match key {
             None => Arc::clone(&self.graph_store),
@@ -524,9 +524,9 @@ impl Session {
                             Arc::clone(wal),
                             name.clone(),
                             Arc::clone(ctx),
-                        )) as Arc<dyn GraphStore>;
+                        )) as Arc<dyn GraphStoreSearch>;
                     }
-                    named_store as Arc<dyn GraphStore>
+                    named_store as Arc<dyn GraphStoreSearch>
                 }
                 None => Arc::clone(&self.graph_store),
             },
@@ -4649,7 +4649,7 @@ impl Session {
     /// `self.active_store()` for graph-aware execution).
     fn create_planner_for_store(
         &self,
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         viewing_epoch: EpochId,
         transaction_id: Option<TransactionId>,
     ) -> crate::query::Planner {
@@ -4658,7 +4658,7 @@ impl Session {
 
     fn create_planner_for_store_with_read_only(
         &self,
-        store: Arc<dyn GraphStore>,
+        store: Arc<dyn GraphStoreSearch>,
         viewing_epoch: EpochId,
         transaction_id: Option<TransactionId>,
         read_only: bool,

--- a/crates/grafeo-engine/src/session/rdf.rs
+++ b/crates/grafeo-engine/src/session/rdf.rs
@@ -16,7 +16,7 @@ use grafeo_core::graph::lpg::LpgStore;
 #[cfg(feature = "lpg")]
 use grafeo_core::graph::rdf::RdfStore;
 #[cfg(feature = "lpg")]
-use grafeo_core::graph::{GraphStore, GraphStoreMut};
+use grafeo_core::graph::{GraphStoreMut, GraphStoreSearch};
 
 use crate::database::QueryResult;
 
@@ -32,7 +32,7 @@ impl Session {
         rdf_store: Arc<RdfStore>,
         cfg: SessionConfig,
     ) -> Self {
-        let graph_store = Arc::clone(&store) as Arc<dyn GraphStore>;
+        let graph_store = Arc::clone(&store) as Arc<dyn GraphStoreSearch>;
         let graph_store_mut = Some(Arc::clone(&store) as Arc<dyn GraphStoreMut>);
         Self {
             store,

--- a/crates/grafeo-engine/tests/compact_store_integration.rs
+++ b/crates/grafeo-engine/tests/compact_store_integration.rs
@@ -11,7 +11,7 @@
 use std::sync::Arc;
 
 use grafeo_core::graph::compact::CompactStoreBuilder;
-use grafeo_core::graph::traits::GraphStore;
+use grafeo_core::graph::traits::GraphStoreSearch;
 use grafeo_engine::{Config, GrafeoDB};
 
 /// Build a CompactStore with test data and wrap it in GrafeoDB::with_store().
@@ -38,8 +38,11 @@ fn build_test_db() -> GrafeoDB {
         .build()
         .expect("CompactStore build failed");
 
-    GrafeoDB::with_read_store(Arc::new(store) as Arc<dyn GraphStore>, Config::default())
-        .expect("GrafeoDB::with_read_store failed")
+    GrafeoDB::with_read_store(
+        Arc::new(store) as Arc<dyn GraphStoreSearch>,
+        Config::default(),
+    )
+    .expect("GrafeoDB::with_read_store failed")
 }
 
 // ── Basic scan queries ──────────────────────────────────────────

--- a/crates/grafeo-engine/tests/post_compact_index.rs
+++ b/crates/grafeo-engine/tests/post_compact_index.rs
@@ -279,7 +279,7 @@ fn layered_store_has_vector_index_forwards_to_overlay() {
     // Now LayeredStore should forward to overlay and report true
     let gs = db.graph_store();
     assert!(gs.has_vector_index("Doc", "embedding"));
-    assert!(gs.get_vector_index_handle("Doc", "embedding").is_some());
+    assert!(gs.vector_index_metric("Doc", "embedding").is_some());
 }
 
 #[test]


### PR DESCRIPTION
## What does this PR do?

refactor of the unified hybrid search

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the graph store API and unified hybrid search. Introduced `GraphStoreSearch` for text/vector search and routed all search to the store (HNSW when indexed, brute force otherwise).

- **Refactors**
  - Added `GraphStoreSearch` and implemented it across stores (`LpgStore`, `CompactStore`, `LayeredStore`, `GraphProjection`, RDF adapter, WAL, CDC).
  - Replaced `Arc<dyn GraphStore>` with `Arc<dyn GraphStoreSearch>` across operators, planners, sessions, DB, and tests (including parallel sources, expand, shortest path, scans, filters, projections).
  - Simplified `VectorScanOperator` to delegate to `vector_search`; public re-export gated via `vector-index`. Cleaned up index-specific code and docs.
  - Centralized index checks and metrics through the store (e.g., `vector_index_metric`); updated tests accordingly.

- **Migration**
  - Custom backends must implement `GraphStoreSearch` (`has_text_index`, `score_text`, `has_vector_index`, `vector_index_metric`, `vector_search`).
  - Update call sites to use `Arc<dyn GraphStoreSearch>` for planning and execution.
  - Enable features `text-index` and/or `vector-index` to compile respective operators.

<sup>Written for commit d172812a84572a67d1751740cd9029e58e3b8567. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

