### PR TITLE
fix(planner): bound unbounded VectorScan k to label node count

### DIFF
--- a/crates/grafeo-engine/src/query/planner/lpg/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/mod.rs
@@ -835,7 +835,16 @@ impl Planner {
             VectorMetric::Manhattan => DistanceMetric::Manhattan,
         });
 
-        let k = scan.k.unwrap_or(usize::MAX);
+        // Top-k mode uses HNSW when available; threshold/unbounded mode
+        // bounds k to the label's node count so we don't feed usize::MAX
+        // into HNSW (which degrades to full traversal and risks overflow
+        // in quantized rescore paths even with saturating_mul).
+        let k = scan.k.unwrap_or_else(|| {
+            scan.label
+                .as_ref()
+                .map(|l| self.store.nodes_by_label(l).len())
+                .unwrap_or(self.store.node_count())
+        });
 
         // Pick the metric we'll execute under. When the user asked for a
         // specific one, honor it. Otherwise inherit the index's metric (so a


### PR DESCRIPTION
## Summary

When `VectorScanOp.k` is `None` (threshold or unbounded mode), the planner passed `usize::MAX` to the store's `vector_search`. The `saturating_mul` fix in quantized HNSW (already merged in 0.5.40) prevents overflow panics, but feeding a huge k into HNSW still degrades to a full graph traversal — slower than brute-force.

This was part of PR #286's code review fixes that got lost in the 0.5.40 refactor.

## What changed

The planner now resolves unbounded k to the label's actual node count:

```rust
let k = scan.k.unwrap_or_else(|| {
    scan.label
        .as_ref()
        .map(|l| self.store.nodes_by_label(l).len())
        .unwrap_or(self.store.node_ids().len())
});
```

This gives correct "return everything" semantics without sentinel values. The store naturally picks the efficient execution path since k ≤ node_count keeps HNSW's candidate heap bounded by real data size.

## Test plan

- [x] Full existing test suite passes (1551+ tests, zero regressions)
- [x] `cargo check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds unbounded vector scan k to the label’s node count (or total node count) to avoid HNSW full-graph traversal and keep queries fast. Restores correct “return everything” behavior without using `usize::MAX`.

- **Bug Fixes**
  - When `scan.k` is `None`, set `k` to the label’s node count or `store.node_count()`, so HNSW uses a bounded heap and the store picks the efficient path.

<sup>Written for commit 2da7a84642f97aa6f945f66da93231083a569e3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

