### PR TITLE
fix(cypher): aggregate substitution inside CASE WHEN expressions

### DIFF
--- a/crates/grafeo-engine/src/query/translators/cypher.rs
+++ b/crates/grafeo-engine/src/query/translators/cypher.rs
@@ -1468,13 +1468,14 @@ impl CypherTranslator {
             } else if contains_aggregate(&item.expression) {
                 // Wrapped aggregate (e.g. `count(n) > 0 AS exists`)
                 needs_post_return = true;
-                let synthetic_alias = format!("_agg_{agg_counter}");
-                agg_counter += 1;
 
-                // Extract the innermost aggregate and build a substitute expression
-                let (agg_expr, substitute) =
-                    self.extract_wrapped_aggregate(&item.expression, &synthetic_alias)?;
-                aggregates.push(agg_expr);
+                // Extract all aggregates and build a substitute expression
+                // with variable references replacing each aggregate.
+                let substitute = self.extract_wrapped_aggregates(
+                    &item.expression,
+                    &mut agg_counter,
+                    &mut aggregates,
+                )?;
                 post_return_items.push(ReturnItem {
                     expression: substitute,
                     alias: item.alias.clone(),
@@ -1501,140 +1502,120 @@ impl CypherTranslator {
         }
     }
 
-    /// Extracts an aggregate from inside a wrapping expression and returns
-    /// both the aggregate and a substitute expression that references the
-    /// aggregate result by `synthetic_alias`.
+    /// Extracts all aggregates from inside a wrapping expression, assigning
+    /// each a synthetic alias (`_agg_{counter}`), and returns the expression
+    /// with every aggregate replaced by a variable reference to its alias.
     ///
-    /// For `count(n) > 0`, returns:
-    /// - aggregate: `count(n)` with alias `synthetic_alias`
-    /// - substitute: `Variable(synthetic_alias) > Literal(0)`
-    fn extract_wrapped_aggregate(
+    /// For `count(n) > 0`:
+    /// - pushes `count(n)` with alias `_agg_0` into `aggregates_out`
+    /// - returns `Variable("_agg_0") > Literal(0)`
+    ///
+    /// For `sum(x) / count(x)`:
+    /// - pushes `sum(x)` as `_agg_0` and `count(x)` as `_agg_1`
+    /// - returns `Variable("_agg_0") / Variable("_agg_1")`
+    fn extract_wrapped_aggregates(
         &self,
         expr: &ast::Expression,
-        synthetic_alias: &str,
-    ) -> Result<(AggregateExpr, LogicalExpression)> {
+        agg_counter: &mut u32,
+        aggregates_out: &mut Vec<AggregateExpr>,
+    ) -> Result<LogicalExpression> {
         match expr {
             ast::Expression::FunctionCall { name, args, .. } => {
                 // Check if the function itself is an aggregate
-                if let Some(agg) =
-                    self.try_extract_aggregate(expr, &Some(synthetic_alias.to_string()))?
-                {
-                    let substitute = LogicalExpression::Variable(synthetic_alias.to_string());
-                    return Ok((agg, substitute));
+                let alias = format!("_agg_{agg_counter}");
+                if let Some(agg) = self.try_extract_aggregate(expr, &Some(alias.clone()))? {
+                    *agg_counter += 1;
+                    aggregates_out.push(agg);
+                    return Ok(LogicalExpression::Variable(alias));
                 }
-                // Non-aggregate function wrapping an aggregate argument,
-                // e.g. size(collect(DISTINCT n.v)). Extract the inner aggregate
-                // and replace the argument with a variable reference.
-                for (i, arg) in args.iter().enumerate() {
+                // Non-aggregate function wrapping aggregate arguments,
+                // e.g. size(collect(DISTINCT n.v)). Recurse into each argument.
+                let mut translated_args = Vec::with_capacity(args.len());
+                for arg in args {
                     if contains_aggregate(arg) {
-                        let (agg, inner_sub) =
-                            self.extract_wrapped_aggregate(arg, synthetic_alias)?;
-                        // Rebuild the outer function call with the substituted argument
-                        let mut translated_args: Vec<LogicalExpression> = args
-                            .iter()
-                            .enumerate()
-                            .map(|(j, a)| {
-                                if j == i {
-                                    Ok(inner_sub.clone())
-                                } else {
-                                    self.translate_expression(a)
-                                }
-                            })
-                            .collect::<Result<_>>()?;
-                        let _ = &mut translated_args; // suppress unused_mut if needed
-                        let substitute = LogicalExpression::FunctionCall {
-                            name: name.clone(),
-                            args: translated_args,
-                            distinct: false,
-                        };
-                        return Ok((agg, substitute));
+                        translated_args.push(self.extract_wrapped_aggregates(
+                            arg,
+                            agg_counter,
+                            aggregates_out,
+                        )?);
+                    } else {
+                        translated_args.push(self.translate_expression(arg)?);
                     }
                 }
-                Err(Error::Query(QueryError::new(
-                    QueryErrorKind::Semantic,
-                    "contains_aggregate was true but no aggregate found in function arguments",
-                )))
+                Ok(LogicalExpression::FunctionCall {
+                    name: name.clone(),
+                    args: translated_args,
+                    distinct: false,
+                })
             }
             ast::Expression::Binary { left, op, right } => {
                 let binary_op = self.translate_binary_op(*op)?;
-                if contains_aggregate(left) {
-                    let (agg, left_sub) = self.extract_wrapped_aggregate(left, synthetic_alias)?;
-                    let right_expr = self.translate_expression(right)?;
-                    Ok((
-                        agg,
-                        LogicalExpression::Binary {
-                            left: Box::new(left_sub),
-                            op: binary_op,
-                            right: Box::new(right_expr),
-                        },
-                    ))
+                let left_sub = if contains_aggregate(left) {
+                    self.extract_wrapped_aggregates(left, agg_counter, aggregates_out)?
                 } else {
-                    let (agg, right_sub) =
-                        self.extract_wrapped_aggregate(right, synthetic_alias)?;
-                    let left_expr = self.translate_expression(left)?;
-                    Ok((
-                        agg,
-                        LogicalExpression::Binary {
-                            left: Box::new(left_expr),
-                            op: binary_op,
-                            right: Box::new(right_sub),
-                        },
-                    ))
-                }
+                    self.translate_expression(left)?
+                };
+                let right_sub = if contains_aggregate(right) {
+                    self.extract_wrapped_aggregates(right, agg_counter, aggregates_out)?
+                } else {
+                    self.translate_expression(right)?
+                };
+                Ok(LogicalExpression::Binary {
+                    left: Box::new(left_sub),
+                    op: binary_op,
+                    right: Box::new(right_sub),
+                })
             }
             ast::Expression::Unary { op, operand } => {
-                let (agg, sub) = self.extract_wrapped_aggregate(operand, synthetic_alias)?;
+                let sub = self.extract_wrapped_aggregates(operand, agg_counter, aggregates_out)?;
                 // Unary positive is identity: just return the operand
                 if *op == ast::UnaryOp::Pos {
-                    return Ok((agg, sub));
+                    return Ok(sub);
                 }
                 let unary_op = self.translate_unary_op(*op)?;
-                Ok((
-                    agg,
-                    LogicalExpression::Unary {
-                        op: unary_op,
-                        operand: Box::new(sub),
-                    },
-                ))
+                Ok(LogicalExpression::Unary {
+                    op: unary_op,
+                    operand: Box::new(sub),
+                })
             }
             ast::Expression::Case {
                 input,
                 whens,
                 else_clause,
             } => {
-                // Find the first aggregate inside the CASE branches and extract it.
-                // The aggregate is replaced by a variable reference; the rest of
-                // the CASE is translated normally.
+                let operand = match input {
+                    Some(inp) if contains_aggregate(inp) => Some(Box::new(
+                        self.extract_wrapped_aggregates(inp, agg_counter, aggregates_out)?,
+                    )),
+                    Some(inp) => Some(Box::new(self.translate_expression(inp)?)),
+                    None => None,
+                };
+                let mut when_clauses = Vec::with_capacity(whens.len());
                 for (cond, then) in whens {
-                    if contains_aggregate(cond) {
-                        let (agg, _) = self.extract_wrapped_aggregate(cond, synthetic_alias)?;
-                        let full_case = self.translate_expression(expr)?;
-                        return Ok((agg, full_case));
-                    }
-                    if contains_aggregate(then) {
-                        let (agg, _) = self.extract_wrapped_aggregate(then, synthetic_alias)?;
-                        let full_case = self.translate_expression(expr)?;
-                        return Ok((agg, full_case));
-                    }
+                    let cond_expr = if contains_aggregate(cond) {
+                        self.extract_wrapped_aggregates(cond, agg_counter, aggregates_out)?
+                    } else {
+                        self.translate_expression(cond)?
+                    };
+                    let then_expr = if contains_aggregate(then) {
+                        self.extract_wrapped_aggregates(then, agg_counter, aggregates_out)?
+                    } else {
+                        self.translate_expression(then)?
+                    };
+                    when_clauses.push((cond_expr, then_expr));
                 }
-                if let Some(el) = else_clause
-                    && contains_aggregate(el)
-                {
-                    let (agg, _) = self.extract_wrapped_aggregate(el, synthetic_alias)?;
-                    let full_case = self.translate_expression(expr)?;
-                    return Ok((agg, full_case));
-                }
-                if let Some(inp) = input
-                    && contains_aggregate(inp)
-                {
-                    let (agg, _) = self.extract_wrapped_aggregate(inp, synthetic_alias)?;
-                    let full_case = self.translate_expression(expr)?;
-                    return Ok((agg, full_case));
-                }
-                Err(Error::Query(QueryError::new(
-                    QueryErrorKind::Semantic,
-                    "Unsupported expression wrapping an aggregate",
-                )))
+                let else_expr = match else_clause {
+                    Some(el) if contains_aggregate(el) => Some(Box::new(
+                        self.extract_wrapped_aggregates(el, agg_counter, aggregates_out)?,
+                    )),
+                    Some(el) => Some(Box::new(self.translate_expression(el)?)),
+                    None => None,
+                };
+                Ok(LogicalExpression::Case {
+                    operand,
+                    when_clauses,
+                    else_clause: else_expr,
+                })
             }
             _ => Err(Error::Query(QueryError::new(
                 QueryErrorKind::Semantic,

--- a/crates/grafeo-engine/tests/coverage_aggregates.rs
+++ b/crates/grafeo-engine/tests/coverage_aggregates.rs
@@ -654,6 +654,66 @@ fn test_case_aggregate_in_then_branch() {
 }
 
 // ===========================================================================
+// T3b: Cypher-specific CASE + aggregate (exercises extract_wrapped_aggregates
+// CASE/Binary branches via the Cypher translator)
+// ===========================================================================
+
+/// Aggregate in WHEN condition — result depends on actual aggregate value.
+/// Before the fix, sum() was not substituted and evaluated to null, so
+/// null > 0 → null → ELSE taken incorrectly.
+#[cfg(feature = "cypher")]
+#[test]
+fn test_cypher_case_when_aggregate_condition_true() {
+    let db = stats_graph();
+    let s = db.session();
+    // sum(d.score) = 150, 150 > 0 is true → 'positive'
+    let r = s
+        .execute_cypher(
+            "MATCH (d:Data) \
+             RETURN CASE WHEN sum(d.score) > 0 THEN 'positive' ELSE 'zero' END AS label",
+        )
+        .unwrap();
+    assert_eq!(r.rows().len(), 1);
+    assert_eq!(r.rows()[0][0], Value::String("positive".into()));
+}
+
+/// Aggregate value in THEN branch — THEN must evaluate to the aggregate, not null.
+#[cfg(feature = "cypher")]
+#[test]
+fn test_cypher_case_then_aggregate_value() {
+    let db = stats_graph();
+    let s = db.session();
+    // CASE WHEN true THEN sum(d.score) ELSE -1 END → 150
+    let r = s
+        .execute_cypher(
+            "MATCH (d:Data) \
+             RETURN CASE WHEN true THEN sum(d.score) ELSE -1 END AS total",
+        )
+        .unwrap();
+    assert_eq!(r.rows().len(), 1);
+    assert_eq!(r.rows()[0][0], Value::Int64(150));
+}
+
+/// Multiple aggregates in ELSE branch (sum/count division).
+/// Before the fix, the Binary handler only extracted one aggregate from
+/// a two-aggregate expression, and the CASE handler discarded the substitute.
+#[cfg(feature = "cypher")]
+#[test]
+fn test_cypher_case_else_aggregate_division() {
+    let db = stats_graph();
+    let s = db.session();
+    // ELSE sum(d.score) / count(d) = 150 / 5 = 30
+    let r = s
+        .execute_cypher(
+            "MATCH (d:Data) \
+             RETURN CASE WHEN false THEN -1 ELSE sum(d.score) / count(d) END AS avg_score",
+        )
+        .unwrap();
+    assert_eq!(r.rows().len(), 1);
+    assert_eq!(r.rows()[0][0], Value::Int64(30));
+}
+
+// ===========================================================================
 // T4: Non-aggregate function wrapping an aggregate argument
 // Exercises: extract_wrapped_aggregates FunctionCall non-aggregate branch
 // ===========================================================================


### PR DESCRIPTION
## Summary

The Cypher translator's `extract_wrapped_aggregate` had two bugs that caused aggregates inside CASE expressions to evaluate to **null** instead of their correct value:

1. **CASE branch discarded the substitute**: After extracting an aggregate from a CASE branch, the method discarded the substituted expression (`let (agg, _) = …`) and re-translated the original AST. This left raw `FunctionCall("sum", …)` nodes in the post-return expression that evaluate to null at execution time — aggregate function names are not recognized as scalar functions.

2. **Binary handler only extracted one aggregate**: For `sum(x) / count(x)`, only the left operand's aggregate was extracted; the right was translated as a raw function call (also evaluating to null).

The GQL translator already had the correct implementation. This PR ports the same approach: replace `extract_wrapped_aggregate` (single-aggregate, lossy) with `extract_wrapped_aggregates` (multi-aggregate, recursive rebuild).

## Replication

Any Cypher query (via `execute_cypher`) with an aggregate inside a CASE expression:

```cypher
-- Expected: 'positive' (sum = 150, 150 > 0 is true)
-- Actual before fix: 'zero' (sum is null, null > 0 is null → ELSE)
MATCH (d:Data)
RETURN CASE WHEN sum(d.score) > 0 THEN 'positive' ELSE 'zero' END AS label

-- Expected: 150
-- Actual before fix: null
MATCH (d:Data)
RETURN CASE WHEN true THEN sum(d.score) ELSE -1 END AS total

-- Expected: 30  (150 / 5)
-- Actual before fix: null  (both sum and count lost)
MATCH (d:Data)
RETURN CASE WHEN false THEN -1 ELSE sum(d.score) / count(d) END AS avg_score
```

**Note:** `session.execute()` routes through the GQL translator (which is correct), so this only manifests via the Cypher-specific path (`execute_cypher`). The existing CASE aggregate tests in `coverage_aggregates.rs` used `execute()` (GQL) and were not affected.

## Root cause

In `cypher.rs:extract_wrapped_aggregate`, the CASE arm:

```rust
// BEFORE (buggy):
let (agg, _) = self.extract_wrapped_aggregate(cond, synthetic_alias)?;
//         ^ substitute discarded
let full_case = self.translate_expression(expr)?;
//              ^ re-translates original, aggregate becomes raw FunctionCall
return Ok((agg, full_case));
```

The fix rebuilds the CASE properly with the substitute in place:

```rust
// AFTER:
let cond_expr = if contains_aggregate(cond) {
    self.extract_wrapped_aggregates(cond, agg_counter, aggregates_out)?
} else {
    self.translate_expression(cond)?
};
// … same for then, else, input …
Ok(LogicalExpression::Case { operand, when_clauses, else_clause })
```

## Test plan

- [x] `test_cypher_case_when_aggregate_condition_true` — aggregate in WHEN condition, result depends on actual value
- [x] `test_cypher_case_then_aggregate_value` — aggregate in THEN branch returns actual value
- [x] `test_cypher_case_else_aggregate_division` — multiple aggregates (`sum/count`) in ELSE branch
- [x] All 57 existing aggregate tests pass (no regressions)
- [x] All 94 expression/projection tests pass
- [x] All 61 Cypher translator unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes aggregates inside CASE WHEN in the Cypher translator so results are correct instead of null. Switches to recursive multi-aggregate substitution with per-aggregate aliases, matching the GQL translator.

- **Bug Fixes**
  - Replaced `extract_wrapped_aggregate` with `extract_wrapped_aggregates`; recursively rebuilds CASE (including input), Binary, Unary, and FunctionCall, assigning `_agg_{n}` aliases and substituting variables.
  - Extracts aggregates on both sides of binary ops and inside function args, preventing raw aggregate calls from leaking into post-return expressions.
  - Scope: affects `execute_cypher` only; adds Cypher tests for aggregates in WHEN, THEN, and ELSE branches (including multiple aggregates).

<sup>Written for commit 1aa23ef1bd7fc3395b8d589c434e8cfb3a0c190d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

