### PR TITLE
test(engine): proptest round-trip suite for compact()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,11 @@ cargo-timing*.html
 # ── Benchmarks ────────────────────────────────────────────────────────
 .benchmarks
 
+# ── Proptest ─────────────────────────────────────────────────────────
+# Persisted failure seeds — committed intentionally only for regressions
+# we want to guard against; otherwise local artefacts.
+*.proptest-regressions
+
 # ── Documentation (auto-generated) ───────────────────────────────────
 docs/changelog.md
 site/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1509,7 @@ dependencies = [
  "md5",
  "ort",
  "parking_lot",
+ "proptest",
  "rayon",
  "regex",
  "regex-lite",
@@ -2855,6 +2871,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pyo3"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2927,6 +2962,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -3013,6 +3054,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rawpointer"
@@ -3231,6 +3281,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustyline"
@@ -3916,6 +3978,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4086,6 +4154,15 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/grafeo-engine/Cargo.toml
+++ b/crates/grafeo-engine/Cargo.toml
@@ -63,6 +63,7 @@ criterion.workspace = true
 tempfile.workspace = true
 serde_json = "1"
 tokio.workspace = true
+proptest.workspace = true
 
 [features]
 default = ["lpg", "gql", "parallel", "wal", "grafeo-file", "spill", "mmap", "regex"]

--- a/crates/grafeo-engine/tests/compact_roundtrip_proptest.rs
+++ b/crates/grafeo-engine/tests/compact_roundtrip_proptest.rs
@@ -1,0 +1,238 @@
+//! Property-based round-trip tests for [`GrafeoDB::compact`].
+//!
+//! Generates arbitrary small LPG graphs, applies them to two fresh in-memory
+//! databases, compacts one, then asserts that a battery of GQL queries returns
+//! equivalent cardinalities and row shapes on both. Catches regressions in the
+//! live → [`LayeredStore`] (CompactStore base + LpgStore overlay) conversion
+//! path introduced in 0.5.31–0.5.32.
+//!
+//! Content-equality (`sum(n.num)` etc.) and post-`compact()` write visibility
+//! are exercised by the sibling fix PRs for GrafeoDB/grafeo#301 and #302,
+//! which ship deterministic tests alongside the fix.
+//!
+//! ```bash
+//! cargo test -p grafeo-engine --features "compact-store lpg gql" \
+//!     --test compact_roundtrip_proptest
+//!
+//! # bump coverage locally:
+//! PROPTEST_CASES=1024 cargo test -p grafeo-engine ...
+//! ```
+//!
+//! [`LayeredStore`]: grafeo_core::graph::compact::layered::LayeredStore
+
+#![cfg(all(feature = "compact-store", feature = "lpg", feature = "gql"))]
+
+use grafeo_common::types::{NodeId, Value};
+use grafeo_engine::GrafeoDB;
+use proptest::prelude::*;
+
+// ── Input space ──────────────────────────────────────────────────
+
+/// A minimal serialisable description of a graph, used to build two identical
+/// databases deterministically from one proptest-generated seed.
+#[derive(Debug, Clone)]
+struct GraphSpec {
+    nodes: Vec<NodeSpec>,
+    edges: Vec<EdgeSpec>,
+}
+
+#[derive(Debug, Clone)]
+struct NodeSpec {
+    label: &'static str,
+    num: Option<i64>,
+    name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct EdgeSpec {
+    src: usize, // index into `nodes`
+    dst: usize,
+    kind: &'static str,
+}
+
+const LABELS: &[&str] = &["A", "B", "C"];
+const EDGE_KINDS: &[&str] = &["R1", "R2"];
+
+fn label_strategy() -> impl Strategy<Value = &'static str> {
+    prop_oneof![Just(LABELS[0]), Just(LABELS[1]), Just(LABELS[2])]
+}
+
+fn edge_kind_strategy() -> impl Strategy<Value = &'static str> {
+    prop_oneof![Just(EDGE_KINDS[0]), Just(EDGE_KINDS[1])]
+}
+
+fn node_spec_strategy() -> impl Strategy<Value = NodeSpec> {
+    // Bound `num` so sum() across ~20 nodes can't overflow i64.
+    (
+        label_strategy(),
+        proptest::option::of(-1_000_000_000i64..1_000_000_000i64),
+        proptest::option::of("[a-z]{1,8}"),
+    )
+        .prop_map(|(label, num, name)| NodeSpec { label, num, name })
+}
+
+fn graph_spec_strategy() -> impl Strategy<Value = GraphSpec> {
+    prop::collection::vec(node_spec_strategy(), 1..=20).prop_flat_map(|nodes| {
+        let n = nodes.len();
+        let edges = prop::collection::vec(
+            (0..n, 0..n, edge_kind_strategy())
+                .prop_map(|(src, dst, kind)| EdgeSpec { src, dst, kind }),
+            0..=30,
+        );
+        (Just(nodes), edges).prop_map(|(nodes, edges)| GraphSpec { nodes, edges })
+    })
+}
+
+// ── Application ──────────────────────────────────────────────────
+
+fn apply_spec(spec: &GraphSpec, db: &GrafeoDB) {
+    let mut ids: Vec<NodeId> = Vec::with_capacity(spec.nodes.len());
+    for n in &spec.nodes {
+        let id = db.create_node(&[n.label]);
+        if let Some(num) = n.num {
+            db.set_node_property(id, "num", Value::Int64(num));
+        }
+        if let Some(s) = &n.name {
+            db.set_node_property(id, "name", Value::String(s.clone().into()));
+        }
+        ids.push(id);
+    }
+    for e in &spec.edges {
+        let _ = db.create_edge(ids[e.src], ids[e.dst], e.kind);
+    }
+}
+
+// ── Query helpers ────────────────────────────────────────────────
+
+fn scalar(db: &GrafeoDB, query: &str) -> Value {
+    let session = db.session();
+    let result = session
+        .execute(query)
+        .unwrap_or_else(|e| panic!("query failed: {query} — {e:?}"));
+    let rows = result.rows();
+    assert_eq!(
+        rows.len(),
+        1,
+        "expected 1 row for `{query}`, got {}",
+        rows.len()
+    );
+    rows[0][0].clone()
+}
+
+fn row_count(db: &GrafeoDB, query: &str) -> usize {
+    let session = db.session();
+    let result = session
+        .execute(query)
+        .unwrap_or_else(|e| panic!("query failed: {query} — {e:?}"));
+    result.rows().len()
+}
+
+// ── Oracle ───────────────────────────────────────────────────────
+
+fn assert_scalar_equivalent(a: &GrafeoDB, b: &GrafeoDB, query: &str) {
+    let va = scalar(a, query);
+    let vb = scalar(b, query);
+    assert_eq!(
+        va, vb,
+        "divergence on scalar query `{query}`: live={va:?}, compacted={vb:?}"
+    );
+}
+
+fn assert_rows_equivalent(a: &GrafeoDB, b: &GrafeoDB, query: &str) {
+    let ra = row_count(a, query);
+    let rb = row_count(b, query);
+    assert_eq!(
+        ra, rb,
+        "divergence on row-count query `{query}`: live={ra}, compacted={rb}"
+    );
+}
+
+fn assert_equivalent(live: &GrafeoDB, compacted: &GrafeoDB) {
+    // ── Cardinality ──────────────────────────────────────────────
+    assert_scalar_equivalent(live, compacted, "MATCH (n) RETURN count(n)");
+    assert_scalar_equivalent(live, compacted, "MATCH ()-[r]->() RETURN count(r)");
+
+    for label in LABELS {
+        let q = format!("MATCH (n:{label}) RETURN count(n)");
+        assert_scalar_equivalent(live, compacted, &q);
+    }
+    for kind in EDGE_KINDS {
+        let q = format!("MATCH ()-[r:{kind}]->() RETURN count(r)");
+        assert_scalar_equivalent(live, compacted, &q);
+    }
+    for src_label in LABELS {
+        for kind in EDGE_KINDS {
+            for dst_label in LABELS {
+                let q = format!(
+                    "MATCH (a:{src_label})-[r:{kind}]->(b:{dst_label}) RETURN count(r)"
+                );
+                assert_scalar_equivalent(live, compacted, &q);
+            }
+        }
+    }
+
+    // ── Row shape ────────────────────────────────────────────────
+    assert_rows_equivalent(live, compacted, "MATCH (n) RETURN n");
+    assert_rows_equivalent(live, compacted, "MATCH (a)-[r]->(b) RETURN a, r, b");
+}
+
+// ── Properties ───────────────────────────────────────────────────
+
+proptest! {
+    // 128 cases balances coverage against CI wall-clock. Bump locally via
+    // `PROPTEST_CASES=1024 cargo test ...` when investigating a flake.
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Cardinality and row-shape queries agree between a freshly built live
+    /// database and the same spec compacted to `LayeredStore`.
+    #[test]
+    fn compact_preserves_cardinality_and_shape(spec in graph_spec_strategy()) {
+        let live = GrafeoDB::new_in_memory();
+        apply_spec(&spec, &live);
+
+        let mut compacted = GrafeoDB::new_in_memory();
+        apply_spec(&spec, &compacted);
+        compacted.compact().expect("compact");
+
+        assert_equivalent(&live, &compacted);
+    }
+}
+
+// ── Fixed regression seeds ───────────────────────────────────────
+//
+// Concrete shapes worth asserting explicitly so regressions surface even
+// when proptest shrinking is disabled.
+
+#[test]
+fn empty_graph_compact_is_noop() {
+    let live = GrafeoDB::new_in_memory();
+    let mut compacted = GrafeoDB::new_in_memory();
+    compacted.compact().expect("compact empty");
+    assert_equivalent(&live, &compacted);
+}
+
+#[test]
+fn single_node_no_properties() {
+    let live = GrafeoDB::new_in_memory();
+    live.create_node(&["A"]);
+
+    let mut compacted = GrafeoDB::new_in_memory();
+    compacted.create_node(&["A"]);
+    compacted.compact().expect("compact");
+
+    assert_equivalent(&live, &compacted);
+}
+
+#[test]
+fn self_loop_survives_compact() {
+    let live = GrafeoDB::new_in_memory();
+    let n = live.create_node(&["A"]);
+    live.create_edge(n, n, "R1");
+
+    let mut compacted = GrafeoDB::new_in_memory();
+    let m = compacted.create_node(&["A"]);
+    compacted.create_edge(m, m, "R1");
+    compacted.compact().expect("compact");
+
+    assert_equivalent(&live, &compacted);
+}

--- a/crates/grafeo-engine/tests/compact_roundtrip_proptest.rs
+++ b/crates/grafeo-engine/tests/compact_roundtrip_proptest.rs
@@ -75,8 +75,11 @@ fn graph_spec_strategy() -> impl Strategy<Value = GraphSpec> {
     prop::collection::vec(node_spec_strategy(), 1..=20).prop_flat_map(|nodes| {
         let n = nodes.len();
         let edges = prop::collection::vec(
-            (0..n, 0..n, edge_kind_strategy())
-                .prop_map(|(src, dst, kind)| EdgeSpec { src, dst, kind }),
+            (0..n, 0..n, edge_kind_strategy()).prop_map(|(src, dst, kind)| EdgeSpec {
+                src,
+                dst,
+                kind,
+            }),
             0..=30,
         );
         (Just(nodes), edges).prop_map(|(nodes, edges)| GraphSpec { nodes, edges })
@@ -163,9 +166,8 @@ fn assert_equivalent(live: &GrafeoDB, compacted: &GrafeoDB) {
     for src_label in LABELS {
         for kind in EDGE_KINDS {
             for dst_label in LABELS {
-                let q = format!(
-                    "MATCH (a:{src_label})-[r:{kind}]->(b:{dst_label}) RETURN count(r)"
-                );
+                let q =
+                    format!("MATCH (a:{src_label})-[r:{kind}]->(b:{dst_label}) RETURN count(r)");
                 assert_scalar_equivalent(live, compacted, &q);
             }
         }


### PR DESCRIPTION
## Motivation

\`GrafeoDB::compact\` has had significant reworking in 0.5.31–0.5.32 (columnar conversion, LayeredStore, epoch sync) and again in 0.5.39 (\"writable after compact\"). The existing integration tests cover a handful of hand-crafted shapes; this PR adds property-based coverage for the broader equivalence invariant across cardinality and row shape.

## What it does

Generates arbitrary small LPG graphs (1–20 nodes, 0–30 edges, three labels, two edge types, optional bounded-\`i64\` \`num\` + \`[a-z]{1,8}\` \`name\` properties), builds two fresh in-memory databases from the same spec, compacts one, then asserts equivalence across a battery of GQL queries.

**\`compact_preserves_cardinality_and_shape\`** — 128 cases:

- \`MATCH (n) RETURN count(n)\` (total)
- \`MATCH ()-[r]->() RETURN count(r)\` (total)
- \`MATCH (n:Label) RETURN count(n)\` (per-label × 3 labels)
- \`MATCH ()-[r:Type]->() RETURN count(r)\` (per-type × 2 types)
- \`MATCH (a:L1)-[r:T]->(b:L2) RETURN count(r)\` (per-pattern × 3×2×3 = 18)
- \`MATCH (n) RETURN n\` row count
- \`MATCH (a)-[r]->(b) RETURN a, r, b\` row count

Plus three fixed regression seeds (empty graph, single node, self-loop) to guard against specific pathologies even when proptest shrinking doesn't hit them.

## Bugs surfaced during authoring

This proptest surfaced two real bugs that are tracked separately:

- #301 — \`sum(n.num)\` returns \`Float64\` instead of \`Int64\` on mixed-sign int columns after \`compact()\`. Fixed by #306, which introduces a new \`RawI64\` codec and ships deterministic tests for the fix.
- #302 — writes after \`compact()\` are invisible to \`MATCH\`. Fixed by #307, which ships deterministic tests for the fix.

Content-equality and post-compact-visibility coverage lives in those sibling PRs rather than here, so each PR is self-contained and can merge independently in any order — no \`#[ignore]\` / \`--ignored\` dance required.

## Run

\`\`\`bash
cargo test -p grafeo-engine --features \"compact-store lpg gql\" \\
    --test compact_roundtrip_proptest

# Bump coverage locally:
PROPTEST_CASES=1024 cargo test -p grafeo-engine ...
\`\`\`

## Scope

Additive only — no library code changes, no feature flags added, no existing tests touched. Non-test changes:

- \`proptest\` added as dev-dep on \`grafeo-engine\` (workspace dep already declared)
- \`*.proptest-regressions\` added to \`.gitignore\`

Staged through four rounds of self-review at [temporaryfix/grafeo#9](https://github.com/temporaryfix/grafeo/pull/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)