### PR TITLE
ci: CodSpeed continuous benchmark regression

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -29,8 +29,12 @@ jobs:
     name: CodSpeed
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Skip on forks where the token is unavailable.
-    if: github.repository == 'GrafeoDB/grafeo'
+    # Skip PRs from forks: `pull_request` events run in the base-repo context
+    # (so `github.repository` alone would still match), but the CODSPEED_TOKEN
+    # secret isn't exposed to fork PRs. Gate on head-repo equality instead.
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,74 @@
+name: CodSpeed
+
+# Callgrind-based microbenchmark regression tracking on every PR.
+# Requires the CODSPEED_TOKEN repository secret (set up at
+# https://codspeed.io/new).
+#
+# Covers all six bench suites across the workspace:
+#   - grafeo-core:    index_bench     (adjacency, HNSW, distance, quantization,
+#                                      CompactStore point queries)
+#   - grafeo-common:  arena_bench     (epoch arena, bump, object pool)
+#   - grafeo-storage: wal_bench       (WAL write + recovery replay)
+#   - grafeo-engine:  query_bench           (end-to-end GQL / SPARQL)
+#                     serialization_bench   (snapshot + value encode/decode)
+#                     regression_bench      (multi-hop, repeated, edge filter)
+#                     memory_bench          (memory footprint snapshot)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codspeed-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmarks:
+    name: CodSpeed
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Skip on forks where the token is unavailable.
+    if: github.repository == 'GrafeoDB/grafeo'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-codspeed-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-codspeed-
+
+      - name: Install cargo-codspeed
+        uses: taiki-e/install-action@v2
+        with:
+          # Pinned to a known-good version. Bump with care; the
+          # codspeed-criterion-compat dev-dep should move in lock-step.
+          tool: cargo-codspeed@4.5.0
+
+      - name: Build instrumented benchmarks
+        run: |
+          cargo codspeed build --package grafeo-common --bench arena_bench
+          cargo codspeed build --package grafeo-storage --features wal --bench wal_bench
+          cargo codspeed build --package grafeo-core \
+            --features "vector-index compact-store" --bench index_bench
+          cargo codspeed build --package grafeo-engine --features full \
+            --bench query_bench \
+            --bench serialization_bench \
+            --bench regression_bench \
+            --bench memory_bench
+
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v4
+        with:
+          run: cargo codspeed run
+          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,9 +155,12 @@ These companion projects live in separate repositories under the [GrafeoDB](http
 
 ## Benchmarks and Performance Regressions
 
-Every PR is benchmarked on [CodSpeed](https://codspeed.io/), which runs the
-Criterion microbenchmarks under Callgrind for <1% variance. Results post as a
-PR comment with a diff vs `main`.
+PRs opened from this repository are benchmarked on
+[CodSpeed](https://codspeed.io/), which runs the Criterion microbenchmarks
+under Callgrind for <1% variance. Results post as a PR comment with a diff
+vs `main`. PRs from forks are skipped — the CodSpeed token isn't exposed to
+fork workflows; after an initial review a maintainer can push the branch to
+this repo to trigger a run.
 
 The following suites are tracked:
 
@@ -176,7 +179,8 @@ The following suites are tracked:
 Reproduce locally:
 
 ```bash
-cargo install cargo-codspeed
+# Pin matches .github/workflows/codspeed.yml; bump both in lock-step.
+cargo install cargo-codspeed --version 4.5.0
 cargo codspeed build --package grafeo-core \
     --features "vector-index compact-store" --bench index_bench
 cargo codspeed run --package grafeo-core

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,46 @@ These companion projects live in separate repositories under the [GrafeoDB](http
 | [graph-bench](https://github.com/GrafeoDB/graph-bench) | Benchmark suite |
 | [ann-benchmarks](https://github.com/GrafeoDB/ann-benchmarks) | Vector search benchmarking |
 
+## Benchmarks and Performance Regressions
+
+Every PR is benchmarked on [CodSpeed](https://codspeed.io/), which runs the
+Criterion microbenchmarks under Callgrind for <1% variance. Results post as a
+PR comment with a diff vs `main`.
+
+The following suites are tracked:
+
+- `grafeo-core/benches/index_bench.rs` — adjacency, HashIndex, HNSW
+  insert/search, distance kernels, quantisation, CompactStore point queries
+- `grafeo-common/benches/arena_bench.rs` — epoch arena, bump allocator,
+  object pool
+- `grafeo-storage/benches/wal_bench.rs` — WAL write throughput, recovery
+  replay
+- `grafeo-engine/benches/query_bench.rs` — end-to-end GQL + SPARQL
+- `grafeo-engine/benches/serialization_bench.rs` — snapshot + Value codecs
+- `grafeo-engine/benches/regression_bench.rs` — multi-hop, repeated-parse,
+  edge-type filter
+- `grafeo-engine/benches/memory_bench.rs` — memory footprint snapshot
+
+Reproduce locally:
+
+```bash
+cargo install cargo-codspeed
+cargo codspeed build --package grafeo-core \
+    --features "vector-index compact-store" --bench index_bench
+cargo codspeed run --package grafeo-core
+```
+
+If a PR flags a >5% regression on a hot path, include a brief explanation in
+the PR description — the trade-off is often acceptable (e.g. a correctness
+fix that costs some throughput), but the maintainer should know it was
+deliberate rather than accidental.
+
+Adding a new Criterion bench: use `codspeed_criterion_compat` in place of
+`criterion` as the import, add a `[[bench]]` entry and any features in the
+owning crate's `Cargo.toml`, and add the suite to `.github/workflows/codspeed.yml`
+so it lands in the PR comment. The adapter is a drop-in replacement — plain
+`cargo bench` continues to work unchanged.
+
 ## Pre-commit Hooks (Optional)
 
 ```bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +300,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -524,10 +542,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
+name = "codspeed"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35584c5fcba8059780748866387fb97c5a203bcfc563fc3d0790af406727a117"
+dependencies = [
+ "anyhow",
+ "bincode 1.3.3",
+ "colored",
+ "glob",
+ "libc",
+ "nix 0.29.0",
+ "serde",
+ "serde_json",
+ "statrs",
+ "uuid",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f6c1c6bed5fd84d319e8b0889da051daa361c79b7709c9394dfe1a882bba67"
+dependencies = [
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c989289ce6b1cbde72ed560496cb8fbf5aa14d5ef5666f168e7f87751038352e"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot 0.5.0",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "comfy-table"
@@ -706,7 +790,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot",
+ "criterion-plot 0.8.2",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -718,6 +802,16 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1343,6 +1437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "grafeo"
 version = "0.5.40"
 dependencies = [
@@ -1358,7 +1458,7 @@ dependencies = [
 name = "grafeo-adapters"
 version = "0.5.40"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "grafeo-common",
  "grafeo-core",
  "hashbrown 0.17.0",
@@ -1421,10 +1521,11 @@ dependencies = [
  "aes-gcm",
  "arcstr",
  "argon2",
- "bincode",
+ "bincode 2.0.1",
  "bumpalo",
  "byteorder",
  "bytes",
+ "codspeed-criterion-compat",
  "criterion",
  "dashmap",
  "foldhash 0.2.0",
@@ -1446,9 +1547,10 @@ name = "grafeo-core"
 version = "0.5.40"
 dependencies = [
  "arcstr",
- "bincode",
+ "bincode 2.0.1",
  "byteorder",
  "bytes",
+ "codspeed-criterion-compat",
  "crc32fast",
  "criterion",
  "crossbeam",
@@ -1480,7 +1582,8 @@ dependencies = [
  "arrow-array",
  "arrow-ipc",
  "arrow-schema",
- "bincode",
+ "bincode 2.0.1",
+ "codspeed-criterion-compat",
  "crc32fast",
  "criterion",
  "crossbeam",
@@ -1564,9 +1667,10 @@ dependencies = [
 name = "grafeo-storage"
 version = "0.5.40"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "byteorder",
  "bytes",
+ "codspeed-criterion-compat",
  "crc32fast",
  "criterion",
  "crossbeam",
@@ -2077,6 +2181,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2427,6 +2540,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3245,7 +3370,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.31.2",
  "radix_trie",
  "unicode-segmentation",
  "unicode-width",
@@ -3484,6 +3609,16 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
 
 [[package]]
 name = "strsim"
@@ -4062,6 +4197,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ unicode-normalization = "0.1"
 # Testing
 proptest = "1"
 criterion = "0.8"
+codspeed-criterion-compat = "3"
 tempfile = "3"
 
 # Allocators (platform-optimized)

--- a/crates/grafeo-common/Cargo.toml
+++ b/crates/grafeo-common/Cargo.toml
@@ -54,6 +54,7 @@ encryption = ["dep:aes-gcm", "dep:hkdf", "dep:argon2", "dep:zeroize", "dep:sha2"
 
 [dev-dependencies]
 criterion.workspace = true
+codspeed-criterion-compat.workspace = true
 
 [lints]
 workspace = true

--- a/crates/grafeo-common/benches/arena_bench.rs
+++ b/crates/grafeo-common/benches/arena_bench.rs
@@ -1,8 +1,11 @@
 //! Benchmarks for memory allocators.
+// reason: criterion_group! expansion from codspeed-criterion-compat does not
+// carry doc comments on the generated wrapper functions.
+#![allow(missing_docs)]
 
 use std::hint::black_box;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use codspeed_criterion_compat::{Criterion, criterion_group, criterion_main};
 
 use grafeo_common::memory::arena::Arena;
 use grafeo_common::memory::bump::BumpAllocator;

--- a/crates/grafeo-core/Cargo.toml
+++ b/crates/grafeo-core/Cargo.toml
@@ -53,6 +53,7 @@ crc32fast.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
+codspeed-criterion-compat.workspace = true
 serde_json = "1"
 tempfile.workspace = true
 

--- a/crates/grafeo-core/benches/index_bench.rs
+++ b/crates/grafeo-core/benches/index_bench.rs
@@ -1,10 +1,18 @@
 //! Benchmarks for index structures.
+//!
+//! Uses `codspeed-criterion-compat` in place of `criterion` directly so the
+//! same bench file runs under plain `cargo bench` (pass-through to criterion)
+//! and under `cargo codspeed build && cargo codspeed run` (instrumented via
+//! Callgrind for commit-level regression tracking on CodSpeed).
 // reason: bench code uses small known constants
 #![allow(clippy::cast_possible_truncation)]
+// reason: criterion_group! expansion from codspeed-criterion-compat does not
+// carry doc comments on the generated wrapper functions.
+#![allow(missing_docs)]
 
 use std::hint::black_box;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use codspeed_criterion_compat::{Criterion, criterion_group, criterion_main};
 
 use grafeo_common::types::{EdgeId, NodeId};
 use grafeo_core::index::adjacency::ChunkedAdjacency;

--- a/crates/grafeo-engine/Cargo.toml
+++ b/crates/grafeo-engine/Cargo.toml
@@ -60,6 +60,7 @@ crc32fast = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion.workspace = true
+codspeed-criterion-compat.workspace = true
 tempfile.workspace = true
 serde_json = "1"
 tokio.workspace = true

--- a/crates/grafeo-engine/benches/memory_bench.rs
+++ b/crates/grafeo-engine/benches/memory_bench.rs
@@ -5,6 +5,9 @@
 //! `target/criterion/memory_snapshot.json`. The CI comparison script reads
 // Bench indices are small known values
 #![allow(clippy::cast_possible_wrap)]
+// reason: criterion_group! expansion from codspeed-criterion-compat does not
+// carry doc comments on the generated wrapper functions.
+#![allow(missing_docs)]
 //! that file and checks against absolute bounds in `bench-thresholds.toml`.
 //!
 //! Run with: cargo bench --all-features --bench memory_bench
@@ -14,7 +17,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use codspeed_criterion_compat::{Criterion, criterion_group, criterion_main};
 
 use grafeo_common::types::Value;
 use grafeo_engine::GrafeoDB;

--- a/crates/grafeo-engine/benches/query_bench.rs
+++ b/crates/grafeo-engine/benches/query_bench.rs
@@ -5,10 +5,13 @@
 //!
 //! Run with: cargo bench -p grafeo-engine
 //! RDF benchmarks require: cargo bench -p grafeo-engine --all-features
+// reason: criterion_group! expansion from codspeed-criterion-compat does not
+// carry doc comments on the generated wrapper functions.
+#![allow(missing_docs)]
 
 use std::hint::black_box;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use codspeed_criterion_compat::{Criterion, criterion_group, criterion_main};
 
 use grafeo_engine::GrafeoDB;
 #[cfg(all(feature = "sparql", feature = "triple-store"))]

--- a/crates/grafeo-engine/benches/regression_bench.rs
+++ b/crates/grafeo-engine/benches/regression_bench.rs
@@ -10,11 +10,14 @@
 //!
 //! Run with: cargo bench -p grafeo-engine --bench regression_bench
 //! All features: cargo bench --all-features --bench regression_bench
+// reason: criterion_group! expansion from codspeed-criterion-compat does not
+// carry doc comments on the generated wrapper functions.
+#![allow(missing_docs)]
 
 use std::hint::black_box;
 use std::time::Duration;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use codspeed_criterion_compat::{Criterion, criterion_group, criterion_main};
 
 use grafeo_engine::GrafeoDB;
 

--- a/crates/grafeo-engine/benches/serialization_bench.rs
+++ b/crates/grafeo-engine/benches/serialization_bench.rs
@@ -5,10 +5,13 @@
 //! Run with: cargo bench -p grafeo-engine --bench serialization_bench
 // Bench values are small known constants
 #![allow(clippy::cast_possible_wrap)]
+// reason: criterion_group! expansion from codspeed-criterion-compat does not
+// carry doc comments on the generated wrapper functions.
+#![allow(missing_docs)]
 
 use std::hint::black_box;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use codspeed_criterion_compat::{Criterion, criterion_group, criterion_main};
 use grafeo_common::types::Value;
 use grafeo_engine::GrafeoDB;
 

--- a/crates/grafeo-storage/Cargo.toml
+++ b/crates/grafeo-storage/Cargo.toml
@@ -41,6 +41,7 @@ tracing = { workspace = true, optional = true }
 tempfile.workspace = true
 serde_json = "1"
 criterion.workspace = true
+codspeed-criterion-compat.workspace = true
 
 [[bench]]
 name = "wal_bench"

--- a/crates/grafeo-storage/benches/wal_bench.rs
+++ b/crates/grafeo-storage/benches/wal_bench.rs
@@ -4,10 +4,13 @@
 //! - Single-record write (NoSync, Batch, Sync)
 //! - Batch write throughput (1K records in a committed transaction)
 //! - Recovery replay of a pre-populated WAL
+// reason: criterion_group! expansion from codspeed-criterion-compat does not
+// carry doc comments on the generated wrapper functions.
+#![allow(missing_docs)]
 
 use std::hint::black_box;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use codspeed_criterion_compat::{Criterion, criterion_group, criterion_main};
 use grafeo_common::types::{NodeId, TransactionId, Value};
 use grafeo_storage::wal::{DurabilityMode, WalConfig, WalManager, WalRecord, WalRecovery};
 


### PR DESCRIPTION
## Motivation

Grafeo has a strong set of microbenchmarks — six Criterion suites across four crates — and a separate \`graph-bench\` repo for macro workloads, but no commit-level regression signal: a 10% slowdown on HNSW search or CompactStore point queries wouldn't flag on a PR. [CodSpeed](https://codspeed.io) runs Criterion benches under Callgrind (<1% variance, no wallclock noise) and posts a differential flame graph per commit as a PR comment. It's free for OSS and \`RDF Fusion\` / \`Oxigraph\` already publish there.

This is an opinionated PR — adopting a SaaS-backed CI perf signal is a maintainer call. Happy to close if it's not the direction you want.

## What it does

**Workspace dep**: \`codspeed-criterion-compat = \"3\"\` added to \`[workspace.dependencies]\`. The adapter re-exports Criterion's API and only emits Callgrind instrumentation when executed under \`cargo codspeed run\`. Plain \`cargo bench\` continues to work unchanged.

**Per-crate dev-deps**: \`codspeed-criterion-compat.workspace = true\` added to \`grafeo-core\`, \`grafeo-common\`, \`grafeo-storage\`, \`grafeo-engine\`.

**All six bench suites migrated** (one-line import swap + \`#![allow(missing_docs)]\` for the adapter's macro expansion):

| Suite | Crate | Covers |
|---|---|---|
| \`index_bench\` | grafeo-core | adjacency, HashIndex, HNSW insert/search, distance kernels, scalar + product quantisation, CompactStore point queries |
| \`arena_bench\` | grafeo-common | epoch arena, bump allocator, object pool |
| \`wal_bench\` | grafeo-storage | WAL write throughput, recovery replay |
| \`query_bench\` | grafeo-engine | end-to-end GQL + SPARQL |
| \`serialization_bench\` | grafeo-engine | snapshot export/import, Value encode/decode |
| \`regression_bench\` | grafeo-engine | multi-hop traversal, repeated parse, edge-type filter |
| \`memory_bench\` | grafeo-engine | memory footprint snapshot |

**Workflow** (\`.github/workflows/codspeed.yml\`):
- Runs on PRs and \`main\` pushes
- Gated on \`github.repository == 'GrafeoDB/grafeo'\` so forks without the token skip cleanly
- \`cargo-codspeed\` pinned to \`4.5.0\`
- \`timeout-minutes: 30\` to bound any Callgrind hang
- \`concurrency: cancel-in-progress\`

**CONTRIBUTING.md** — new \"Benchmarks and Performance Regressions\" section documenting the tracked suites, local reproduction via \`cargo install cargo-codspeed\` + \`cargo codspeed build\` + \`cargo codspeed run\`, expectation that >5% regressions get a short justification in the PR description, and the recipe for adding a new bench.

## Verified end-to-end

Installed \`cargo-codspeed 4.5.0\` locally and confirmed:

1. \`cargo codspeed build\` succeeds for all six suites with their feature combinations.
2. \`cargo codspeed run --package grafeo-core\` processes all 20+ \`index_bench\` functions.
3. \`cargo codspeed run --package grafeo-engine\` processes all four engine suites end-to-end.

Locally the harness reports \"unknown environment — no performance measurement will be made\" because Callgrind isn't installed; CodSpeed's Valgrind wrapper provides that in CI.

## Setup

Requires a \`CODSPEED_TOKEN\` repo secret from <https://codspeed.io/new>. Without it the run fails at the upload step; on forks it's skipped by the \`if: github.repository\` guard.

## Why all six in one PR

Starting with just \`index_bench\` was my instinct, but the per-file delta is tiny (one import + one \`#![allow]\` + one workspace dep) and shipping them together avoids the \"why only this one?\" question plus a dangling follow-up.

## Scope

- No library code changes.
- No changes to existing Criterion benches other than the import swap.
- Existing \`cargo bench\` and CI flows continue unchanged.

Staged through two rounds of self-review at [temporaryfix/grafeo#10](https://github.com/temporaryfix/grafeo/pull/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CodSpeed CI to run our microbenchmarks on every PR and main push, giving commit-level regression signals with low variance. Bench suites now use `codspeed-criterion-compat`; `cargo bench` remains unchanged.

- **New Features**
  - New workflow `.github/workflows/codspeed.yml` runs `cargo codspeed build/run` on PRs and `main`, cancels in-progress jobs, 30‑minute timeout; pinned to `cargo-codspeed@4.5.0`.
  - Skips fork PRs by gating on `github.event.pull_request.head.repo.full_name == github.repository`; requires `CODSPEED_TOKEN`.
  - Covers all seven suites across `grafeo-core`, `grafeo-common`, `grafeo-storage`, and `grafeo-engine`; posts a diff vs `main` in PRs.
  - CONTRIBUTING updated with local repro steps, pinned `cargo-codspeed 4.5.0` to match CI, and a note to explain >5% regressions.

- **Dependencies**
  - Added workspace dev-dep `codspeed-criterion-compat = "3"` and enabled it in bench crates.
  - Switched bench imports to `codspeed_criterion_compat` and added `#![allow(missing_docs)]` where required.

<sup>Written for commit 8a1dd4ffa2648e6985bdd48a69ea86b85a55d48b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

