### PR TITLE
perf(vector): wasm32 simd128 distance kernels

### DIFF
--- a/crates/grafeo-core/src/index/vector/simd.rs
+++ b/crates/grafeo-core/src/index/vector/simd.rs
@@ -1,23 +1,28 @@
 //! SIMD-accelerated distance computations.
 //!
 //! This module provides hardware-accelerated implementations of distance functions
-//! using SIMD instructions (AVX2 on x86_64, NEON on aarch64).
+//! using SIMD instructions (AVX2 on x86_64, NEON on aarch64, WASM simd128 in the
+//! browser / Wasmtime).
 //!
 //! # Performance
 //!
-//! SIMD acceleration provides 4-8x speedup for distance computations:
+//! SIMD acceleration provides 3-8x speedup for distance computations:
 //!
-//! | Instruction Set | Speedup | Vectors/sec (384-dim) |
-//! |-----------------|---------|----------------------|
-//! | Scalar          | 1x      | ~2M                  |
-//! | SSE (128-bit)   | ~3x     | ~6M                  |
-//! | AVX2 (256-bit)  | ~6x     | ~12M                 |
-//! | AVX-512         | ~10x    | ~20M (planned)       |
+//! | Instruction Set       | Speedup | Vectors/sec (384-dim) |
+//! |-----------------------|---------|----------------------|
+//! | Scalar                | 1x      | ~2M                  |
+//! | SSE (128-bit)         | ~3x     | ~6M                  |
+//! | AVX2 (256-bit)        | ~6x     | ~12M                 |
+//! | AVX-512               | ~10x    | ~20M (planned)       |
+//! | WASM simd128          | ~4-5x   | ~8-10M               |
 //!
 //! # Runtime Detection
 //!
-//! SIMD support is detected at runtime using CPU feature detection.
-//! If the required instructions are not available, the scalar fallback is used.
+//! On x86_64 and aarch64 the best available instruction set is chosen at
+//! runtime via `std::arch::is_x86_feature_detected!` / NEON-is-mandatory.
+//! For `wasm32`, SIMD is a compile-time target feature — enable it with
+//! `RUSTFLAGS="-C target-feature=+simd128"`. Without it the scalar
+//! fallback is used.
 
 // SIMD intrinsics require unsafe code - this is well-understood and verified.
 #![allow(unsafe_code)]
@@ -53,7 +58,7 @@ pub fn has_neon() -> bool {
     true // NEON is mandatory on aarch64
 }
 
-// Fallback for other architectures (wasm32, riscv, etc.)
+// Fallback for other architectures (wasm32 without simd128, riscv, etc.)
 #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
 #[inline]
 #[allow(dead_code)] // Platform stub: called only on matching target
@@ -75,6 +80,16 @@ pub fn has_neon() -> bool {
     false
 }
 
+/// Returns true if WASM simd128 intrinsics are available (compile-time only;
+/// enable with `RUSTFLAGS="-C target-feature=+simd128"`).
+#[cfg(target_arch = "wasm32")]
+#[inline]
+#[allow(dead_code)] // Used only when WASM SIMD paths are compiled
+pub fn has_wasm_simd128() -> bool {
+    cfg!(target_feature = "simd128")
+}
+
+
 /// Returns the best available SIMD instruction set name.
 #[must_use]
 #[allow(unreachable_code)]
@@ -91,6 +106,10 @@ pub fn simd_support() -> &'static str {
     #[cfg(target_arch = "aarch64")]
     {
         return "neon";
+    }
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    {
+        return "wasm-simd128";
     }
     "scalar"
 }
@@ -134,6 +153,12 @@ pub fn dot_product_simd(a: &[f32], b: &[f32]) -> f32 {
         return unsafe { dot_product_neon(a, b) };
     }
 
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    {
+        // SAFETY: simd128 target feature is enabled at compile time
+        return unsafe { dot_product_wasm_simd(a, b) };
+    }
+
     // Scalar fallback
     dot_product_scalar(a, b)
 }
@@ -158,6 +183,12 @@ pub fn euclidean_distance_squared_simd(a: &[f32], b: &[f32]) -> f32 {
     {
         // SAFETY: NEON is always available on aarch64
         return unsafe { euclidean_squared_neon(a, b) };
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    {
+        // SAFETY: simd128 target feature is enabled at compile time
+        return unsafe { euclidean_squared_wasm_simd(a, b) };
     }
 
     euclidean_squared_scalar(a, b)
@@ -191,6 +222,12 @@ pub fn cosine_distance_simd(a: &[f32], b: &[f32]) -> f32 {
         return unsafe { cosine_distance_neon(a, b) };
     }
 
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    {
+        // SAFETY: simd128 target feature is enabled at compile time
+        return unsafe { cosine_distance_wasm_simd(a, b) };
+    }
+
     cosine_distance_scalar(a, b)
 }
 
@@ -214,6 +251,12 @@ pub fn manhattan_distance_simd(a: &[f32], b: &[f32]) -> f32 {
     {
         // SAFETY: NEON is always available on aarch64
         return unsafe { manhattan_distance_neon(a, b) };
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    {
+        // SAFETY: simd128 target feature is enabled at compile time
+        return unsafe { manhattan_distance_wasm_simd(a, b) };
     }
 
     manhattan_distance_scalar(a, b)
@@ -697,6 +740,139 @@ unsafe fn horizontal_sum_neon(v: std::arch::aarch64::float32x4_t) -> f32 {
 }
 
 // ============================================================================
+// wasm32 simd128 Implementations
+// ============================================================================
+//
+// Compiled only when `target_feature = "simd128"` is set at build time.
+// Enable via `RUSTFLAGS="-C target-feature=+simd128"` or a `.cargo/config.toml`
+// `[target.wasm32-*]` block.
+//
+// Runtime support: Chrome 91+, Firefox 89+, Safari 16.4+.
+//
+// A relaxed-simd FMA fast path (`f32x4_relaxed_madd`) is intentionally *not*
+// wired up here — the Wasm spec permits runtime-defined rounding for that
+// intrinsic, making distance values implementation-dependent. Can be added
+// behind an opt-in Cargo feature in a follow-up if benchmarks justify the
+// extra complexity.
+
+/// Horizontal sum of the 4 lanes of an f32x4 vector.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline]
+unsafe fn horizontal_sum_wasm(v: std::arch::wasm32::v128) -> f32 {
+    use std::arch::wasm32::*;
+    f32x4_extract_lane::<0>(v)
+        + f32x4_extract_lane::<1>(v)
+        + f32x4_extract_lane::<2>(v)
+        + f32x4_extract_lane::<3>(v)
+}
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+unsafe fn dot_product_wasm_simd(a: &[f32], b: &[f32]) -> f32 {
+    use std::arch::wasm32::*;
+
+    let n = a.len();
+    let mut i = 0;
+    let mut sum = f32x4_splat(0.0);
+
+    while i + 4 <= n {
+        let va = v128_load(a.as_ptr().add(i) as *const v128);
+        let vb = v128_load(b.as_ptr().add(i) as *const v128);
+        sum = f32x4_add(sum, f32x4_mul(va, vb));
+        i += 4;
+    }
+
+    let mut result = horizontal_sum_wasm(sum);
+    while i < n {
+        result += a[i] * b[i];
+        i += 1;
+    }
+    result
+}
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+unsafe fn euclidean_squared_wasm_simd(a: &[f32], b: &[f32]) -> f32 {
+    use std::arch::wasm32::*;
+
+    let n = a.len();
+    let mut i = 0;
+    let mut sum = f32x4_splat(0.0);
+
+    while i + 4 <= n {
+        let va = v128_load(a.as_ptr().add(i) as *const v128);
+        let vb = v128_load(b.as_ptr().add(i) as *const v128);
+        let diff = f32x4_sub(va, vb);
+        sum = f32x4_add(sum, f32x4_mul(diff, diff));
+        i += 4;
+    }
+
+    let mut result = horizontal_sum_wasm(sum);
+    while i < n {
+        let d = a[i] - b[i];
+        result += d * d;
+        i += 1;
+    }
+    result
+}
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+unsafe fn cosine_distance_wasm_simd(a: &[f32], b: &[f32]) -> f32 {
+    use std::arch::wasm32::*;
+
+    let n = a.len();
+    let mut i = 0;
+    let mut dot = f32x4_splat(0.0);
+    let mut na = f32x4_splat(0.0);
+    let mut nb = f32x4_splat(0.0);
+
+    while i + 4 <= n {
+        let va = v128_load(a.as_ptr().add(i) as *const v128);
+        let vb = v128_load(b.as_ptr().add(i) as *const v128);
+        dot = f32x4_add(dot, f32x4_mul(va, vb));
+        na = f32x4_add(na, f32x4_mul(va, va));
+        nb = f32x4_add(nb, f32x4_mul(vb, vb));
+        i += 4;
+    }
+
+    let mut dot_scalar = horizontal_sum_wasm(dot);
+    let mut na_scalar = horizontal_sum_wasm(na);
+    let mut nb_scalar = horizontal_sum_wasm(nb);
+
+    while i < n {
+        dot_scalar += a[i] * b[i];
+        na_scalar += a[i] * a[i];
+        nb_scalar += b[i] * b[i];
+        i += 1;
+    }
+
+    let denom = (na_scalar.sqrt() * nb_scalar.sqrt()) + f32::EPSILON;
+    1.0 - (dot_scalar / denom)
+}
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+unsafe fn manhattan_distance_wasm_simd(a: &[f32], b: &[f32]) -> f32 {
+    use std::arch::wasm32::*;
+
+    let n = a.len();
+    let mut i = 0;
+    let mut sum = f32x4_splat(0.0);
+
+    while i + 4 <= n {
+        let va = v128_load(a.as_ptr().add(i) as *const v128);
+        let vb = v128_load(b.as_ptr().add(i) as *const v128);
+        let diff = f32x4_sub(va, vb);
+        sum = f32x4_add(sum, f32x4_abs(diff));
+        i += 4;
+    }
+
+    let mut result = horizontal_sum_wasm(sum);
+    while i < n {
+        result += (a[i] - b[i]).abs();
+        i += 1;
+    }
+    result
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -715,7 +891,9 @@ mod tests {
         let support = simd_support();
         println!("SIMD support: {support}");
         // Should be one of the valid values
-        assert!(["avx2", "sse", "neon", "scalar"].contains(&support));
+        assert!(
+            ["avx2", "sse", "neon", "wasm-simd128", "scalar"].contains(&support),
+        );
     }
 
     #[test]
@@ -853,5 +1031,57 @@ mod tests {
         let _ = compute_distance_simd(&a, &b, DistanceMetric::Euclidean);
         let _ = compute_distance_simd(&a, &b, DistanceMetric::DotProduct);
         let _ = compute_distance_simd(&a, &b, DistanceMetric::Manhattan);
+    }
+
+    /// Cross-path agreement: the active SIMD dispatcher (whatever backend is
+    /// selected for this build) must stay within a generous tolerance of the
+    /// scalar reference across all four metrics on a representative 384-dim
+    /// workload. Covers AVX2, SSE, NEON, and wasm32 simd128. Tolerance is
+    /// 1e-3 absolute — loose enough to accommodate horizontal-sum ordering
+    /// differences, tight enough to catch kernel bugs.
+    #[test]
+    fn wasm_simd_matches_scalar() {
+        let dims = 384;
+        let mut a = Vec::with_capacity(dims);
+        let mut b = Vec::with_capacity(dims);
+        let mut state: u64 = 0xA55A_A55A_A55A_A55A;
+        for _ in 0..dims {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            a.push(((state >> 33) as f32) / (u32::MAX as f32) - 0.5);
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            b.push(((state >> 33) as f32) / (u32::MAX as f32) - 0.5);
+        }
+
+        // 1e-3 is generous enough to absorb relaxed-simd rounding differences
+        // while still catching actual kernel bugs (wrong accumulator type,
+        // missing tail loop, off-by-one on lane extraction, etc.).
+        const TOLERANCE: f32 = 1e-3;
+
+        let pairs = [
+            ("dot", dot_product_simd(&a, &b), dot_product_scalar(&a, &b)),
+            (
+                "euclidean_sq",
+                euclidean_distance_squared_simd(&a, &b),
+                euclidean_squared_scalar(&a, &b),
+            ),
+            (
+                "cosine",
+                cosine_distance_simd(&a, &b),
+                cosine_distance_scalar(&a, &b),
+            ),
+            (
+                "manhattan",
+                manhattan_distance_simd(&a, &b),
+                manhattan_distance_scalar(&a, &b),
+            ),
+        ];
+        for (name, simd, scalar) in pairs {
+            let delta = (simd - scalar).abs();
+            assert!(
+                delta < TOLERANCE,
+                "{name}: simd={simd}, scalar={scalar}, delta={delta} (backend={})",
+                simd_support(),
+            );
+        }
     }
 }

--- a/crates/grafeo-core/src/index/vector/simd.rs
+++ b/crates/grafeo-core/src/index/vector/simd.rs
@@ -770,6 +770,11 @@ unsafe fn horizontal_sum_wasm(v: std::arch::wasm32::v128) -> f32 {
 unsafe fn dot_product_wasm_simd(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::wasm32::*;
 
+    // SAFETY precondition: the raw `v128_load` on `b` below is bounded by
+    // `a.len()`, so mismatched lengths would read out of `b`. Enforce in all
+    // builds, not just debug.
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
+
     let n = a.len();
     let mut i = 0;
     let mut sum = f32x4_splat(0.0);
@@ -792,6 +797,8 @@ unsafe fn dot_product_wasm_simd(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 unsafe fn euclidean_squared_wasm_simd(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::wasm32::*;
+
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -817,6 +824,8 @@ unsafe fn euclidean_squared_wasm_simd(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 unsafe fn cosine_distance_wasm_simd(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::wasm32::*;
+
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -851,6 +860,8 @@ unsafe fn cosine_distance_wasm_simd(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 unsafe fn manhattan_distance_wasm_simd(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::wasm32::*;
+
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;

--- a/crates/grafeo-core/src/index/vector/simd.rs
+++ b/crates/grafeo-core/src/index/vector/simd.rs
@@ -89,7 +89,6 @@ pub fn has_wasm_simd128() -> bool {
     cfg!(target_feature = "simd128")
 }
 
-
 /// Returns the best available SIMD instruction set name.
 #[must_use]
 #[allow(unreachable_code)]
@@ -902,9 +901,7 @@ mod tests {
         let support = simd_support();
         println!("SIMD support: {support}");
         // Should be one of the valid values
-        assert!(
-            ["avx2", "sse", "neon", "wasm-simd128", "scalar"].contains(&support),
-        );
+        assert!(["avx2", "sse", "neon", "wasm-simd128", "scalar"].contains(&support),);
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

\`crates/grafeo-core/src/index/vector/simd.rs\` already ships hand-rolled AVX2, SSE, and NEON implementations of the four HNSW distance metrics, with runtime dispatch. \`wasm32\` currently falls through to the scalar path. Given Grafeo's 660 KB gzipped WASM story and \`grafeo-web\`, this is a visible performance gap for any vector-search workload running in the browser.

## What it does

- **Four \`*_wasm_simd\` functions** — dot product, squared-euclidean, cosine, manhattan — using \`std::arch::wasm32\` intrinsics (\`v128_load\`, \`f32x4_splat\`, \`f32x4_add/mul/sub/abs\`, \`f32x4_extract_lane\`). Compiled only when \`target_feature=\"simd128\"\` is set.
- **Dispatcher updates** — each of \`dot_product_simd\`, \`euclidean_distance_squared_simd\`, \`cosine_distance_simd\`, \`manhattan_distance_simd\` gains a \`#[cfg(all(target_arch=\"wasm32\", target_feature=\"simd128\"))]\` branch between NEON and the scalar fallback.
- **New public helper** \`has_wasm_simd128()\` mirroring the existing \`has_avx2/sse/neon\`. \`simd_support()\` returns \`\"wasm-simd128\"\` on the appropriate target.
- **New cross-path test** \`wasm_simd_matches_scalar\` — asserts the active SIMD dispatcher agrees with the scalar reference within 1e-3 across all four metrics on 384-dim random vectors.

## Measured speedup

Apple Silicon (M-series), wasmtime 44, \`wasm32-wasip2\`, \`opt-level=3\`/\`lto=fat\`, 384-dim f32 × f32 vectors, N = 200,000 iterations, \`std::hint::black_box\`-wrapped, best-of-5:

| metric        | scalar ns | simd128 ns | speedup |
|---------------|-----------|------------|---------|
| dot_product   |     163.1 |       36.2 |   4.51× |
| cosine        |     223.4 |       51.2 |   4.36× |
| euclidean_sq  |     191.8 |       38.3 |   5.00× |
| manhattan     |     194.0 |       36.3 |   5.35× |

4.36–5.35× on Apple Silicon. Harness was a standalone wasmtime bench (outside the workspace) — happy to upstream it under \`tests/benches/\` or similar if useful, or it can live in \`graph-bench\`.

## Why relaxed-simd is NOT in this PR

A relaxed-simd FMA fast path (\`f32x4_relaxed_madd\`, Wasm 3.0) was prototyped. Dropped for two independent reasons:

1. **Nondeterminism by spec.** The Wasm spec explicitly permits a runtime to compute \`relaxed_madd\` as either a fused or unfused FMA. Distance values would therefore be implementation-dependent — fine for HNSW ordering in the large, not fine if any downstream code relies on bit-equality.
2. **Measured regression on current wasmtime.** On wasmtime 44 / aarch64, the relaxed variant *regresses* vs plain \`f32x4_add + f32x4_mul\`: cosine −6%, euclidean_sq −17%. Only dot_product shows a small win (+6%). Cranelift's aarch64 codegen evidently doesn't collapse three contending \`relaxed_madd\` accumulators into \`fmla\` cleanly. V8/SpiderMonkey may behave differently, but until someone has numbers showing a consistent cross-runtime win, the added complexity + spec caveat isn't worth it.

Can be revisited as a separate PR, behind an opt-in Cargo feature, if and when benchmarks warrant.

## Enabling

\`\`\`bash
RUSTFLAGS=\"-C target-feature=+simd128\" \\
  cargo build --target wasm32-wasip2 --features vector-index
\`\`\`

Runtime support: Chrome 91+, Firefox 89+, Safari 16.4+.

## Verified

- \`cargo test -p grafeo-core --features vector-index --lib index::vector::simd\` — 10/10 pass (9 existing + 1 new cross-path tolerance test)
- \`cargo clippy -p grafeo-core --features vector-index --lib --tests -- -D warnings\` — clean
- \`RUSTFLAGS='-C target-feature=+simd128' cargo check --target wasm32-wasip2\` — clean

## Scope

Self-contained to one file (\`simd.rs\`, +242 / −12). No Cargo.toml changes. No runtime API changes other than \`simd_support()\`'s return value set.

Staged through three rounds of self-review at [temporaryfix/grafeo#11](https://github.com/temporaryfix/grafeo/pull/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `wasm32` `simd128` distance kernels for dot, cosine, squared-euclidean, and manhattan, delivering 4–5× speedups in browser/Wasmtime. Also adds release-mode length checks in the wasm kernels to prevent out-of-bounds reads.

- **New Features**
  - `std::arch::wasm32` `simd128` kernels for all four metrics (compiled with `target_feature=+simd128`).
  - Dispatcher gains a `wasm-simd128` branch; `simd_support()` can return `wasm-simd128`.
  - New `has_wasm_simd128()` helper for feature checks.
  - Cross-path test validates SIMD vs scalar within 1e-3.
  - Benchmarks: 4.3–5.3× faster than scalar at 384-dim.

- **Migration**
  - Enable at build time: `RUSTFLAGS="-C target-feature=+simd128" cargo build --target wasm32-wasip2 --features vector-index`.
  - Runtime support: Chrome 91+, Firefox 89+, Safari 16.4+.

<sup>Written for commit 92fdd8dfe89e46236e18fb6df2e68566966aaaaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

