### PR TITLE
fix(compact): signed Int64 columns round-trip via new RawI64 codec

### DIFF
--- a/crates/grafeo-core/src/graph/compact/builder.rs
+++ b/crates/grafeo-core/src/graph/compact/builder.rs
@@ -1582,12 +1582,12 @@ mod tests {
         assert_eq!(ids.len(), 2);
         let mut temps: Vec<i64> = ids
             .iter()
-            .filter_map(|&id| {
-                match compact.get_node_property(id, &PropertyKey::new("temp")) {
+            .filter_map(
+                |&id| match compact.get_node_property(id, &PropertyKey::new("temp")) {
                     Some(Value::Int64(n)) => Some(n),
                     _ => None,
-                }
-            })
+                },
+            )
             .collect();
         temps.sort_unstable();
         assert_eq!(temps, vec![-10, 5]);

--- a/crates/grafeo-core/src/graph/compact/builder.rs
+++ b/crates/grafeo-core/src/graph/compact/builder.rs
@@ -582,6 +582,7 @@ fn infer_column_type(codec: &ColumnCodec) -> ColumnType {
         ColumnCodec::Float32Vector { dimensions, .. } => ColumnType::Float32Vector {
             dimensions: *dimensions,
         },
+        ColumnCodec::RawI64(_) => ColumnType::Int64,
     }
 }
 
@@ -608,6 +609,23 @@ fn compute_zone_map_u64(values: &[u64]) -> ZoneMap {
     ZoneMap {
         min: Some(Value::Int64(min as i64)),
         max: Some(Value::Int64(max as i64)),
+        null_count: 0,
+        row_count: values.len(),
+    }
+}
+
+/// Computes a zone map from signed i64 values (RawI64 column).
+///
+/// Produces `Value::Int64` min/max, which flows naturally into `compare_values`
+/// and yields correct signed ordering in predicate pushdown.
+fn compute_zone_map_i64(values: &[i64]) -> ZoneMap {
+    let Some(&min) = values.iter().min() else {
+        return ZoneMap::new();
+    };
+    let max = *values.iter().max().expect("non-empty after min check");
+    ZoneMap {
+        min: Some(Value::Int64(min)),
+        max: Some(Value::Int64(max)),
         null_count: 0,
         row_count: values.len(),
     }
@@ -653,6 +671,11 @@ fn compute_zone_map_bool(values: &[bool]) -> ZoneMap {
 enum InferredType {
     /// All non-null values are `Value::Int64` with value >= 0.
     BitPacked,
+    /// All non-null values are `Value::Int64`, with at least one negative.
+    /// Uses the `ColumnCodec::RawI64` encoding so signed ordering works in
+    /// `find_eq`, `find_in_range`, and zone-map comparisons, and the
+    /// `Int64` type is preserved on decode.
+    RawI64,
     /// All non-null values are `Value::Float64`, or mixed `Int64`+`Float64`.
     Float64,
     /// All non-null values are `Value::Bool`.
@@ -796,6 +819,20 @@ pub fn from_graph_store(
                         t.zone_maps.push((key.clone(), zone_map));
                         t.columns.push((key.clone(), ColumnCodec::BitPacked(bp)));
                         t.record_len(u64_values.len());
+                    }
+                    InferredType::RawI64 => {
+                        let i64_values: Vec<i64> = values
+                            .iter()
+                            .map(|v| match v {
+                                Value::Int64(n) => *n,
+                                _ => 0,
+                            })
+                            .collect();
+                        let zone_map = compute_zone_map_i64(&i64_values);
+                        t.zone_maps.push((key.clone(), zone_map));
+                        t.columns
+                            .push((key.clone(), ColumnCodec::RawI64(i64_values.clone())));
+                        t.record_len(i64_values.len());
                     }
                     InferredType::Float64 => {
                         let f64_values: Vec<f64> = values
@@ -952,6 +989,17 @@ pub fn from_graph_store(
                                     .collect();
                                 let bp = BitPackedInts::pack(&u64_values);
                                 r.properties.push((key.clone(), ColumnCodec::BitPacked(bp)));
+                            }
+                            InferredType::RawI64 => {
+                                let i64_values: Vec<i64> = values
+                                    .iter()
+                                    .map(|v| match v {
+                                        Value::Int64(n) => *n,
+                                        _ => 0,
+                                    })
+                                    .collect();
+                                r.properties
+                                    .push((key.clone(), ColumnCodec::RawI64(i64_values)));
                             }
                             InferredType::Float64 => {
                                 let f64_values: Vec<f64> = values
@@ -1177,7 +1225,8 @@ pub fn from_graph_store_preserving_ids(
 /// - If all non-null values are `Bool`, returns `Bitmap`.
 /// - Otherwise returns `Dict` (string fallback).
 fn infer_type_from_values(values: &[Value]) -> InferredType {
-    let mut saw_int = false;
+    let mut saw_unsigned_int = false; // Value::Int64 with n >= 0
+    let mut saw_signed_int = false; // Value::Int64 with n < 0
     let mut saw_float = false;
     let mut saw_bool = false;
     let mut saw_vector = false;
@@ -1187,7 +1236,8 @@ fn infer_type_from_values(values: &[Value]) -> InferredType {
     for v in values {
         match v {
             Value::Null => {} // skip nulls
-            Value::Int64(n) if *n >= 0 => saw_int = true,
+            Value::Int64(n) if *n >= 0 => saw_unsigned_int = true,
+            Value::Int64(_) => saw_signed_int = true,
             Value::Float64(_) => saw_float = true,
             Value::Bool(_) => saw_bool = true,
             Value::Vector(vec) => {
@@ -1208,13 +1258,15 @@ fn infer_type_from_values(values: &[Value]) -> InferredType {
         }
     }
 
+    let saw_any_int = saw_unsigned_int || saw_signed_int;
+
     // Vectors are exclusive; mixed with other types falls back to Dict.
     // Zero-dimension vectors cannot be round-tripped through the Float32Vector
     // codec (stride=0 means no row can be decoded), so those fall back to Dict
     // as well.
     if saw_vector
         && !saw_other
-        && !saw_int
+        && !saw_any_int
         && !saw_float
         && !saw_bool
         && let Some(dims) = vector_dims
@@ -1225,11 +1277,16 @@ fn infer_type_from_values(values: &[Value]) -> InferredType {
 
     // Mixed Int64+Float64 coalesces to Float64.
     // Vectors mixed with any other type fall back to Dict.
-    if saw_other || saw_vector || ((saw_int || saw_float) && saw_bool) {
+    if saw_other || saw_vector || (saw_any_int && saw_bool) || (saw_float && saw_bool) {
         InferredType::Dict
     } else if saw_float {
         InferredType::Float64
-    } else if saw_int {
+    } else if saw_signed_int {
+        // Any negative value routes the whole column to RawI64, which uses
+        // native i64 ordering. Non-negative-only columns still use the
+        // more compact BitPacked encoding.
+        InferredType::RawI64
+    } else if saw_unsigned_int {
         InferredType::BitPacked
     } else if saw_bool {
         InferredType::Bitmap
@@ -1505,7 +1562,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_graph_store_negative_int_falls_back_to_dict() {
+    fn test_from_graph_store_negative_int_preserves_int64_type() {
         use crate::graph::lpg::LpgStore;
 
         let store = LpgStore::new().unwrap();
@@ -1518,19 +1575,22 @@ mod tests {
 
         let compact = from_graph_store(&store).unwrap();
 
-        // Negative Int64 falls back to Dict encoding (serialized as string).
+        // Signed Int64 columns round-trip as Value::Int64 via the RawI64 codec.
+        // Prior behaviour (<=0.5.40) stringified them into a Dict column,
+        // breaking WHERE matches and promoting sum() to Float64.
         let ids = compact.nodes_by_label("Item");
         assert_eq!(ids.len(), 2);
-        let mut temps: Vec<String> = ids
+        let mut temps: Vec<i64> = ids
             .iter()
             .filter_map(|&id| {
-                compact
-                    .get_node_property(id, &PropertyKey::new("temp"))
-                    .and_then(|v| v.as_str().map(|s| s.to_string()))
+                match compact.get_node_property(id, &PropertyKey::new("temp")) {
+                    Some(Value::Int64(n)) => Some(n),
+                    _ => None,
+                }
             })
             .collect();
-        temps.sort();
-        assert_eq!(temps, vec!["-10", "5"]);
+        temps.sort_unstable();
+        assert_eq!(temps, vec![-10, 5]);
     }
 
     #[test]
@@ -1716,9 +1776,21 @@ mod tests {
 
     #[test]
     fn test_infer_type_negative_int() {
+        // Any negative Int64 routes the whole column to RawI64 (prior
+        // behaviour fell back to Dict, which broke type round-trip and
+        // ordered operations).
         assert_eq!(
             infer_type_from_values(&[Value::Int64(-5), Value::Int64(10)]),
-            InferredType::Dict
+            InferredType::RawI64
+        );
+        assert_eq!(
+            infer_type_from_values(&[Value::Int64(-5)]),
+            InferredType::RawI64
+        );
+        // Non-negative-only columns still use BitPacked for compression.
+        assert_eq!(
+            infer_type_from_values(&[Value::Int64(5), Value::Int64(10)]),
+            InferredType::BitPacked
         );
     }
 

--- a/crates/grafeo-core/src/graph/compact/builder.rs
+++ b/crates/grafeo-core/src/graph/compact/builder.rs
@@ -831,8 +831,8 @@ pub fn from_graph_store(
                         let zone_map = compute_zone_map_i64(&i64_values);
                         t.zone_maps.push((key.clone(), zone_map));
                         t.columns
-                            .push((key.clone(), ColumnCodec::RawI64(i64_values.clone())));
-                        t.record_len(i64_values.len());
+                            .push((key.clone(), ColumnCodec::RawI64(i64_values)));
+                        t.record_len(values.len());
                     }
                     InferredType::Float64 => {
                         let f64_values: Vec<f64> = values

--- a/crates/grafeo-core/src/graph/compact/column.rs
+++ b/crates/grafeo-core/src/graph/compact/column.rs
@@ -21,6 +21,9 @@ use crate::codec::{BitPackedInts, BitVector, DictionaryEncoding};
 #[non_exhaustive]
 pub enum ColumnCodec {
     /// Fixed-width bit-packed unsigned integers.
+    ///
+    /// Used for `Value::Int64` columns whose values are all `>= 0`. Preserves
+    /// the `Int64` type on decode via `v as i64`.
     BitPacked(BitPackedInts),
     /// Dictionary-encoded strings.
     Dict(DictionaryEncoding),
@@ -42,6 +45,14 @@ pub enum ColumnCodec {
         /// Number of dimensions per vector.
         dimensions: u16,
     },
+    /// Native signed 64-bit integers.
+    ///
+    /// Used for `Value::Int64` columns when at least one value is negative.
+    /// `BitPacked` can't represent negatives correctly in its ordered
+    /// operations (`find_eq`, `find_in_range`, zone maps) because it operates
+    /// on `u64`; `RawI64` stores the values natively to preserve both the
+    /// GQL type and signed ordering semantics on round-trip.
+    RawI64(Vec<i64>),
 }
 
 impl ColumnCodec {
@@ -52,6 +63,7 @@ impl ColumnCodec {
     /// - [`Bitmap`](Self::Bitmap) → `Value::Bool(b)`
     /// - [`Int8Vector`](Self::Int8Vector) → `Value::List(...)` of `Int64` values
     /// - [`Float64`](Self::Float64) → `Value::Float64(f)`
+    /// - [`RawI64`](Self::RawI64) → `Value::Int64(n)`
     ///
     /// Returns `None` when `index` is out of bounds.
     #[inline]
@@ -85,6 +97,7 @@ impl ColumnCodec {
                 Some(Value::List(Arc::from(values)))
             }
             Self::Float64(vec) => vec.get(index).copied().map(Value::Float64),
+            Self::RawI64(vec) => vec.get(index).copied().map(Value::Int64),
             Self::Float32Vector { data, dimensions } => {
                 let dims = *dimensions as usize;
                 if dims == 0 {
@@ -152,6 +165,7 @@ impl ColumnCodec {
                 let dims = *dimensions as usize;
                 data.len().checked_div(dims).unwrap_or(0)
             }
+            Self::RawI64(vec) => vec.len(),
         }
     }
 
@@ -194,6 +208,12 @@ impl ColumnCodec {
                 .filter(|&i| bv.get(i) == Some(target_bool))
                 .collect(),
             (Self::Float64(vec), &Value::Float64(target)) => vec
+                .iter()
+                .enumerate()
+                .filter(|&(_, v)| *v == target)
+                .map(|(i, _)| i)
+                .collect(),
+            (Self::RawI64(vec), &Value::Int64(target)) => vec
                 .iter()
                 .enumerate()
                 .filter(|&(_, v)| *v == target)
@@ -252,6 +272,39 @@ impl ColumnCodec {
                         false
                     }
                 })
+                .collect();
+        }
+
+        if let Self::RawI64(values) = self {
+            // Native i64 comparison — signed ordering semantics "for free".
+            let min_i64 = match min {
+                Some(&Value::Int64(v)) => Some(v),
+                None => None,
+                _ => return self.find_in_range_fallback(min, max, min_inclusive, max_inclusive),
+            };
+            let max_i64 = match max {
+                Some(&Value::Int64(v)) => Some(v),
+                None => None,
+                _ => return self.find_in_range_fallback(min, max, min_inclusive, max_inclusive),
+            };
+
+            return values
+                .iter()
+                .enumerate()
+                .filter(|&(_, &v)| {
+                    let above_min = match min_i64 {
+                        Some(lo) if min_inclusive => v >= lo,
+                        Some(lo) => v > lo,
+                        None => true,
+                    };
+                    let below_max = match max_i64 {
+                        Some(hi) if max_inclusive => v <= hi,
+                        Some(hi) => v < hi,
+                        None => true,
+                    };
+                    above_min && below_max
+                })
+                .map(|(i, _)| i)
                 .collect();
         }
 
@@ -355,6 +408,13 @@ impl ColumnCodec {
                 buf.extend_from_slice(&dimensions.to_le_bytes());
                 write_usize_as_u32(buf, data.len());
                 for &v in data {
+                    buf.extend_from_slice(&v.to_le_bytes());
+                }
+            }
+            Self::RawI64(vec) => {
+                buf.push(6); // discriminant
+                write_usize_as_u32(buf, vec.len());
+                for &v in vec {
                     buf.extend_from_slice(&v.to_le_bytes());
                 }
             }
@@ -465,6 +525,15 @@ impl ColumnCodec {
                     dimensions,
                 })
             }
+            6 => {
+                // RawI64
+                let count = read_u32_le(data, pos)? as usize;
+                let mut vec = Vec::with_capacity(count);
+                for _ in 0..count {
+                    vec.push(read_i64_le(data, pos)?);
+                }
+                Ok(Self::RawI64(vec))
+            }
             _ => Err("unknown codec discriminant"),
         }
     }
@@ -483,6 +552,7 @@ impl ColumnCodec {
             Self::Int8Vector { data, .. } => data.len(),
             Self::Float64(vec) => vec.len() * std::mem::size_of::<f64>(),
             Self::Float32Vector { data, .. } => data.len() * std::mem::size_of::<f32>(),
+            Self::RawI64(vec) => vec.len() * std::mem::size_of::<i64>(),
         }
     }
 }
@@ -527,6 +597,15 @@ fn read_f64_le(data: &[u8], pos: &mut usize) -> Result<f64, &'static str> {
         return Err("truncated f64");
     }
     let v = f64::from_le_bytes(data[*pos..*pos + 8].try_into().unwrap());
+    *pos += 8;
+    Ok(v)
+}
+
+fn read_i64_le(data: &[u8], pos: &mut usize) -> Result<i64, &'static str> {
+    if *pos + 8 > data.len() {
+        return Err("truncated i64");
+    }
+    let v = i64::from_le_bytes(data[*pos..*pos + 8].try_into().unwrap());
     *pos += 8;
     Ok(v)
 }
@@ -1835,5 +1914,93 @@ mod tests {
         let mut pos = 0;
         let decoded = ColumnCodec::read_from(&buf, &mut pos).expect("decode should succeed");
         assert_eq!(decoded.len(), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // RawI64 tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_raw_i64_get_decodes_as_int64() {
+        let col = ColumnCodec::RawI64(vec![-100, 0, 42, i64::MIN, i64::MAX]);
+        assert_eq!(col.len(), 5);
+        assert_eq!(col.get(0), Some(Value::Int64(-100)));
+        assert_eq!(col.get(1), Some(Value::Int64(0)));
+        assert_eq!(col.get(2), Some(Value::Int64(42)));
+        assert_eq!(col.get(3), Some(Value::Int64(i64::MIN)));
+        assert_eq!(col.get(4), Some(Value::Int64(i64::MAX)));
+        assert_eq!(col.get(5), None);
+    }
+
+    #[test]
+    fn test_raw_i64_find_eq() {
+        let col = ColumnCodec::RawI64(vec![-50, 10, -50, 20, 0, -50]);
+        assert_eq!(col.find_eq(&Value::Int64(-50)), vec![0, 2, 5]);
+        assert_eq!(col.find_eq(&Value::Int64(10)), vec![1]);
+        assert_eq!(col.find_eq(&Value::Int64(0)), vec![4]);
+        assert_eq!(col.find_eq(&Value::Int64(999)), Vec::<usize>::new());
+        // Cross-type matches are not supported: a Float64 target should
+        // not match any i64 row via the fast path. Fallback may coerce,
+        // but for now the equality predicate is type-strict.
+        assert_eq!(col.find_eq(&Value::Float64(10.0)), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn test_raw_i64_find_in_range_signed_ordering() {
+        // Values span the sign boundary; native i64 ordering must apply.
+        let col = ColumnCodec::RawI64(vec![-10, -5, 0, 5, 10, -100, 100]);
+
+        // [-5, 5] inclusive
+        let result =
+            col.find_in_range(Some(&Value::Int64(-5)), Some(&Value::Int64(5)), true, true);
+        assert_eq!(result, vec![1, 2, 3]);
+
+        // (-5, 5) exclusive
+        let result =
+            col.find_in_range(Some(&Value::Int64(-5)), Some(&Value::Int64(5)), false, false);
+        assert_eq!(result, vec![2]);
+
+        // < 0 (no lower bound)
+        let result = col.find_in_range(None, Some(&Value::Int64(0)), false, false);
+        assert_eq!(result, vec![0, 1, 5]);
+
+        // >= 10 (no upper bound)
+        let result = col.find_in_range(Some(&Value::Int64(10)), None, true, true);
+        assert_eq!(result, vec![4, 6]);
+    }
+
+    #[test]
+    fn test_write_to_read_from_raw_i64_round_trip() {
+        let col = ColumnCodec::RawI64(vec![-42, 0, 1, i64::MIN, i64::MAX, -1_000_000_000]);
+
+        let mut buf = Vec::new();
+        col.write_to(&mut buf);
+
+        let mut pos = 0;
+        let decoded = ColumnCodec::read_from(&buf, &mut pos).expect("decode should succeed");
+        assert_eq!(pos, buf.len());
+        assert_eq!(decoded.len(), col.len());
+        for i in 0..col.len() {
+            assert_eq!(decoded.get(i), col.get(i));
+        }
+    }
+
+    #[test]
+    fn test_write_to_read_from_empty_raw_i64() {
+        let col = ColumnCodec::RawI64(Vec::new());
+        let mut buf = Vec::new();
+        col.write_to(&mut buf);
+        let mut pos = 0;
+        let decoded = ColumnCodec::read_from(&buf, &mut pos).expect("decode should succeed");
+        assert_eq!(decoded.len(), 0);
+    }
+
+    #[test]
+    fn test_raw_i64_heap_bytes() {
+        let col = ColumnCodec::RawI64(vec![-1, 2, -3]);
+        assert_eq!(col.heap_bytes(), 3 * std::mem::size_of::<i64>());
+
+        let empty = ColumnCodec::RawI64(Vec::new());
+        assert_eq!(empty.heap_bytes(), 0);
     }
 }

--- a/crates/grafeo-core/src/graph/compact/column.rs
+++ b/crates/grafeo-core/src/graph/compact/column.rs
@@ -1951,13 +1951,16 @@ mod tests {
         let col = ColumnCodec::RawI64(vec![-10, -5, 0, 5, 10, -100, 100]);
 
         // [-5, 5] inclusive
-        let result =
-            col.find_in_range(Some(&Value::Int64(-5)), Some(&Value::Int64(5)), true, true);
+        let result = col.find_in_range(Some(&Value::Int64(-5)), Some(&Value::Int64(5)), true, true);
         assert_eq!(result, vec![1, 2, 3]);
 
         // (-5, 5) exclusive
-        let result =
-            col.find_in_range(Some(&Value::Int64(-5)), Some(&Value::Int64(5)), false, false);
+        let result = col.find_in_range(
+            Some(&Value::Int64(-5)),
+            Some(&Value::Int64(5)),
+            false,
+            false,
+        );
         assert_eq!(result, vec![2]);
 
         // < 0 (no lower bound)

--- a/crates/grafeo-core/src/graph/compact/schema.rs
+++ b/crates/grafeo-core/src/graph/compact/schema.rs
@@ -34,6 +34,12 @@ pub enum ColumnType {
         /// Number of dimensions in each vector.
         dimensions: u16,
     },
+    /// Native 64-bit signed integer column (no bit-packing; used when at
+    /// least one value is negative). See [`ColumnCodec::RawI64`] for the
+    /// storage layout.
+    ///
+    /// [`ColumnCodec::RawI64`]: super::column::ColumnCodec::RawI64
+    Int64,
 }
 
 /// A single column within a table schema.

--- a/crates/grafeo-core/src/graph/compact/section.rs
+++ b/crates/grafeo-core/src/graph/compact/section.rs
@@ -555,6 +555,7 @@ fn infer_column_type_from_codec(codec: &ColumnCodec) -> ColumnType {
         ColumnCodec::Float32Vector { dimensions, .. } => ColumnType::Float32Vector {
             dimensions: *dimensions,
         },
+        ColumnCodec::RawI64(_) => ColumnType::Int64,
     }
 }
 

--- a/crates/grafeo-engine/tests/post_compact_numeric_content.rs
+++ b/crates/grafeo-engine/tests/post_compact_numeric_content.rs
@@ -124,7 +124,10 @@ fn where_range_matches_across_zero() {
 
     // Signed range semantics — -100 ≤ val < 0 must include exactly -100, -10, -5.
     assert_eq!(
-        row_count(&db, "MATCH (n:A) WHERE n.val >= -100 AND n.val < 0 RETURN n"),
+        row_count(
+            &db,
+            "MATCH (n:A) WHERE n.val >= -100 AND n.val < 0 RETURN n"
+        ),
         3
     );
     // -5 ≤ val ≤ 5 must include -5, 0, 5.
@@ -155,7 +158,15 @@ fn per_label_sum_preserves_int64_across_compact() {
     let post_b = scalar(&db, "MATCH (n:B) RETURN sum(n.num)");
 
     assert_eq!(pre_a, Value::Int64(20));
-    assert_eq!(post_a, Value::Int64(20), "A column has mixed signs (RawI64)");
+    assert_eq!(
+        post_a,
+        Value::Int64(20),
+        "A column has mixed signs (RawI64)"
+    );
     assert_eq!(pre_b, Value::Int64(3));
-    assert_eq!(post_b, Value::Int64(3), "B column is non-negative (BitPacked)");
+    assert_eq!(
+        post_b,
+        Value::Int64(3),
+        "B column is non-negative (BitPacked)"
+    );
 }

--- a/crates/grafeo-engine/tests/post_compact_numeric_content.rs
+++ b/crates/grafeo-engine/tests/post_compact_numeric_content.rs
@@ -1,0 +1,161 @@
+//! Regression tests for `Int64` round-trip through `GrafeoDB::compact()`.
+//!
+//! Pre-fix behaviour: any `Value::Int64` column containing at least one
+//! negative value was routed by `infer_type_from_values` to
+//! `InferredType::Dict`, which stringified each value for storage and
+//! decoded it back as `Value::String`. `WHERE n.num = 100` never matched
+//! post-compact (comparing `Int64` to `String`), and `sum(n.num)`
+//! returned `Float64` because the aggregate operator's `SumInt` state
+//! parsed the strings and transitioned to `SumFloat`.
+//!
+//! The `ColumnCodec::RawI64` variant introduced in this PR stores
+//! signed integers natively, preserving both the GQL type and signed
+//! ordering semantics across compaction.
+//!
+//! Tracked upstream as GrafeoDB/grafeo#301.
+//!
+//! ```bash
+//! cargo test -p grafeo-engine --features "compact-store lpg gql" \
+//!     --test post_compact_numeric_content
+//! ```
+
+#![cfg(all(feature = "compact-store", feature = "lpg", feature = "gql"))]
+
+use grafeo_common::types::Value;
+use grafeo_engine::GrafeoDB;
+
+fn scalar(db: &GrafeoDB, q: &str) -> Value {
+    let s = db.session();
+    s.execute(q).unwrap().rows()[0][0].clone()
+}
+
+fn row_count(db: &GrafeoDB, q: &str) -> usize {
+    let s = db.session();
+    s.execute(q).unwrap().rows().len()
+}
+
+// ── Type round-trip ─────────────────────────────────────────────
+
+#[test]
+fn positive_only_sum_returns_int64() {
+    // Unchanged from pre-fix behaviour: all-non-negative columns already
+    // went through BitPacked and round-tripped correctly. Guards against
+    // regressions from the RawI64 wiring.
+    let mut db = GrafeoDB::new_in_memory();
+    let a = db.create_node(&["A"]);
+    let b = db.create_node(&["A"]);
+    db.set_node_property(a, "num", Value::Int64(100));
+    db.set_node_property(b, "num", Value::Int64(200));
+
+    let pre = scalar(&db, "MATCH (n) RETURN sum(n.num)");
+    db.compact().unwrap();
+    let post = scalar(&db, "MATCH (n) RETURN sum(n.num)");
+
+    assert_eq!(pre, Value::Int64(300));
+    assert_eq!(post, Value::Int64(300), "pos-only column must stay Int64");
+    assert_eq!(pre, post);
+}
+
+#[test]
+fn mixed_signs_sum_returns_int64() {
+    // The diagnostic case from GrafeoDB/grafeo#301. Pre-fix this returned
+    // Float64(50.0) post-compact.
+    let mut db = GrafeoDB::new_in_memory();
+    let a = db.create_node(&["A"]);
+    let b = db.create_node(&["A"]);
+    db.set_node_property(a, "num", Value::Int64(100));
+    db.set_node_property(b, "num", Value::Int64(-50));
+
+    let pre = scalar(&db, "MATCH (n) RETURN sum(n.num)");
+    db.compact().unwrap();
+    let post = scalar(&db, "MATCH (n) RETURN sum(n.num)");
+
+    assert_eq!(pre, Value::Int64(50));
+    assert_eq!(post, Value::Int64(50), "mixed-sign column must stay Int64");
+    assert_eq!(pre, post);
+}
+
+#[test]
+fn i64_extremes_roundtrip() {
+    let mut db = GrafeoDB::new_in_memory();
+    for v in [i64::MIN + 1, -1, 0, 1, i64::MAX] {
+        let n = db.create_node(&["A"]);
+        db.set_node_property(n, "val", Value::Int64(v));
+    }
+    db.compact().unwrap();
+
+    // Each value survives as Int64; WHERE matches on specific values.
+    for v in [i64::MIN + 1, -1, 0, 1, i64::MAX] {
+        let q = format!("MATCH (n:A) WHERE n.val = {v} RETURN n.val");
+        let r = db.session().execute(&q).unwrap();
+        assert_eq!(r.rows().len(), 1, "WHERE n.val = {v}: expected 1 row");
+        assert_eq!(
+            r.rows()[0][0],
+            Value::Int64(v),
+            "decoded value for {v} should be Int64"
+        );
+    }
+}
+
+// ── WHERE filter ────────────────────────────────────────────────
+
+#[test]
+fn where_matches_negative_int() {
+    let mut db = GrafeoDB::new_in_memory();
+    let a = db.create_node(&["A"]);
+    let b = db.create_node(&["A"]);
+    db.set_node_property(a, "num", Value::Int64(42));
+    db.set_node_property(b, "num", Value::Int64(-17));
+    db.compact().unwrap();
+
+    assert_eq!(row_count(&db, "MATCH (n:A) WHERE n.num = 42 RETURN n"), 1);
+    assert_eq!(row_count(&db, "MATCH (n:A) WHERE n.num = -17 RETURN n"), 1);
+    assert_eq!(row_count(&db, "MATCH (n:A) WHERE n.num = 99 RETURN n"), 0);
+}
+
+#[test]
+fn where_range_matches_across_zero() {
+    let mut db = GrafeoDB::new_in_memory();
+    for v in [-10i64, -5, 0, 5, 10, -100, 100] {
+        let n = db.create_node(&["A"]);
+        db.set_node_property(n, "val", Value::Int64(v));
+    }
+    db.compact().unwrap();
+
+    // Signed range semantics — -100 ≤ val < 0 must include exactly -100, -10, -5.
+    assert_eq!(
+        row_count(&db, "MATCH (n:A) WHERE n.val >= -100 AND n.val < 0 RETURN n"),
+        3
+    );
+    // -5 ≤ val ≤ 5 must include -5, 0, 5.
+    assert_eq!(
+        row_count(&db, "MATCH (n:A) WHERE n.val >= -5 AND n.val <= 5 RETURN n"),
+        3
+    );
+}
+
+// ── Per-label content parity ────────────────────────────────────
+
+#[test]
+fn per_label_sum_preserves_int64_across_compact() {
+    let mut db = GrafeoDB::new_in_memory();
+    for v in [10, -20, 30] {
+        let n = db.create_node(&["A"]);
+        db.set_node_property(n, "num", Value::Int64(v));
+    }
+    for v in [1, 2] {
+        let n = db.create_node(&["B"]);
+        db.set_node_property(n, "num", Value::Int64(v));
+    }
+
+    let pre_a = scalar(&db, "MATCH (n:A) RETURN sum(n.num)");
+    let pre_b = scalar(&db, "MATCH (n:B) RETURN sum(n.num)");
+    db.compact().unwrap();
+    let post_a = scalar(&db, "MATCH (n:A) RETURN sum(n.num)");
+    let post_b = scalar(&db, "MATCH (n:B) RETURN sum(n.num)");
+
+    assert_eq!(pre_a, Value::Int64(20));
+    assert_eq!(post_a, Value::Int64(20), "A column has mixed signs (RawI64)");
+    assert_eq!(pre_b, Value::Int64(3));
+    assert_eq!(post_b, Value::Int64(3), "B column is non-negative (BitPacked)");
+}


### PR DESCRIPTION
Closes #301.

## The bug

Any \`Value::Int64\` column containing at least one negative value was routed by \`infer_type_from_values\` to \`InferredType::Dict\`, which stringified each value via \`format!(\"{n}\")\` for storage and decoded it back as \`Value::String\`. Two downstream consequences:

1. \`MATCH (n:A) WHERE n.num = 100\` returned 0 rows after \`compact()\` because it compared \`Value::Int64(100)\` against \`Value::String(\"100\")\`.
2. \`sum(n.num)\` returned \`Value::Float64(n)\` instead of \`Value::Int64(n)\` because the aggregate operator's \`SumInt\` state saw strings, fell through to \`value_to_f64\`, and transitioned to \`SumFloat\`.

Positive-only columns were unaffected. Simply removing the \`>= 0\` guard is not a sound fix — \`BitPacked\` treats stored values as \`u64\` for ordered operations, so signed values reinterpreted as \`u64\` sort with the sign bit in the MSB, inverting ordering semantics.

## The fix

New \`ColumnCodec::RawI64(Vec<i64>)\` variant that stores signed integers natively. Type inference now routes:

- all-non-negative \`Int64\` → \`BitPacked\` (unchanged; preserves compression)
- at-least-one-negative \`Int64\` (and no other types) → **\`RawI64\`** (new)
- mixed \`Int64\` + \`Float64\` → \`Float64\` (unchanged)

\`RawI64\` supports native i64 comparison in \`find_eq\` and \`find_in_range\`, produces a meaningful \`Value::Int64\` min/max zone map via a new \`compute_zone_map_i64\` helper, and decodes cleanly to \`Value::Int64(n)\`.

## On-disk format

Serialization uses discriminant 6 on \`ColumnCodec\` (next after \`Float32Vector=5\`); \`ColumnType::Int64\` is added as the schema-level pair. \`#[non_exhaustive]\` on both enums keeps the addition API-compatible at the Rust level, but **databases written after this change can contain columns that prior versions will reject with \"unknown codec discriminant\"**. One-way format break in line with the 0.5.35 precedent.

## Tests for the fix

Ships a deterministic regression suite at \`crates/grafeo-engine/tests/post_compact_numeric_content.rs\`:

1. \`positive_only_sum_returns_int64\` — guards against regression from RawI64 wiring
2. \`mixed_signs_sum_returns_int64\` — the diagnostic case from #301
3. \`i64_extremes_roundtrip\` — \`i64::MIN+1\`, -1, 0, 1, \`i64::MAX\` each survive as \`Int64\` with \`WHERE\` matching
4. \`where_matches_negative_int\`
5. \`where_range_matches_across_zero\` — signed range semantics
6. \`per_label_sum_preserves_int64_across_compact\` — mixed-sign A column uses RawI64, non-negative B column uses BitPacked, both round-trip

Plus new \`RawI64\` unit tests in \`column.rs\`: decode, \`find_eq\`, \`find_in_range\` with signed ordering, serialize round-trip (including \`i64::MIN\`/\`i64::MAX\`), empty column, \`heap_bytes\`.

## Verified

- 6/6 new \`post_compact_numeric_content\` tests pass
- new \`RawI64\` unit tests (column.rs) all pass
- updated \`test_infer_type_negative_int\` + renamed \`test_from_graph_store_negative_int_falls_back_to_dict\` → \`test_from_graph_store_negative_int_preserves_int64_type\` (both now assert correct \`Int64\` round-trip)
- all **1955 grafeo-core lib tests** pass; all 13 grafeo-engine compact integration tests pass
- \`cargo clippy -p grafeo-core --features \"vector-index compact-store\" --lib -- -D warnings\` — clean

## Independence

- #303 is the property-based coverage PR for compact; it no longer XFAILs anything — each bug has its own self-contained fix PR.
- #307 fixes the sibling overlay-invisibility bug (#302). Both touch the compact-store path but the changes are disjoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)