### PR TITLE
fix(compact): post-compact writes visible to MATCH via LayeredStore

### DIFF
--- a/crates/grafeo-core/src/graph/compact/layered.rs
+++ b/crates/grafeo-core/src/graph/compact/layered.rs
@@ -170,7 +170,9 @@ impl GraphStore for LayeredStore {
         if self.is_edge_dirty(id) {
             return self.overlay.get_edge(id);
         }
-        self.base.get_edge(id)
+        // Edges created after `compact()` live only in the overlay; fall
+        // through when the base doesn't recognise the id.
+        self.base.get_edge(id).or_else(|| self.overlay.get_edge(id))
     }
 
     fn get_node_versioned(
@@ -185,7 +187,14 @@ impl GraphStore for LayeredStore {
         if self.is_node_dirty(id) {
             return self.overlay.get_node_versioned(id, epoch, transaction_id);
         }
-        self.base.get_node(id)
+        // `dirty_node_ids` only tracks overlay modifications of *base* nodes.
+        // Overlay-only nodes (post-`compact()` writes) fall through to here;
+        // the base doesn't know them, so defer to the overlay's versioned
+        // fetch. CompactStore itself has no MVCC versions, so `get_node`
+        // is the right base call.
+        self.base
+            .get_node(id)
+            .or_else(|| self.overlay.get_node_versioned(id, epoch, transaction_id))
     }
 
     fn get_edge_versioned(
@@ -200,7 +209,9 @@ impl GraphStore for LayeredStore {
         if self.is_edge_dirty(id) {
             return self.overlay.get_edge_versioned(id, epoch, transaction_id);
         }
-        self.base.get_edge(id)
+        self.base
+            .get_edge(id)
+            .or_else(|| self.overlay.get_edge_versioned(id, epoch, transaction_id))
     }
 
     fn get_node_at_epoch(&self, id: NodeId, epoch: EpochId) -> Option<Node> {
@@ -210,7 +221,9 @@ impl GraphStore for LayeredStore {
         if self.is_node_dirty(id) {
             return self.overlay.get_node_at_epoch(id, epoch);
         }
-        self.base.get_node(id)
+        self.base
+            .get_node(id)
+            .or_else(|| self.overlay.get_node_at_epoch(id, epoch))
     }
 
     fn get_edge_at_epoch(&self, id: EdgeId, epoch: EpochId) -> Option<Edge> {
@@ -220,7 +233,9 @@ impl GraphStore for LayeredStore {
         if self.is_edge_dirty(id) {
             return self.overlay.get_edge_at_epoch(id, epoch);
         }
-        self.base.get_edge(id)
+        self.base
+            .get_edge(id)
+            .or_else(|| self.overlay.get_edge_at_epoch(id, epoch))
     }
 
     fn get_node_property(&self, id: NodeId, key: &PropertyKey) -> Option<Value> {
@@ -242,7 +257,9 @@ impl GraphStore for LayeredStore {
         if self.is_edge_dirty(id) {
             return self.overlay.get_edge_property(id, key);
         }
-        self.base.get_edge_property(id, key)
+        self.base
+            .get_edge_property(id, key)
+            .or_else(|| self.overlay.get_edge_property(id, key))
     }
 
     fn get_node_property_batch(&self, ids: &[NodeId], key: &PropertyKey) -> Vec<Option<Value>> {
@@ -316,18 +333,16 @@ impl GraphStore for LayeredStore {
             }
         }
 
-        // Overlay neighbors (for dirty source node or overlay-only node).
-        if self.is_node_dirty(node) || self.overlay.get_node(node).is_some() {
-            for nid in self.overlay.neighbors(node, direction) {
-                if !deleted_nodes.contains(&nid) {
-                    results.push(nid);
-                }
+        // Overlay neighbors — always consulted. An edge created after
+        // `compact()` whose src is a base node records the base id in
+        // the overlay's adjacency even though the overlay has no
+        // corresponding node object; gating on `overlay.get_node(node)`
+        // would miss that case.
+        for nid in self.overlay.neighbors(node, direction) {
+            if !deleted_nodes.contains(&nid) {
+                results.push(nid);
             }
         }
-
-        // Overlay edges that connect base nodes.
-        // If node is in the base and the overlay has edges for it
-        // (e.g., after promote), those are already in dirty.
 
         results.sort_unstable();
         results.dedup();
@@ -349,14 +364,22 @@ impl GraphStore for LayeredStore {
             }
         }
 
-        // Overlay edges.
-        if self.is_node_dirty(node) || self.overlay.get_node(node).is_some() {
-            for (target, eid) in self.overlay.edges_from(node, direction) {
-                if !deleted_nodes.contains(&target) && !deleted_edges.contains(&eid) {
-                    results.push((target, eid));
-                }
+        // Overlay edges — always consulted. The overlay stores edges
+        // keyed by src/dst even when the endpoint is a base node (e.g. a
+        // post-`compact()` edge from a base node to an overlay node), so
+        // we can't gate this on whether the overlay has the node itself.
+        // `LpgStore::edges_from` returns empty for ids with no outgoing
+        // edges, so the unconditional call is cheap when there's nothing
+        // to report.
+        for (target, eid) in self.overlay.edges_from(node, direction) {
+            if !deleted_nodes.contains(&target) && !deleted_edges.contains(&eid) {
+                results.push((target, eid));
             }
         }
+
+        // Deduplicate in case a promoted edge appears in both layers.
+        results.sort_unstable_by_key(|&(_, eid)| eid);
+        results.dedup_by_key(|&mut (_, eid)| eid);
 
         results
     }
@@ -444,7 +467,9 @@ impl GraphStore for LayeredStore {
         if self.is_edge_dirty(id) {
             return self.overlay.edge_type(id);
         }
-        self.base.edge_type(id)
+        self.base
+            .edge_type(id)
+            .or_else(|| self.overlay.edge_type(id))
     }
 
     fn find_nodes_by_property(&self, property: &str, value: &Value) -> Vec<NodeId> {
@@ -598,7 +623,15 @@ impl GraphStore for LayeredStore {
         if self.is_node_dirty(id) {
             return self.overlay.is_node_visible_at_epoch(id, epoch);
         }
-        self.base.is_node_visible_at_epoch(id, epoch)
+        // `dirty_node_ids` only tracks overlay *modifications of base nodes*
+        // — overlay-only nodes (e.g. post-`compact()` writes) fall through
+        // here and must be dispatched to the overlay's MVCC check. The base
+        // doesn't know the id, so it would otherwise report them invisible.
+        if self.base.get_node(id).is_some() {
+            self.base.is_node_visible_at_epoch(id, epoch)
+        } else {
+            self.overlay.is_node_visible_at_epoch(id, epoch)
+        }
     }
 
     fn is_node_visible_versioned(
@@ -615,8 +648,13 @@ impl GraphStore for LayeredStore {
                 .overlay
                 .is_node_visible_versioned(id, epoch, transaction_id);
         }
-        self.base
-            .is_node_visible_versioned(id, epoch, transaction_id)
+        if self.base.get_node(id).is_some() {
+            self.base
+                .is_node_visible_versioned(id, epoch, transaction_id)
+        } else {
+            self.overlay
+                .is_node_visible_versioned(id, epoch, transaction_id)
+        }
     }
 
     fn is_edge_visible_at_epoch(&self, id: EdgeId, epoch: EpochId) -> bool {
@@ -626,7 +664,11 @@ impl GraphStore for LayeredStore {
         if self.is_edge_dirty(id) {
             return self.overlay.is_edge_visible_at_epoch(id, epoch);
         }
-        self.base.is_edge_visible_at_epoch(id, epoch)
+        if self.base.get_edge(id).is_some() {
+            self.base.is_edge_visible_at_epoch(id, epoch)
+        } else {
+            self.overlay.is_edge_visible_at_epoch(id, epoch)
+        }
     }
 
     fn is_edge_visible_versioned(
@@ -643,8 +685,13 @@ impl GraphStore for LayeredStore {
                 .overlay
                 .is_edge_visible_versioned(id, epoch, transaction_id);
         }
-        self.base
-            .is_edge_visible_versioned(id, epoch, transaction_id)
+        if self.base.get_edge(id).is_some() {
+            self.base
+                .is_edge_visible_versioned(id, epoch, transaction_id)
+        } else {
+            self.overlay
+                .is_edge_visible_versioned(id, epoch, transaction_id)
+        }
     }
 
     fn filter_visible_node_ids(&self, ids: &[NodeId], epoch: EpochId) -> Vec<NodeId> {

--- a/crates/grafeo-engine/tests/post_compact_overlay_visibility.rs
+++ b/crates/grafeo-engine/tests/post_compact_overlay_visibility.rs
@@ -74,10 +74,7 @@ fn post_compact_edge_visible() {
     db.create_edge(c, d, "POST");
 
     assert_eq!(int_scalar(&db, "MATCH ()-[r]->() RETURN count(r)"), 2);
-    assert_eq!(
-        int_scalar(&db, "MATCH ()-[r:POST]->() RETURN count(r)"),
-        1
-    );
+    assert_eq!(int_scalar(&db, "MATCH ()-[r:POST]->() RETURN count(r)"), 1);
     assert_eq!(int_scalar(&db, "MATCH ()-[r:PRE]->() RETURN count(r)"), 1);
 }
 
@@ -107,9 +104,7 @@ fn post_compact_node_property_survives_reread() {
     db.set_node_property(n, "label", Value::String("hello".into()));
 
     let s = db.session();
-    let r = s
-        .execute("MATCH (n:Y) RETURN n.label")
-        .unwrap();
+    let r = s.execute("MATCH (n:Y) RETURN n.label").unwrap();
     assert_eq!(r.rows().len(), 1);
     assert_eq!(
         r.rows()[0][0],

--- a/crates/grafeo-engine/tests/post_compact_overlay_visibility.rs
+++ b/crates/grafeo-engine/tests/post_compact_overlay_visibility.rs
@@ -1,0 +1,119 @@
+//! Regression tests for writes performed after `GrafeoDB::compact()`
+//! remaining visible to subsequent GQL `MATCH` queries.
+//!
+//! Pre-fix behaviour: `LayeredStore::is_node_visible_at_epoch` (and its
+//! edge / versioned / epoch siblings) fell through to the base store's
+//! visibility check for any id not in `dirty_node_ids`. Overlay-only
+//! nodes (post-`compact()` writes) are not "dirty" in that sense —
+//! `dirty_node_ids` only tracks overlay modifications of base nodes —
+//! so the base was asked, didn't know the id, and returned false.
+//! Result: post-compact writes silently vanished from reads.
+//!
+//! Tracked upstream as GrafeoDB/grafeo#302.
+//!
+//! ```bash
+//! cargo test -p grafeo-engine --features "compact-store lpg gql" \
+//!     --test post_compact_overlay_visibility
+//! ```
+
+#![cfg(all(feature = "compact-store", feature = "lpg", feature = "gql"))]
+
+use grafeo_common::types::Value;
+use grafeo_engine::GrafeoDB;
+
+fn int_scalar(db: &GrafeoDB, q: &str) -> i64 {
+    let s = db.session();
+    match &s.execute(q).unwrap().rows()[0][0] {
+        Value::Int64(n) => *n,
+        other => panic!("expected Int64 for `{q}`, got {other:?}"),
+    }
+}
+
+fn row_count(db: &GrafeoDB, q: &str) -> usize {
+    let s = db.session();
+    s.execute(q).unwrap().rows().len()
+}
+
+#[test]
+fn node_created_after_compact_is_visible() {
+    let mut db = GrafeoDB::new_in_memory();
+    db.create_node(&["X"]);
+    db.compact().expect("compact");
+    db.create_node(&["Y"]);
+
+    assert_eq!(int_scalar(&db, "MATCH (n) RETURN count(n)"), 2);
+    assert_eq!(row_count(&db, "MATCH (n:Y) RETURN n"), 1);
+    assert_eq!(row_count(&db, "MATCH (n:X) RETURN n"), 1);
+}
+
+#[test]
+fn multiple_post_compact_nodes_visible() {
+    let mut db = GrafeoDB::new_in_memory();
+    db.create_node(&["Base"]);
+    db.compact().expect("compact");
+    for _ in 0..5 {
+        db.create_node(&["Overlay"]);
+    }
+
+    assert_eq!(int_scalar(&db, "MATCH (n) RETURN count(n)"), 6);
+    assert_eq!(int_scalar(&db, "MATCH (n:Overlay) RETURN count(n)"), 5);
+    assert_eq!(int_scalar(&db, "MATCH (n:Base) RETURN count(n)"), 1);
+}
+
+#[test]
+fn post_compact_edge_visible() {
+    let mut db = GrafeoDB::new_in_memory();
+    let a = db.create_node(&["A"]);
+    let b = db.create_node(&["B"]);
+    db.create_edge(a, b, "PRE");
+    db.compact().expect("compact");
+
+    // New nodes + edge entirely in the overlay.
+    let c = db.create_node(&["A"]);
+    let d = db.create_node(&["B"]);
+    db.create_edge(c, d, "POST");
+
+    assert_eq!(int_scalar(&db, "MATCH ()-[r]->() RETURN count(r)"), 2);
+    assert_eq!(
+        int_scalar(&db, "MATCH ()-[r:POST]->() RETURN count(r)"),
+        1
+    );
+    assert_eq!(int_scalar(&db, "MATCH ()-[r:PRE]->() RETURN count(r)"), 1);
+}
+
+#[test]
+fn post_compact_edge_between_base_and_overlay_nodes() {
+    let mut db = GrafeoDB::new_in_memory();
+    let base_a = db.create_node(&["A"]);
+    db.compact().expect("compact");
+    let overlay_b = db.create_node(&["B"]);
+    db.create_edge(base_a, overlay_b, "CROSS");
+
+    // The edge connects a base node to an overlay node — visibility has
+    // to work on both sides.
+    assert_eq!(int_scalar(&db, "MATCH ()-[r]->() RETURN count(r)"), 1);
+    assert_eq!(
+        row_count(&db, "MATCH (a:A)-[r:CROSS]->(b:B) RETURN a, r, b"),
+        1
+    );
+}
+
+#[test]
+fn post_compact_node_property_survives_reread() {
+    let mut db = GrafeoDB::new_in_memory();
+    db.create_node(&["X"]);
+    db.compact().expect("compact");
+    let n = db.create_node(&["Y"]);
+    db.set_node_property(n, "label", Value::String("hello".into()));
+
+    let s = db.session();
+    let r = s
+        .execute("MATCH (n:Y) RETURN n.label")
+        .unwrap();
+    assert_eq!(r.rows().len(), 1);
+    assert_eq!(
+        r.rows()[0][0],
+        Value::String("hello".into()),
+        "overlay-only node property should be readable"
+    );
+}


### PR DESCRIPTION
Closes #302.

## The bug

\`LayeredStore\`'s read path tried the base first and only consulted the overlay when a node/edge was flagged \"dirty\" (overlay modification of a base entity), or — for \`neighbors\`/\`edges_from\` — when \`overlay.get_node(node).is_some()\`. Neither condition holds for overlay-only entities (post-\`compact()\` writes landing in the fresh overlay LpgStore), so the base was asked, didn't recognise the id, and returned empty / false. \`compact()\`'s docstring promised \"writes go to the overlay\" and are visible; in practice they vanished.

Minimal reproducer from #302:

\`\`\`rust
let mut db = GrafeoDB::new_in_memory();
db.create_node(&[\"X\"]);
db.compact().unwrap();
db.create_node(&[\"Y\"]);
// MATCH (n) RETURN count(n)  -> was: Int64(1), now: Int64(2)
// MATCH (n:Y) RETURN n       -> was: 0 rows,  now: 1 row
\`\`\`

## The fix

Two independent patterns needed fixing:

**1. \`get_*\` / \`is_visible_*\` methods** — fell through to \`self.base.X(id)\` without an overlay fallback. For each, apply the same shape as the already-correct \`get_node\` and \`get_node_property\`: try the base, then fall back to the overlay. CompactStore base has no MVCC so the base call is the non-versioned \`get_node\`/\`get_edge\`; the overlay's versioned/epoch-aware method then carries the MVCC semantics. Affects: \`get_edge\`, \`get_node_versioned\`, \`get_edge_versioned\`, \`get_node_at_epoch\`, \`get_edge_at_epoch\`, \`get_edge_property\`, \`edge_type\`, \`is_node_visible_at_epoch\`, \`is_node_visible_versioned\`, \`is_edge_visible_at_epoch\`, \`is_edge_visible_versioned\`.

**2. \`edges_from\` / \`neighbors\`** — gated overlay consultation on \`overlay.get_node(node).is_some()\`. Misses cross-layer edges whose src is a base node: the overlay's adjacency stores the edge keyed on the base-node id even though the overlay has no corresponding node object. Fix: always consult the overlay (empty for ids without adjacency entries, so the unconditional call is cheap) and dedup \`edges_from\` by \`EdgeId\` to handle promoted edges that could appear in both layers.

## Tests for the fix

Ships a deterministic regression suite at \`crates/grafeo-engine/tests/post_compact_overlay_visibility.rs\`:

1. \`node_created_after_compact_is_visible\` — count and per-label scan
2. \`multiple_post_compact_nodes_visible\` — 5 overlay + 1 base
3. \`post_compact_edge_visible\` — edges fully within the overlay
4. \`post_compact_edge_between_base_and_overlay_nodes\` — the cross-layer case
5. \`post_compact_node_property_survives_reread\` — property read on an overlay-only node

## Verified

- 5/5 new tests pass
- all 1949 grafeo-core lib tests pass; all 13 existing grafeo-engine compact integration tests pass
- \`cargo clippy -p grafeo-core --features \"vector-index compact-store\" --lib -- -D warnings\` — clean

## Independence

- #303 is the property-based coverage PR for compact; it no longer XFAILs anything — each bug has its own self-contained fix PR.
- #306 fixes the sibling numeric-content / type promotion bug (#301). Both touch the compact-store path but the changes are disjoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)