### PR TITLE
fix(store): delegate GraphStoreSearch in WAL/CDC wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,6 +1558,7 @@ dependencies = [
  "grafeo-common",
  "grafeo-engine",
  "md5",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/grafeo-engine/src/database/cdc_store.rs
+++ b/crates/grafeo-engine/src/database/cdc_store.rs
@@ -393,13 +393,7 @@ impl GraphStoreSearch for CdcGraphStore {
     }
 
     #[cfg(feature = "text-index")]
-    fn score_text(
-        &self,
-        node_id: NodeId,
-        label: &str,
-        property: &str,
-        query: &str,
-    ) -> Option<f64> {
+    fn score_text(&self, node_id: NodeId, label: &str, property: &str, query: &str) -> Option<f64> {
         self.inner.score_text(node_id, label, property, query)
     }
 

--- a/crates/grafeo-engine/src/database/cdc_store.rs
+++ b/crates/grafeo-engine/src/database/cdc_store.rs
@@ -451,6 +451,19 @@ impl GraphStoreSearch for CdcGraphStore {
     ) -> Vec<(NodeId, f64)> {
         self.inner.vector_search(label, property, query, k, metric)
     }
+
+    #[cfg(feature = "vector-index")]
+    fn vector_search_with_threshold(
+        &self,
+        label: Option<&str>,
+        property: &str,
+        query: &[f32],
+        threshold: f64,
+        metric: grafeo_core::index::vector::DistanceMetric,
+    ) -> Vec<(NodeId, f64)> {
+        self.inner
+            .vector_search_with_threshold(label, property, query, threshold, metric)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/grafeo-engine/src/database/cdc_store.rs
+++ b/crates/grafeo-engine/src/database/cdc_store.rs
@@ -381,7 +381,77 @@ impl GraphStore for CdcGraphStore {
     }
 }
 
-impl GraphStoreSearch for CdcGraphStore {}
+// Pure delegation: CDC wraps the store to buffer mutation events but owns no
+// index state, so every text/vector lookup has to fall through to the
+// underlying `GraphStoreMut` (which is a `GraphStoreSearch` by bound). A stub
+// impl silently turns into "no index exists" at every call site — the same
+// regression that hit the WAL wrapper in issue #308.
+impl GraphStoreSearch for CdcGraphStore {
+    #[cfg(feature = "text-index")]
+    fn has_text_index(&self, label: &str, property: &str) -> bool {
+        self.inner.has_text_index(label, property)
+    }
+
+    #[cfg(feature = "text-index")]
+    fn score_text(
+        &self,
+        node_id: NodeId,
+        label: &str,
+        property: &str,
+        query: &str,
+    ) -> Option<f64> {
+        self.inner.score_text(node_id, label, property, query)
+    }
+
+    #[cfg(feature = "text-index")]
+    fn text_search(
+        &self,
+        label: &str,
+        property: &str,
+        query: &str,
+        k: usize,
+    ) -> Vec<(NodeId, f64)> {
+        self.inner.text_search(label, property, query, k)
+    }
+
+    #[cfg(feature = "text-index")]
+    fn text_search_with_threshold(
+        &self,
+        label: &str,
+        property: &str,
+        query: &str,
+        threshold: f64,
+    ) -> Vec<(NodeId, f64)> {
+        self.inner
+            .text_search_with_threshold(label, property, query, threshold)
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn has_vector_index(&self, label: &str, property: &str) -> bool {
+        self.inner.has_vector_index(label, property)
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn vector_index_metric(
+        &self,
+        label: &str,
+        property: &str,
+    ) -> Option<grafeo_core::index::vector::DistanceMetric> {
+        self.inner.vector_index_metric(label, property)
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn vector_search(
+        &self,
+        label: Option<&str>,
+        property: &str,
+        query: &[f32],
+        k: usize,
+        metric: grafeo_core::index::vector::DistanceMetric,
+    ) -> Vec<(NodeId, f64)> {
+        self.inner.vector_search(label, property, query, k, metric)
+    }
+}
 
 // ---------------------------------------------------------------------------
 // GraphStoreMut: delegate + CDC buffer/record

--- a/crates/grafeo-engine/src/database/wal_store.rs
+++ b/crates/grafeo-engine/src/database/wal_store.rs
@@ -334,13 +334,7 @@ impl GraphStoreSearch for WalGraphStore {
     }
 
     #[cfg(feature = "text-index")]
-    fn score_text(
-        &self,
-        node_id: NodeId,
-        label: &str,
-        property: &str,
-        query: &str,
-    ) -> Option<f64> {
+    fn score_text(&self, node_id: NodeId, label: &str, property: &str, query: &str) -> Option<f64> {
         self.inner.score_text(node_id, label, property, query)
     }
 

--- a/crates/grafeo-engine/src/database/wal_store.rs
+++ b/crates/grafeo-engine/src/database/wal_store.rs
@@ -321,7 +321,78 @@ impl GraphStore for WalGraphStore {
     }
 }
 
-impl GraphStoreSearch for WalGraphStore {}
+// Pure delegation: the WAL wrapper logs mutations but owns no index state,
+// so every text/vector lookup has to fall through to the underlying
+// `LpgStore`. A stub impl silently turns into "no index exists" at every
+// call site (has_text_index → false, text_search → [], etc.), which
+// regressed hybrid queries on persistent DBs until it was caught by the
+// `_persistent` spec variants — see issue #308.
+impl GraphStoreSearch for WalGraphStore {
+    #[cfg(feature = "text-index")]
+    fn has_text_index(&self, label: &str, property: &str) -> bool {
+        self.inner.has_text_index(label, property)
+    }
+
+    #[cfg(feature = "text-index")]
+    fn score_text(
+        &self,
+        node_id: NodeId,
+        label: &str,
+        property: &str,
+        query: &str,
+    ) -> Option<f64> {
+        self.inner.score_text(node_id, label, property, query)
+    }
+
+    #[cfg(feature = "text-index")]
+    fn text_search(
+        &self,
+        label: &str,
+        property: &str,
+        query: &str,
+        k: usize,
+    ) -> Vec<(NodeId, f64)> {
+        self.inner.text_search(label, property, query, k)
+    }
+
+    #[cfg(feature = "text-index")]
+    fn text_search_with_threshold(
+        &self,
+        label: &str,
+        property: &str,
+        query: &str,
+        threshold: f64,
+    ) -> Vec<(NodeId, f64)> {
+        self.inner
+            .text_search_with_threshold(label, property, query, threshold)
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn has_vector_index(&self, label: &str, property: &str) -> bool {
+        self.inner.has_vector_index(label, property)
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn vector_index_metric(
+        &self,
+        label: &str,
+        property: &str,
+    ) -> Option<grafeo_core::index::vector::DistanceMetric> {
+        self.inner.vector_index_metric(label, property)
+    }
+
+    #[cfg(feature = "vector-index")]
+    fn vector_search(
+        &self,
+        label: Option<&str>,
+        property: &str,
+        query: &[f32],
+        k: usize,
+        metric: grafeo_core::index::vector::DistanceMetric,
+    ) -> Vec<(NodeId, f64)> {
+        self.inner.vector_search(label, property, query, k, metric)
+    }
+}
 
 // ---------------------------------------------------------------------------
 // GraphStoreMut: delegate + WAL log

--- a/crates/grafeo-engine/src/database/wal_store.rs
+++ b/crates/grafeo-engine/src/database/wal_store.rs
@@ -392,6 +392,19 @@ impl GraphStoreSearch for WalGraphStore {
     ) -> Vec<(NodeId, f64)> {
         self.inner.vector_search(label, property, query, k, metric)
     }
+
+    #[cfg(feature = "vector-index")]
+    fn vector_search_with_threshold(
+        &self,
+        label: Option<&str>,
+        property: &str,
+        query: &[f32],
+        threshold: f64,
+        metric: grafeo_core::index::vector::DistanceMetric,
+    ) -> Vec<(NodeId, f64)> {
+        self.inner
+            .vector_search_with_threshold(label, property, query, threshold, metric)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/grafeo-spec-tests/Cargo.toml
+++ b/crates/grafeo-spec-tests/Cargo.toml
@@ -23,9 +23,12 @@ algos = []
 shacl = ["triple-store", "grafeo-engine/shacl"]
 
 [dependencies]
-grafeo-engine = { workspace = true, features = ["embedded", "languages", "triple-store"] }
+grafeo-engine = { workspace = true, features = ["embedded", "languages", "triple-store", "wal"] }
 grafeo-common = { workspace = true }
 md5 = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [build-dependencies]
 # No serde_yaml: hand-written parser for the simple YAML subset

--- a/crates/grafeo-spec-tests/build.rs
+++ b/crates/grafeo-spec-tests/build.rs
@@ -734,6 +734,16 @@ fn generate_tests(
     writeln!(output, "    use super::*;").unwrap();
     writeln!(output).unwrap();
 
+    // Cases in text-index or vector-index spec files get an extra `_persistent`
+    // variant so the WAL-wrapped store path (the one every `GrafeoDB::open()`
+    // goes through) is exercised alongside the in-memory one. Index-aware
+    // operators have historically diverged between the two paths (see #308).
+    let file_needs_persistent = file
+        .meta
+        .requires
+        .iter()
+        .any(|r| r == "text-index" || r == "vector-index");
+
     for tc in &file.tests {
         // Skip tests with skip field
         if tc.skip.is_some() {
@@ -746,6 +756,12 @@ fn generate_tests(
             count += 1;
             continue;
         }
+
+        let case_needs_persistent = file_needs_persistent
+            || tc
+                .requires
+                .iter()
+                .any(|r| r == "text-index" || r == "vector-index");
 
         // Handle rosetta variants
         if !tc.variants.is_empty() {
@@ -763,20 +779,49 @@ fn generate_tests(
                     Some(query),
                     Some(lang),
                     rel_path,
+                    DbSource::InMemory,
                 );
                 count += 1;
+                if case_needs_persistent {
+                    generate_single_test(
+                        output,
+                        &format!("{fn_name}_persistent"),
+                        file,
+                        tc,
+                        Some(query),
+                        Some(lang),
+                        rel_path,
+                        DbSource::Persistent,
+                    );
+                    count += 1;
+                }
             }
         } else {
+            let base = sanitize_test_name(&tc.name);
             generate_single_test(
                 output,
-                &sanitize_test_name(&tc.name),
+                &base,
                 file,
                 tc,
                 None,
                 None,
                 rel_path,
+                DbSource::InMemory,
             );
             count += 1;
+            if case_needs_persistent {
+                generate_single_test(
+                    output,
+                    &format!("{base}_persistent"),
+                    file,
+                    tc,
+                    None,
+                    None,
+                    rel_path,
+                    DbSource::Persistent,
+                );
+                count += 1;
+            }
         }
     }
 
@@ -784,6 +829,12 @@ fn generate_tests(
     writeln!(output).unwrap();
 
     count
+}
+
+#[derive(Clone, Copy)]
+enum DbSource {
+    InMemory,
+    Persistent,
 }
 
 fn generate_single_test(
@@ -794,6 +845,7 @@ fn generate_single_test(
     query_override: Option<&str>,
     lang_override: Option<&str>,
     rel_path: &str,
+    db_source: DbSource,
 ) {
     let language = lang_override
         .or(tc.language.as_deref())
@@ -872,8 +924,27 @@ fn generate_single_test(
     writeln!(output, "    #[test]").unwrap();
     writeln!(output, "    fn {fn_name}() {{").unwrap();
 
-    // Create DB and load dataset
-    writeln!(output, "        let db = GrafeoDB::new_in_memory();").unwrap();
+    // Create DB and load dataset. The persistent variant exercises the
+    // WAL-wrapped store path that `GrafeoDB::open()` always produces, so
+    // regressions in wrapper delegation (e.g. #308) fail here instead of
+    // slipping past the in-memory-only suite.
+    match db_source {
+        DbSource::InMemory => {
+            writeln!(output, "        let db = GrafeoDB::new_in_memory();").unwrap();
+        }
+        DbSource::Persistent => {
+            writeln!(
+                output,
+                "        let _tmp = tempfile::tempdir().expect(\"tempdir for persistent spec test\");"
+            )
+            .unwrap();
+            writeln!(
+                output,
+                "        let db = GrafeoDB::open(_tmp.path().join(\"spec.grafeo\")).expect(\"open persistent GrafeoDB for spec test\");"
+            )
+            .unwrap();
+        }
+    }
 
     let effective_dataset = tc.dataset.as_deref().unwrap_or(&file.meta.dataset);
     if effective_dataset != "empty" {


### PR DESCRIPTION
## Summary

Closes #308.

- `WalGraphStore` and `CdcGraphStore` had empty `impl GraphStoreSearch for ... {}` blocks. The trait's default methods are all no-ops (`has_text_index` → `false`, `text_search` → `[]`, `score_text` → `None`, same for the vector methods).
- In-memory sessions bypass both wrappers and use `LpgStore`'s real impl directly, so `GrafeoDB::new_in_memory()` worked fine. Every `GrafeoDB::open()` session wraps the overlay in `WalGraphStore`, which turned every text/vector index lookup into "no index exists" — the planner then falls through to per-row eval in `try_plan_filter_with_text_index`, which itself returns `None` from `score_text`, so `text_match(...)` is `false` for every row.
- The reporter saw this as `text_match` returning zero rows against a fresh DB opened from the CLI, while the exact same sequence in the spec suite was green because the harness only runs against `new_in_memory()`.

## Fix

- `WalGraphStore` and `CdcGraphStore` now delegate every `GraphStoreSearch` method to `self.inner` (which is `Arc<LpgStore>` / `Arc<dyn GraphStoreMut>` — both satisfy `GraphStoreSearch`). Same pattern `LayeredStore` already uses.

## Test harness hardening

- The `.gtest` code generator now emits a second `_persistent` variant for any case in a file whose `requires` includes `text-index` or `vector-index`. The variant opens `GrafeoDB::open(tempdir)` instead of `new_in_memory()`, so the WAL-wrapped read path is exercised in CI alongside the in-memory path.
- Before the fix: 6 new persistent variants fail — every text-related case in `common/hybrid_queries.gtest`. Vector variants pass because vector search has a brute-force fallback that doesn't depend on `has_vector_index`; text has no such fallback.
- After the fix: all 49 persistent variants pass; the in-memory suite is unchanged (2843 passed, 95 ignored).

## Follow-up: trait redesign

The root cause is that `GraphStoreSearch`'s default impls hide missing delegation. A wrapper author who forgets to delegate gets `false` / `[]` at runtime, not a compile error. The follow-up is to **drop the default impls** and make every method required — every non-indexed store (`CompactStore`, `GraphProjection`, `RdfGraphStoreAdapter`, `NullGraphStore`) then needs an explicit stub, which is the point: the next wrapper regression becomes `error[E0046]: not all trait items implemented` instead of a silent zero-rows bug that the `_persistent` harness only catches for specs touching text/vector indexes. Happy to open that as a separate PR once this one lands, since it's a breaking internal API change and deserves its own review.

## Test plan

- [x] `cargo test -p grafeo-spec-tests --lib` — 2843 passed, 95 ignored, 0 failed (includes 49 new `_persistent` variants)
- [x] `cargo test -p grafeo-engine --lib` — 1059 passed
- [x] `cargo test -p grafeo-engine --test text_index_mutations --test hybrid_query --test hybrid_pushdown_coverage --test post_compact_index --features text-index,vector-index,wal,compact-store` — all passed
- [x] `cargo test -p grafeo-engine --lib wal_store` / `cdc_store` — 18 + 71 passed
- [x] `cargo clippy -p grafeo-engine -p grafeo-spec-tests --tests --no-deps` — no new warnings
- [x] Reproduced the original CLI failure locally on HEAD (file-backed DB → 0 rows) and confirmed the fix makes it return the expected row.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes text/vector search on file-backed DBs by delegating all `GraphStoreSearch` calls in `WalGraphStore` and `CdcGraphStore`, including `vector_search_with_threshold`. Adds persistent spec tests to exercise the WAL path. Closes #308.

- **Bug Fixes**
  - `WalGraphStore` and `CdcGraphStore` now forward every `GraphStoreSearch` method to the inner store (all `has_*`, `score_text`, `text_search[_with_threshold]`, all `vector_*`, including `vector_search_with_threshold`).
  - Spec harness generates `_persistent` variants for tests requiring `text-index` or `vector-index` (file- or case-level), running them against `GrafeoDB::open()` to cover the WAL path.

- **Dependencies**
  - Enabled `wal` feature for `grafeo-spec-tests`.
  - Added `tempfile` (dev) for persistent test DBs.

<sup>Written for commit daca8a104e4eb7f4afa82622f316bf3349c4a779. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

