### PR TITLE
fix(vector): assert equal slice lengths in native SIMD kernels

### DIFF
--- a/crates/grafeo-core/src/index/vector/simd.rs
+++ b/crates/grafeo-core/src/index/vector/simd.rs
@@ -102,8 +102,7 @@ pub fn simd_support() -> &'static str {
 /// Computes distance using the best available SIMD implementation.
 #[inline]
 pub fn compute_distance_simd(a: &[f32], b: &[f32], metric: DistanceMetric) -> f32 {
-    debug_assert_eq!(a.len(), b.len(), "Vector dimensions must match");
-
+    // Length equality is enforced at each *_simd dispatcher below.
     match metric {
         DistanceMetric::Cosine => cosine_distance_simd(a, b),
         DistanceMetric::Euclidean => euclidean_distance_simd(a, b),
@@ -116,21 +115,23 @@ pub fn compute_distance_simd(a: &[f32], b: &[f32], metric: DistanceMetric) -> f3
 #[inline]
 #[allow(unreachable_code)]
 pub fn dot_product_simd(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
+
     #[cfg(target_arch = "x86_64")]
     {
         if has_avx2() {
-            // SAFETY: We checked AVX2 support above
+            // SAFETY: AVX2 support and equal lengths checked above
             return unsafe { dot_product_avx2(a, b) };
         }
         if has_sse() {
-            // SAFETY: We checked SSE support above
+            // SAFETY: SSE support and equal lengths checked above
             return unsafe { dot_product_sse(a, b) };
         }
     }
 
     #[cfg(target_arch = "aarch64")]
     {
-        // SAFETY: NEON is always available on aarch64
+        // SAFETY: NEON is always available on aarch64 and lengths are equal
         return unsafe { dot_product_neon(a, b) };
     }
 
@@ -142,21 +143,23 @@ pub fn dot_product_simd(a: &[f32], b: &[f32]) -> f32 {
 #[inline]
 #[allow(unreachable_code)]
 pub fn euclidean_distance_squared_simd(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
+
     #[cfg(target_arch = "x86_64")]
     {
         if has_avx2() {
-            // SAFETY: AVX2+FMA availability is checked by `has_avx2()` above
+            // SAFETY: AVX2+FMA checked by `has_avx2()` and lengths equal above
             return unsafe { euclidean_squared_avx2(a, b) };
         }
         if has_sse() {
-            // SAFETY: SSE availability is checked by `has_sse()` above
+            // SAFETY: SSE checked by `has_sse()` and lengths equal above
             return unsafe { euclidean_squared_sse(a, b) };
         }
     }
 
     #[cfg(target_arch = "aarch64")]
     {
-        // SAFETY: NEON is always available on aarch64
+        // SAFETY: NEON is always available on aarch64 and lengths are equal
         return unsafe { euclidean_squared_neon(a, b) };
     }
 
@@ -173,21 +176,23 @@ pub fn euclidean_distance_simd(a: &[f32], b: &[f32]) -> f32 {
 #[inline]
 #[allow(unreachable_code)]
 pub fn cosine_distance_simd(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
+
     #[cfg(target_arch = "x86_64")]
     {
         if has_avx2() {
-            // SAFETY: AVX2+FMA availability is checked by `has_avx2()` above
+            // SAFETY: AVX2+FMA checked by `has_avx2()` and lengths equal above
             return unsafe { cosine_distance_avx2(a, b) };
         }
         if has_sse() {
-            // SAFETY: SSE availability is checked by `has_sse()` above
+            // SAFETY: SSE checked by `has_sse()` and lengths equal above
             return unsafe { cosine_distance_sse(a, b) };
         }
     }
 
     #[cfg(target_arch = "aarch64")]
     {
-        // SAFETY: NEON is always available on aarch64
+        // SAFETY: NEON is always available on aarch64 and lengths are equal
         return unsafe { cosine_distance_neon(a, b) };
     }
 
@@ -198,21 +203,23 @@ pub fn cosine_distance_simd(a: &[f32], b: &[f32]) -> f32 {
 #[inline]
 #[allow(unreachable_code)]
 pub fn manhattan_distance_simd(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
+
     #[cfg(target_arch = "x86_64")]
     {
         if has_avx2() {
-            // SAFETY: AVX2+FMA availability is checked by `has_avx2()` above
+            // SAFETY: AVX2+FMA checked by `has_avx2()` and lengths equal above
             return unsafe { manhattan_distance_avx2(a, b) };
         }
         if has_sse() {
-            // SAFETY: SSE availability is checked by `has_sse()` above
+            // SAFETY: SSE checked by `has_sse()` and lengths equal above
             return unsafe { manhattan_distance_sse(a, b) };
         }
     }
 
     #[cfg(target_arch = "aarch64")]
     {
-        // SAFETY: NEON is always available on aarch64
+        // SAFETY: NEON is always available on aarch64 and lengths are equal
         return unsafe { manhattan_distance_neon(a, b) };
     }
 
@@ -276,8 +283,6 @@ fn manhattan_distance_scalar(a: &[f32], b: &[f32]) -> f32 {
 unsafe fn dot_product_avx2(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
 
-    assert_eq!(a.len(), b.len(), "vector lengths must match");
-
     let n = a.len();
     let mut i = 0;
 
@@ -308,8 +313,6 @@ unsafe fn dot_product_avx2(a: &[f32], b: &[f32]) -> f32 {
 unsafe fn euclidean_squared_avx2(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
 
-    assert_eq!(a.len(), b.len(), "vector lengths must match");
-
     let n = a.len();
     let mut i = 0;
 
@@ -338,8 +341,6 @@ unsafe fn euclidean_squared_avx2(a: &[f32], b: &[f32]) -> f32 {
 #[target_feature(enable = "avx2", enable = "fma")]
 unsafe fn cosine_distance_avx2(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
-
-    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -378,8 +379,6 @@ unsafe fn cosine_distance_avx2(a: &[f32], b: &[f32]) -> f32 {
 #[target_feature(enable = "avx2")]
 unsafe fn manhattan_distance_avx2(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
-
-    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -436,8 +435,6 @@ unsafe fn horizontal_sum_avx2(v: std::arch::x86_64::__m256) -> f32 {
 unsafe fn dot_product_sse(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
 
-    assert_eq!(a.len(), b.len(), "vector lengths must match");
-
     let n = a.len();
     let mut i = 0;
 
@@ -465,8 +462,6 @@ unsafe fn dot_product_sse(a: &[f32], b: &[f32]) -> f32 {
 #[target_feature(enable = "sse")]
 unsafe fn euclidean_squared_sse(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
-
-    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -497,8 +492,6 @@ unsafe fn euclidean_squared_sse(a: &[f32], b: &[f32]) -> f32 {
 #[target_feature(enable = "sse")]
 unsafe fn cosine_distance_sse(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
-
-    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -537,8 +530,6 @@ unsafe fn cosine_distance_sse(a: &[f32], b: &[f32]) -> f32 {
 #[target_feature(enable = "sse")]
 unsafe fn manhattan_distance_sse(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
-
-    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -589,8 +580,6 @@ unsafe fn horizontal_sum_sse(v: std::arch::x86_64::__m128) -> f32 {
 unsafe fn dot_product_neon(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::aarch64::*;
 
-    assert_eq!(a.len(), b.len(), "vector lengths must match");
-
     let n = a.len();
     let mut i = 0;
 
@@ -616,8 +605,6 @@ unsafe fn dot_product_neon(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(target_arch = "aarch64")]
 unsafe fn euclidean_squared_neon(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::aarch64::*;
-
-    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -646,8 +633,6 @@ unsafe fn euclidean_squared_neon(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(target_arch = "aarch64")]
 unsafe fn cosine_distance_neon(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::aarch64::*;
-
-    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -685,8 +670,6 @@ unsafe fn cosine_distance_neon(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(target_arch = "aarch64")]
 unsafe fn manhattan_distance_neon(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::aarch64::*;
-
-    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;

--- a/crates/grafeo-core/src/index/vector/simd.rs
+++ b/crates/grafeo-core/src/index/vector/simd.rs
@@ -276,6 +276,8 @@ fn manhattan_distance_scalar(a: &[f32], b: &[f32]) -> f32 {
 unsafe fn dot_product_avx2(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
 
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
+
     let n = a.len();
     let mut i = 0;
 
@@ -306,6 +308,8 @@ unsafe fn dot_product_avx2(a: &[f32], b: &[f32]) -> f32 {
 unsafe fn euclidean_squared_avx2(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
 
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
+
     let n = a.len();
     let mut i = 0;
 
@@ -334,6 +338,8 @@ unsafe fn euclidean_squared_avx2(a: &[f32], b: &[f32]) -> f32 {
 #[target_feature(enable = "avx2", enable = "fma")]
 unsafe fn cosine_distance_avx2(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
+
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -372,6 +378,8 @@ unsafe fn cosine_distance_avx2(a: &[f32], b: &[f32]) -> f32 {
 #[target_feature(enable = "avx2")]
 unsafe fn manhattan_distance_avx2(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
+
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -428,6 +436,8 @@ unsafe fn horizontal_sum_avx2(v: std::arch::x86_64::__m256) -> f32 {
 unsafe fn dot_product_sse(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
 
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
+
     let n = a.len();
     let mut i = 0;
 
@@ -455,6 +465,8 @@ unsafe fn dot_product_sse(a: &[f32], b: &[f32]) -> f32 {
 #[target_feature(enable = "sse")]
 unsafe fn euclidean_squared_sse(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
+
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -485,6 +497,8 @@ unsafe fn euclidean_squared_sse(a: &[f32], b: &[f32]) -> f32 {
 #[target_feature(enable = "sse")]
 unsafe fn cosine_distance_sse(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
+
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -523,6 +537,8 @@ unsafe fn cosine_distance_sse(a: &[f32], b: &[f32]) -> f32 {
 #[target_feature(enable = "sse")]
 unsafe fn manhattan_distance_sse(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::x86_64::*;
+
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -573,6 +589,8 @@ unsafe fn horizontal_sum_sse(v: std::arch::x86_64::__m128) -> f32 {
 unsafe fn dot_product_neon(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::aarch64::*;
 
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
+
     let n = a.len();
     let mut i = 0;
 
@@ -598,6 +616,8 @@ unsafe fn dot_product_neon(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(target_arch = "aarch64")]
 unsafe fn euclidean_squared_neon(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::aarch64::*;
+
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -626,6 +646,8 @@ unsafe fn euclidean_squared_neon(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(target_arch = "aarch64")]
 unsafe fn cosine_distance_neon(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::aarch64::*;
+
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -663,6 +685,8 @@ unsafe fn cosine_distance_neon(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(target_arch = "aarch64")]
 unsafe fn manhattan_distance_neon(a: &[f32], b: &[f32]) -> f32 {
     use std::arch::aarch64::*;
+
+    assert_eq!(a.len(), b.len(), "vector lengths must match");
 
     let n = a.len();
     let mut i = 0;
@@ -853,5 +877,40 @@ mod tests {
         let _ = compute_distance_simd(&a, &b, DistanceMetric::Euclidean);
         let _ = compute_distance_simd(&a, &b, DistanceMetric::DotProduct);
         let _ = compute_distance_simd(&a, &b, DistanceMetric::Manhattan);
+    }
+
+    // The public *_simd dispatchers feed unsafe raw-pointer loads from `b`
+    // bounded by `a.len()`. These panics guarantee we never read past `b` in
+    // release builds.
+    #[test]
+    #[should_panic(expected = "vector lengths must match")]
+    fn test_dot_product_simd_panics_on_mismatched_lengths() {
+        let a = [1.0f32; 8];
+        let b = [1.0f32; 4];
+        let _ = dot_product_simd(&a, &b);
+    }
+
+    #[test]
+    #[should_panic(expected = "vector lengths must match")]
+    fn test_euclidean_distance_squared_simd_panics_on_mismatched_lengths() {
+        let a = [1.0f32; 8];
+        let b = [1.0f32; 4];
+        let _ = euclidean_distance_squared_simd(&a, &b);
+    }
+
+    #[test]
+    #[should_panic(expected = "vector lengths must match")]
+    fn test_cosine_distance_simd_panics_on_mismatched_lengths() {
+        let a = [1.0f32; 8];
+        let b = [1.0f32; 4];
+        let _ = cosine_distance_simd(&a, &b);
+    }
+
+    #[test]
+    #[should_panic(expected = "vector lengths must match")]
+    fn test_manhattan_distance_simd_panics_on_mismatched_lengths() {
+        let a = [1.0f32; 8];
+        let b = [1.0f32; 4];
+        let _ = manhattan_distance_simd(&a, &b);
     }
 }


### PR DESCRIPTION
## Summary

- Promotes the release-skipped `debug_assert_eq!` length check on the SIMD distance kernels to an in-kernel `assert_eq!`, closing an out-of-bounds read on mismatched-length slices in release builds.
- Covers all twelve native kernels: AVX2 / SSE / NEON × {dot product, squared Euclidean, cosine, Manhattan}.
- Adds four `#[should_panic]` regression tests at the public `*_simd` entry-point level.

Fixes #311.

## Background

The unsafe kernels drive their main loop from `a.len()` and load `b` with raw-pointer SIMD instructions (e.g. `_mm256_loadu_ps(b.as_ptr().add(i))`). If `b.len() < a.len()`, the load reads past the end of `b` — UB in Rust, garbage or a fault in practice. The dispatcher-level `debug_assert_eq!` becomes a no-op in release, and the four public `*_simd` dispatchers bypass even that. See #311 for the full write-up.

Same shape as the wasm simd128 kernels addressed in the #305 review (PR #309 of the parent fork); this PR covers the pre-existing native kernels.

## Approach

- `assert_eq!(a.len(), b.len(), "vector lengths must match")` at the top of each of the twelve kernels — release-mode check, negligible cost vs. the loop work.
- Left the existing `debug_assert_eq!` in `compute_distance_simd` in place; it still gives a cleaner error in debug if a caller mismatches upstream of the dispatcher, and is otherwise shadowed.
- Four new tests exercise each public `*_simd` dispatcher with `a.len() = 8`, `b.len() = 4` and expect panic.

## Test plan

- [x] `cargo check -p grafeo-core --lib --tests`
- [x] `cargo test -p grafeo-core --lib index::vector::simd` — 13 tests pass, including 4 new should_panic regressions
- [ ] CI: native Linux + macOS + aarch64 (AVX2/SSE/NEON paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces equal slice lengths at the four public `*_simd` dispatchers so all SIMD and scalar paths fail fast with a clear message in release. Prevents out-of-bounds reads and makes panics consistent across AVX2/SSE/NEON and scalar fallbacks.

- **Bug Fixes**
  - Added `assert_eq!(a.len(), b.len(), "vector lengths must match")` to `dot_product_simd`, `euclidean_distance_squared_simd`, `cosine_distance_simd`, and `manhattan_distance_simd`.
  - Removed redundant `debug_assert_eq!` in `compute_distance_simd` and kernel-local checks; one dispatcher-level guard now covers all paths.
  - Added four `#[should_panic]` tests validating mismatched-length panics at each public `*_simd` entry point.

<sup>Written for commit 7078d22200ee132712616f6e7521074ca920f49c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

