### PR TITLE
fix(storage): handle v2 files in read_snapshot

### DIFF
--- a/crates/grafeo-storage/src/file/manager.rs
+++ b/crates/grafeo-storage/src/file/manager.rs
@@ -315,6 +315,13 @@ impl GrafeoFileManager {
             return Ok(Vec::new());
         }
 
+        // v2 files store sections rather than a v1 snapshot blob. They set
+        // snapshot_length == 0 and put the directory CRC in the checksum field.
+        // Reading 0 bytes here would CRC to 0 and mismatch the directory CRC.
+        if active_header.snapshot_length == 0 {
+            return Ok(Vec::new());
+        }
+
         // reason: snapshot_length is the size of serialized in-memory data, fits in usize on 64-bit targets;
         // on 32-bit targets the database would OOM long before reaching 4 GiB
         // reason: value bounded by collection size, fits usize
@@ -889,6 +896,36 @@ mod tests {
         let manager = GrafeoFileManager::create(&path).unwrap();
         let data = manager.read_snapshot().unwrap();
         assert!(data.is_empty());
+    }
+
+    #[test]
+    fn read_snapshot_returns_empty_on_v2_header() {
+        // After write_sections, snapshot_length == 0 in the active header and the
+        // checksum field holds the section-directory CRC. The pre-fix v1 reader
+        // would read 0 bytes, CRC empty data to 0, and mismatch the directory CRC.
+        // The fix early-returns Ok(Vec::new()) when snapshot_length == 0.
+        use grafeo_common::storage::SectionType;
+
+        let dir = test_dir();
+        let path = dir.path().join("v2.grafeo");
+
+        let mut manager = GrafeoFileManager::create(&path).unwrap();
+        manager
+            .write_sections(&[(SectionType::LpgStore, b"section payload")], 1, 1, 0, 0)
+            .unwrap();
+
+        // Pre-fix: this returned Err("snapshot checksum mismatch").
+        // Post-fix: returns Ok(Vec::new()), letting engine fall through to v2 dispatch.
+        let data = manager.read_snapshot().unwrap();
+        assert!(
+            data.is_empty(),
+            "v2 file should produce empty snapshot vec, not an error"
+        );
+
+        // Sanity: header confirms this is a v2 file (snapshot_length == 0 with non-zero checksum).
+        let header = manager.active_header();
+        assert_eq!(header.snapshot_length, 0);
+        assert!(!header.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do?

Fixes the `GRAFEO-X001: snapshot checksum mismatch` error reported in #323.

`read_snapshot` is unconditionally a v1 reader, but `grafeo-engine`'s open path also calls it as a fallback when `read_section_directory` returns `None` — including silently on parse failures. The result is that any v2 file (`snapshot_length == 0`, directory CRC in the checksum field) where directory parsing trips falls into v1 logic and hits a guaranteed CRC mismatch.

The fix is a single early-return: when `snapshot_length == 0` on a non-empty header, return `Ok(Vec::new())` instead of CRCing zero bytes against a non-zero checksum. Legitimate v1 files always have `snapshot_length > 0`, so this is a no-op for them.

Note: I'm leaving issue #323 open for the second half of the diagnosis — the question of *why* `read_section_directory` returns `None` on some v2 files when those same files round-trip through CLI `dump` and `info` correctly. That's a separate investigation; this PR just prevents the broken v1 fallback from making the silent dispatch failure user-visible as a hard open error.

Fixes #323

## How was it tested?

Added `read_snapshot_returns_empty_on_v2_header` covering the v2 case directly: write a v2 file via `write_sections`, then call `read_snapshot` and assert it returns `Ok(Vec::new())` rather than the pre-fix CRC-mismatch error. Existing `read_snapshot` tests continue to cover v1 behavior unchanged.

```
cargo fmt --all -- --check                                            # clean
cargo clippy -p grafeo-storage --all-features -- -D warnings          # clean
cargo test -p grafeo-storage --all-features                           # 152 + 7 + 7 + 5 tests pass
```

The patched code has been running in production embedded in [cqr-mcp](https://github.com/teipsum/cqr-mcp) since 2026-04-29 against a 14MB v2 database (3012 nodes, 8776 edges) that previously failed to open with GRAFEO-X001. With the patch applied, the database opens via `read_section_directory`'s v2 path on the same machine.

## Community PR checklist

- [x] **No unsolicited architecture changes.** Single function in `grafeo-storage`, addressing the linked issue.
- [x] **No changes to shared infrastructure.** No CI workflows, root `Cargo.toml`, `codecov.yml`, or `scripts/` modified.
- [x] **No naming or concept conflicts.** No new types, modules, or subsystem names introduced.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GRAFEO-X001 snapshot checksum mismatch on v2 files by making `read_snapshot` return an empty buffer when `snapshot_length == 0`, avoiding incorrect v1 CRC validation. V1 behavior is unchanged. Fixes #323.

- **Bug Fixes**
  - `grafeo-storage`: In `read_snapshot`, early-return `Ok(Vec::new())` when `snapshot_length == 0` on a non-empty header to prevent CRC mismatch on v2 files.
  - Added test `read_snapshot_returns_empty_on_v2_header` to cover the v2 case.

<sup>Written for commit e87f29000116a8b7cd7d9423cbd4c7554c5321ad. Summary will update on new commits. <a href="https://cubic.dev/pr/GrafeoDB/grafeo/pull/324?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

