### PR TITLE
feat: add support for Gremlin notRegex() predicate

### DIFF
--- a/crates/grafeo-adapters/src/query/gremlin/ast.rs
+++ b/crates/grafeo-adapters/src/query/gremlin/ast.rs
@@ -209,6 +209,8 @@ pub enum Predicate {
     EndingWith(String),
     /// P.regex(pattern)
     Regex(String),
+    /// P.notRegex(pattern)
+    NotRegex(String),
     /// P.and(predicates...)
     And(Vec<Predicate>),
     /// P.or(predicates...)

--- a/crates/grafeo-adapters/src/query/gremlin/lexer.rs
+++ b/crates/grafeo-adapters/src/query/gremlin/lexer.rs
@@ -205,6 +205,8 @@ pub enum TokenKind {
     EndingWith,
     /// The `regex()` regular-expression predicate.
     Regex,
+    /// The `notRegex()` negated regular-expression predicate.
+    NotRegex,
 
     // Tokens (T.*)
     /// The `T` token namespace (e.g., `T.id`, `T.label`).
@@ -541,6 +543,7 @@ impl<'a> Lexer<'a> {
             "startingWith" => TokenKind::StartingWith,
             "endingWith" => TokenKind::EndingWith,
             "regex" => TokenKind::Regex,
+            "notRegex" => TokenKind::NotRegex,
             "T" => TokenKind::T,
             "asc" => TokenKind::Asc,
             "desc" => TokenKind::Desc,

--- a/crates/grafeo-adapters/src/query/gremlin/parser.rs
+++ b/crates/grafeo-adapters/src/query/gremlin/parser.rs
@@ -633,6 +633,7 @@ impl<'a> Parser<'a> {
             Some(TokenKind::StartingWith) => Some(TokenKind::StartingWith),
             Some(TokenKind::EndingWith) => Some(TokenKind::EndingWith),
             Some(TokenKind::Regex) => Some(TokenKind::Regex),
+            Some(TokenKind::NotRegex) => Some(TokenKind::NotRegex),
             _ => None,
         };
 
@@ -709,6 +710,10 @@ impl<'a> Parser<'a> {
             TokenKind::Regex => {
                 let s = self.parse_string()?;
                 Predicate::Regex(s)
+            }
+            TokenKind::NotRegex => {
+                let s = self.parse_string()?;
+                Predicate::NotRegex(s)
             }
             _ => return Err(self.error("Unknown predicate")),
         };

--- a/crates/grafeo-engine/src/query/translators/gremlin.rs
+++ b/crates/grafeo-engine/src/query/translators/gremlin.rs
@@ -2111,6 +2111,16 @@ impl GremlinTranslator {
                     pattern.clone().into(),
                 ))),
             }),
+            ast::Predicate::NotRegex(pattern) => Ok(LogicalExpression::Unary {
+                op: UnaryOp::Not,
+                operand: Box::new(LogicalExpression::Binary {
+                    left: Box::new(expr),
+                    op: BinaryOp::Regex,
+                    right: Box::new(LogicalExpression::Literal(Value::String(
+                        pattern.clone().into(),
+                    ))),
+                }),
+            }),
         }
     }
 

--- a/crates/grafeo-engine/tests/gremlin.rs
+++ b/crates/grafeo-engine/tests/gremlin.rs
@@ -1432,6 +1432,45 @@ fn test_has_property_regex_substring_match() {
 }
 
 // ============================================================================
+// Text Predicates: notRegex()
+// ============================================================================
+
+#[test]
+fn test_has_property_not_regex_prefix_match() {
+    let db = create_social_network();
+    let result = db
+        .execute_gremlin("g.V().hasLabel('Person').has('name', notRegex('A.*'))")
+        .unwrap();
+    assert_eq!(result.row_count(), 2, "Gus and Vincent do not match 'A.*'");
+}
+
+#[test]
+fn test_has_property_not_regex_suffix_match() {
+    let db = create_social_network();
+    let result = db
+        .execute_gremlin("g.V().hasLabel('Person').has('city', notRegex('.*in$'))")
+        .unwrap();
+    assert_eq!(
+        result.row_count(),
+        2,
+        "Amsterdam and Paris do not match '.*in$'"
+    );
+}
+
+#[test]
+fn test_has_property_not_regex_substring_match() {
+    let db = create_social_network();
+    let result = db
+        .execute_gremlin("g.V().hasLabel('Person').has('city', notRegex('.*er.*'))")
+        .unwrap();
+    assert_eq!(
+        result.row_count(),
+        1,
+        "Only Paris does not match regex '.*er.*'"
+    );
+}
+
+// ============================================================================
 // Dedup with Keys
 // ============================================================================
 

--- a/tests/spec/lpg/gremlin/predicates_extended.gtest
+++ b/tests/spec/lpg/gremlin/predicates_extended.gtest
@@ -144,6 +144,30 @@ tests:
         - [2]
 
   # ---------------------------------------------------------------------------
+  # notRegex() predicate
+  # ---------------------------------------------------------------------------
+
+  - name: not_regex_prefix
+    query: "g.V().hasLabel('Person').has('name', notRegex('A.*')).values('name')"
+    expect:
+      rows:
+        - [Gus]
+        - [Vincent]
+
+  - name: not_regex_suffix
+    query: "g.V().hasLabel('Person').has('city', notRegex('.*in$')).values('name')"
+    expect:
+      rows:
+        - [Alix]
+        - [Vincent]
+
+  - name: not_regex_substring
+    query: "g.V().hasLabel('Person').has('city', notRegex('.*er.*')).count()"
+    expect:
+      rows:
+        - [1]
+
+  # ---------------------------------------------------------------------------
   # Compound predicates P.and(), P.or(), P.not()
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Adds support for Gremlin's `.notRegex()` predicate.

## How was it tested?

Local `cargo test --all-features --workspace`.

## Community PR checklist

- [x] **No unsolicited architecture changes.** New crates, new workspace dependencies, changes to `grafeo-core`/`grafeo-engine` internals, or new feature flags were either (a) requested in the linked issue or (b) discussed and approved in a GitHub Discussion before this PR was opened.
- [x] **No changes to shared infrastructure.** CI workflows (`.github/workflows/`), the root `Cargo.toml`, `codecov.yml`, and `scripts/` are not modified unless the change is the explicit purpose of this PR.
- [x] **No naming or concept conflicts.** I have searched the codebase and existing issues/discussions to confirm that any new types, modules, or subsystem names do not duplicate or conflict with existing ones.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the Gremlin `notRegex()` predicate to negate regex matches in `has()` filters (e.g., `has('name', notRegex('^A.*'))`). This enables filtering out values that match a pattern.

- **New Features**
  - `grafeo-adapters`: Lexer, parser, and AST now support `notRegex()` via `Predicate::NotRegex`.
  - `grafeo-engine`: Translator converts `notRegex()` to a NOT of the regex binary op.
  - Tests cover prefix, suffix, and substring cases in both unit and spec suites.

<sup>Written for commit 570cd874a32c90e35f06e620fc4c045928cc7e25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

