### PR TITLE
fix(engine): RETURN n ORDER BY n.p LIMIT k returns Value::Map not NodeId (#335)

### DIFF
--- a/crates/grafeo-engine/src/query/planner/lpg/project.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/project.rs
@@ -1373,9 +1373,15 @@ fn collect_vars(expr: &LogicalExpression, out: &mut Vec<String>) {
 /// True if `sort` requires injecting extra projection columns before sorting.
 ///
 /// Mirrors the logic at the top of `plan_sort`: when the sort input is a
-/// `Return` and any sort key references a variable that the RETURN clause has
-/// projected away, the planner must augment the Return with extra columns so
-/// the sort key is available at compare time.
+/// `Return` and any sort key is not fully materialised by that Return, the
+/// planner must augment the Return with extra columns so the sort key is
+/// available at compare time.
+///
+/// Two cases trigger augmenting:
+/// - Sort key `Property { v, p }` where Return does not explicitly project
+///   that property (e.g. `RETURN n ORDER BY n.title`: "n" is in Return but
+///   "n_title" is not a column — returning a full node is not enough).
+/// - Sort key variable `v` that is absent from Return entirely.
 ///
 /// Used by both `plan_sort` (which knows how to inject the augmenting
 /// projection) and `try_heap_topk_rewrite` (which doesn't, and bails out so
@@ -1385,17 +1391,34 @@ pub(super) fn sort_needs_augmenting_projection(sort: &SortOp) -> bool {
         return false;
     };
     sort.keys.iter().any(|key| {
-        let mut vars = Vec::new();
-        collect_vars(&key.expression, &mut vars);
-        vars.iter().any(|variable| {
-            !ret.items.iter().any(|item| {
-                item.alias.as_deref() == Some(variable)
-                    || matches!(
+        match &key.expression {
+            LogicalExpression::Property { variable, property } => {
+                // Sort key is v.p. Return satisfies it only if it explicitly
+                // projects Property{v,p} (possibly under any alias). Returning
+                // Variable(v) as a full node is not sufficient: the sort column
+                // "v_p" does not exist in the output, so augmenting is needed.
+                !ret.items.iter().any(|item| {
+                    matches!(
                         &item.expression,
-                        LogicalExpression::Variable(v) if v == variable
+                        LogicalExpression::Property { variable: v, property: p }
+                        if v == variable && p == property
                     )
-            })
-        })
+                })
+            }
+            _ => {
+                let mut vars = Vec::new();
+                collect_vars(&key.expression, &mut vars);
+                vars.iter().any(|variable| {
+                    !ret.items.iter().any(|item| {
+                        item.alias.as_deref() == Some(variable)
+                            || matches!(
+                                &item.expression,
+                                LogicalExpression::Variable(v) if v == variable
+                            )
+                    })
+                })
+            }
+        }
     })
 }
 

--- a/crates/grafeo-engine/tests/topk_rewrite.rs
+++ b/crates/grafeo-engine/tests/topk_rewrite.rs
@@ -263,3 +263,41 @@ fn cypher_order_by_limit_uses_topk() {
     let actual_top5: Vec<Value> = result.rows().iter().map(|row| row[0].clone()).collect();
     assert_eq!(actual_top5, expected_top5);
 }
+
+// Regression test for issue #335: ORDER BY + LIMIT on a full-node RETURN
+// was returning raw NodeIds instead of resolved maps. The heap top-K probe
+// inside try_heap_topk_rewrite mutated scalar_columns as a side effect,
+// causing the unfused re-plan of the same Return subtree to skip NodeResolve.
+#[test]
+fn order_by_limit_node_return_yields_map() {
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+    session
+        .execute("INSERT (:Article {title: 'A1', body: 'rust database internals'})")
+        .unwrap();
+
+    // Each variant must return Value::Map, not a raw integer NodeId.
+    let result = session
+        .execute("MATCH (n:Article) RETURN n")
+        .unwrap();
+    assert!(result.rows()[0][0].as_map().is_some(), "bare RETURN n");
+
+    let result = session
+        .execute("MATCH (n:Article) RETURN n LIMIT 50")
+        .unwrap();
+    assert!(result.rows()[0][0].as_map().is_some(), "RETURN n LIMIT 50");
+
+    let result = session
+        .execute("MATCH (n:Article) RETURN n ORDER BY n.title")
+        .unwrap();
+    assert!(result.rows()[0][0].as_map().is_some(), "RETURN n ORDER BY n.title");
+
+    let result = session
+        .execute("MATCH (n:Article) RETURN n ORDER BY n.title LIMIT 50")
+        .unwrap();
+    assert!(
+        result.rows()[0][0].as_map().is_some(),
+        "RETURN n ORDER BY n.title LIMIT 50: col 0 = {:?}",
+        result.rows()[0][0]
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #335.

`MATCH (n:Article) RETURN n ORDER BY n.title LIMIT 50` returned a raw integer NodeId (`Value::Int64`) instead of a resolved node map (`Value::Map`). The same query without `LIMIT`, or without `ORDER BY`, worked correctly.

## Root cause

The bug is in two cooperating places in `crates/grafeo-engine/src/query/planner/lpg/project.rs`.

**`sort_needs_augmenting_projection`** decides whether a `Sort(Return(...))` subtree needs extra columns injected before the Return so the sort key is available at compare time. The function returned `false` for `RETURN n ORDER BY n.title` because it checked whether variable `"n"` appeared in the Return items — and it did, as `Variable("n")`. It did not check whether the *specific property column* `"n_title"` was materialised by the Return. It was not: `RETURN n` outputs one node-valued column `"n"`, not a string column `"n_title"`.

Because `sort_needs_augmenting_projection` returned `false`, **`try_heap_topk_rewrite`** ran a speculative `plan_operator` probe on the Return subtree to see if a TopK operator could be built. Planning a `Return` that projects `Variable("n")` registers `"n"` in `self.scalar_columns` as a side-effect. The probe then failed (sort key `"n_title"` was not among the columns), and fell through to the unfused `plan_sort` path.

The unfused path re-planned the same Return subtree. But now `"n"` was already in `scalar_columns` from the probe, so `plan_return_projection` chose `ProjectExpr::Column(0)` (a raw integer pass-through) instead of `ProjectExpr::NodeResolve(0)` (which resolves the NodeId to a `Value::Map`). The result was a `Value::Int64` NodeId in the output row, causing `as_map()` to return `None`.

## Fix

Strengthen `sort_needs_augmenting_projection` to handle `Property { variable, property }` sort keys correctly: a property sort key requires augmenting unless the Return explicitly projects that exact `Property` expression. Returning `Variable(v)` as a full node does not satisfy `Property { v, p }`.

```rust
// before: checked only whether the variable was in Return
LogicalExpression::Property { .. } => { /* fell into the variable check */ }

// after: Property keys need the exact property in Return, not just the variable
LogicalExpression::Property { variable, property } => {
    !ret.items.iter().any(|item| {
        matches!(
            &item.expression,
            LogicalExpression::Property { variable: v, property: p }
            if v == variable && p == property
        )
    })
}
```

With this fix `sort_needs_augmenting_projection` returns `true` for `RETURN n ORDER BY n.title`, so `try_heap_topk_rewrite` exits early at its existing gate (line 1272) before the probe runs. The query routes through `plan_sort`'s `needs_pre_return = true` branch, which already correctly injects a `"n_title"` sort column, sorts on it, then strips it — projecting `"n"` via `NodeResolve`.

## Approaches considered and rejected

**Save/restore `scalar_columns`/`edge_columns` in `try_heap_topk_rewrite`** — an earlier version of this fix saved and restored the two mutable planner state sets around the probe call, rolling them back on fall-through. This fixed the symptom (state pollution) but not the cause (the predicate answering the wrong question). It was also a footgun: any future mutable field added to `Planner` would need to be added to the save/restore too, with no compiler enforcement. Removed in favour of the correct predicate fix.

## Potential gotchas

- **`sort_needs_augmenting_projection` is now stricter for `Property` sort keys.** If a query has a sort key `v.p` and Return *does* explicitly project `v.p` (e.g. `RETURN n.title ORDER BY n.title`), the function still returns `false` and the TopK rewrite still fires. If Return projects it under an alias (e.g. `RETURN n.title AS t ORDER BY n.title`), the new code also returns `false` correctly — it checks `item.expression`, not the alias.

- **The TopK rewrite no longer fires for `RETURN n ORDER BY n.p LIMIT k`.** Queries of this shape now always route through `plan_sort`'s augmenting projection path. This is a minor throughput regression for any caller that was relying on TopK behaviour here — but the previous TopK path was returning wrong results, so correctness takes priority. If the full-node + property-sort + limit pattern is a hot path, a future improvement would be to teach TopK how to resolve node maps for sort keys.

- **PROFILE mode is unaffected.** `plan_limit` gates off the TopK rewrite for `PROFILE` queries before `try_heap_topk_rewrite` is reached; this path is unchanged.

## Test

Added `order_by_limit_node_return_yields_map` to `crates/grafeo-engine/tests/topk_rewrite.rs`. It asserts that `RETURN n`, `RETURN n LIMIT 50`, `RETURN n ORDER BY n.title`, and `RETURN n ORDER BY n.title LIMIT 50` all yield `Value::Map` rows. All 8 integration tests and 1071 unit tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a planner bug where queries like MATCH (n:Article) RETURN n ORDER BY n.title LIMIT k returned a raw NodeId instead of a resolved node map. We now detect when a property sort key needs an extra projection so nodes are resolved correctly.

- **Bug Fixes**
  - Make `sort_needs_augmenting_projection` strict for property sort keys: it now requires the Return to project the exact property; returning the full node doesn’t satisfy sorting on `v.p`.
  - This prevents the TopK probe from mutating planner state and routes the plan through `plan_sort`’s augmenting path, which injects the property column for sorting and then strips it, yielding `Value::Map`.
  - Add a regression test ensuring `RETURN n`, with `LIMIT`, with `ORDER BY n.title`, and with both, all return `Value::Map`.

<sup>Written for commit 530edc5fa09df2dc6b2814971665cb07ba2956af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

