### PR TITLE
Release/0.5.43

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1005,4 +1005,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: crate-ci/typos@v1.46.0
+      - uses: crate-ci/typos@v1.46.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1005,4 +1005,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: crate-ci/typos@v1.46.0
+      - uses: crate-ci/typos@v1.46.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Grafeo, for future reference (and enjoyment).
 
+## [0.5.43] - Unreleased
+
+Gremlin `notRegex()` predicate plus a planner fix for `ORDER BY` + `LIMIT` over full-node `RETURN`.
+
+### Added
+
+- **Gremlin `notRegex()` text predicate**: negated regex match in `has()` filters, e.g. `g.V().has('name', notRegex('^A.*'))`. Lexer/parser/AST symmetrical with the existing `regex()`; translator emits `Not(Regex)` so the engine reuses the existing primitive. Cross-binding spec coverage in `predicates_extended.gtest`. ([#336](https://github.com/GrafeoDB/grafeo/pull/336), [@jakeboone02](https://github.com/jakeboone02))
+
+### Fixed
+
+- **`MATCH (n) RETURN n ORDER BY n.p LIMIT k` returned a raw NodeId instead of a resolved map** ([#335](https://github.com/GrafeoDB/grafeo/issues/335)): `sort_needs_augmenting_projection` checked whether the variable `n` appeared in `RETURN`, not whether the specific property column was materialised. The TopK probe then mutated `scalar_columns` as a side effect, causing the unfused re-plan to skip `NodeResolve` and emit raw `Int64` NodeIds. The predicate now requires `Property{v,p}` sort keys to find that exact property in `RETURN`, and `collect_vars` recurses into `Case` so CASE-wrapped property references are visible too (otherwise queries like `ORDER BY CASE c.tier ... END` silently route through the non-augmenting path). Diagnosis and initial fix by [@temporaryfix](https://github.com/temporaryfix) ([#337](https://github.com/GrafeoDB/grafeo/pull/337)).
+
+---
+
+Thanks to [@jakeboone02](https://github.com/jakeboone02) for the `notRegex()` predicate, and to [@temporaryfix](https://github.com/temporaryfix) for the precise root-cause analysis on [#335](https://github.com/GrafeoDB/grafeo/issues/335) — the side-effect interaction between `try_heap_topk_rewrite`'s probe and `plan_return_projection` was subtle, and the write-up made the follow-up extension to `collect_vars` straightforward.
+
 ## [0.5.42] - 2026-05-04
 
 End-to-end tiered storage: section data (LPG, RDF Ring, vector topology) can spill to mmap-backed disk under memory pressure or explicit configuration, with per-section tier overrides, introspection, and reload. Plus per-block columnar zone maps for selective range scans, paged HNSW topology, packed RDF Ring on disk, a WAL overlay for mutating mmap'd compact stores and a streaming top-K operator that fuses `ORDER BY ... LIMIT` into a single bounded-heap pass.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e3e962dae2b1e5007fe9e3db363ddc43a8bf25546d279f7a8a4401204690e80c"
 dependencies = [
  "clap",
 ]
@@ -1414,7 +1414,7 @@ dependencies = [
  "bincode",
  "grafeo-common",
  "grafeo-core",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "parking_lot",
  "rayon",
  "serde",
@@ -1481,7 +1481,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "dashmap",
  "foldhash 0.2.0",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "hkdf",
  "indexmap",
  "parking_lot",
@@ -1509,7 +1509,7 @@ dependencies = [
  "dashmap",
  "foldhash 0.2.0",
  "grafeo-common",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "ordered-float 5.3.0",
  "parking_lot",
@@ -1543,7 +1543,7 @@ dependencies = [
  "grafeo-common",
  "grafeo-core",
  "grafeo-storage",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "hf-hub",
  "indexmap",
  "md5",
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2053,7 +2053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2738,7 +2738,7 @@ dependencies = [
  "bytes",
  "chrono",
  "half",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -3830,9 +3830,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,7 +1397,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "grafeo"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "grafeo-adapters",
  "grafeo-common",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-adapters"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "bincode",
  "grafeo-common",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-bindings-common"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "grafeo-common",
  "grafeo-engine",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-c"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "grafeo-bindings-common",
  "grafeo-common",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-cli"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "anyhow",
  "clap",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-common"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "aes-gcm",
  "arcstr",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-core"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "arc-swap",
  "arcstr",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-engine"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "arcstr",
  "arrow-array",
@@ -1568,14 +1568,14 @@ dependencies = [
 
 [[package]]
 name = "grafeo-examples"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "grafeo",
 ]
 
 [[package]]
 name = "grafeo-node"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "grafeo-adapters",
  "grafeo-bindings-common",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-python"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "grafeo-adapters",
  "grafeo-bindings-common",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-spec-tests"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "grafeo-common",
  "grafeo-engine",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-storage"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "grafeo-wasm"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.4.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841321891f247aa86c6112c80d83d89cb36e0addd020fa2425085b8eb6c3f579"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -195,7 +195,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f955dfb73fae000425f49c8226d2044dab60fb7ad4af1e24f961756354d996c9"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
 dependencies = [
  "bytes",
  "half",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3b5846209775b6dc8056d77ff9a032b27043383dd5488abd0b663e265b9373"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8907ddd8f9fbabf91ec2c85c1d81fe2874e336d2443eb36373595e28b98dd5"
+checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -242,15 +242,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18aa020f6bc8e5201dcd2d4b7f98c68f8a410ef37128263243e6ff2a47a67d4f"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 
 [[package]]
 name = "arrow-select"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657ab5132e9c8ca3b24eb15a823d0ced38017fe3930ff50167466b02e2d592c"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.11.1"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
+checksum = "6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5"
 
 [[package]]
 name = "ctr"
@@ -977,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1414,7 +1414,7 @@ dependencies = [
  "bincode",
  "grafeo-common",
  "grafeo-core",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "parking_lot",
  "rayon",
  "serde",
@@ -1481,7 +1481,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "dashmap",
  "foldhash 0.2.0",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "hkdf",
  "indexmap",
  "parking_lot",
@@ -1509,7 +1509,7 @@ dependencies = [
  "dashmap",
  "foldhash 0.2.0",
  "grafeo-common",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "ordered-float 5.3.0",
  "parking_lot",
@@ -1543,7 +1543,7 @@ dependencies = [
  "grafeo-common",
  "grafeo-core",
  "grafeo-storage",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "hf-hub",
  "indexmap",
  "md5",
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2053,7 +2053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2381,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.8.6"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e55037284865448ecf329baa86a4d05401f647ebde99f5747b640d32c2c5226"
+checksum = "f1d395473824516f38dd1071a1a37bc57daa7be65b293ebba4ead5f7abb017a2"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2400,15 +2400,15 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
+checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.5"
+version = "3.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ba740fe4c9524d86fd90798fd8ccdb23402b3eef7e7c30897a8a369b529fcf"
+checksum = "89b3f766e04667e6da0e181e2da4f85475d5a6513b7cf6a80bea184e224a5b42"
 dependencies = [
  "convert_case",
  "ctor",
@@ -2730,15 +2730,15 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d7efd3052f7d6ef601085559a246bc991e9a8cc77e02753737df6322ce35f1"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
  "ahash",
  "bytes",
  "chrono",
  "half",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -3830,9 +3830,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.42"
+version = "0.5.43"
 edition = "2024"
 rust-version = "1.91.1"
 license = "Apache-2.0"
@@ -28,13 +28,13 @@ description = "A high-performance, embeddable graph database with support for LP
 
 [workspace.dependencies]
 # Internal crates (default-features = false to allow per-crate control)
-grafeo-common = { path = "crates/grafeo-common", version = "0.5.42" }
-grafeo-core = { path = "crates/grafeo-core", version = "0.5.42", default-features = false }
-grafeo-adapters = { path = "crates/grafeo-adapters", version = "0.5.42", default-features = false }
-grafeo-storage = { path = "crates/grafeo-storage", version = "0.5.42", default-features = false }
-grafeo-engine = { path = "crates/grafeo-engine", version = "0.5.42", default-features = false }
-grafeo = { path = "crates/grafeo", version = "0.5.42" }
-grafeo-bindings-common = { path = "crates/bindings/common", version = "0.5.42", default-features = false }
+grafeo-common = { path = "crates/grafeo-common", version = "0.5.43" }
+grafeo-core = { path = "crates/grafeo-core", version = "0.5.43", default-features = false }
+grafeo-adapters = { path = "crates/grafeo-adapters", version = "0.5.43", default-features = false }
+grafeo-storage = { path = "crates/grafeo-storage", version = "0.5.43", default-features = false }
+grafeo-engine = { path = "crates/grafeo-engine", version = "0.5.43", default-features = false }
+grafeo = { path = "crates/grafeo", version = "0.5.43" }
+grafeo-bindings-common = { path = "crates/bindings/common", version = "0.5.43", default-features = false }
 
 # Error handling
 thiserror = "2.0"

--- a/crates/bindings/csharp/src/Grafeo/Grafeo.csproj
+++ b/crates/bindings/csharp/src/Grafeo/Grafeo.csproj
@@ -6,7 +6,7 @@
 
     <!-- NuGet metadata -->
     <PackageId>Grafeo</PackageId>
-    <Version>0.5.42</Version>
+    <Version>0.5.43</Version>
     <Description>C# bindings for the Grafeo graph database. Supports GQL queries, ACID transactions, and vector search.</Description>
     <Authors>GrafeoDB</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/crates/bindings/dart/CHANGELOG.md
+++ b/crates/bindings/dart/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.43
+
+- Version bump to match workspace release
+
 ## 0.5.42
 
 - Version bump to match workspace release

--- a/crates/bindings/dart/README.md
+++ b/crates/bindings/dart/README.md
@@ -6,7 +6,7 @@ Dart FFI bindings for the [Grafeo](https://grafeo.dev) graph database. Wraps the
 
 ```yaml
 dependencies:
-  grafeo: ^0.5.42
+  grafeo: ^0.5.43
 ```
 
 You also need the `grafeo-c` native library for your platform. See [Building from Source](#building-from-source) below.

--- a/crates/bindings/dart/pubspec.yaml
+++ b/crates/bindings/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 name: grafeo
-version: 0.5.42
+version: 0.5.43
 description: >-
   High-performance embeddable graph database with GQL support.
   Dart bindings for grafeo-c via dart:ffi.

--- a/crates/bindings/node/Cargo.toml
+++ b/crates/bindings/node/Cargo.toml
@@ -20,7 +20,7 @@ grafeo-adapters = { path = "../../grafeo-adapters" }
 grafeo-bindings-common = { path = "../common" }
 
 napi = { version = "3", default-features = false, features = ["napi9", "async", "serde-json", "error_anyhow"] }
-napi-derive = "3.5.5"
+napi-derive = "3.5.6"
 parking_lot.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/bindings/node/index.js
+++ b/crates/bindings/node/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-android-arm64')
         const bindingPackageVersion = require('@grafeo-db/js-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-android-arm-eabi')
         const bindingPackageVersion = require('@grafeo-db/js-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-win32-x64-gnu')
         const bindingPackageVersion = require('@grafeo-db/js-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-win32-x64-msvc')
         const bindingPackageVersion = require('@grafeo-db/js-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-win32-ia32-msvc')
         const bindingPackageVersion = require('@grafeo-db/js-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-win32-arm64-msvc')
         const bindingPackageVersion = require('@grafeo-db/js-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@grafeo-db/js-darwin-universal')
       const bindingPackageVersion = require('@grafeo-db/js-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-darwin-x64')
         const bindingPackageVersion = require('@grafeo-db/js-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-darwin-arm64')
         const bindingPackageVersion = require('@grafeo-db/js-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-freebsd-x64')
         const bindingPackageVersion = require('@grafeo-db/js-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-freebsd-arm64')
         const bindingPackageVersion = require('@grafeo-db/js-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-x64-musl')
           const bindingPackageVersion = require('@grafeo-db/js-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-x64-gnu')
           const bindingPackageVersion = require('@grafeo-db/js-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-arm64-musl')
           const bindingPackageVersion = require('@grafeo-db/js-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-arm64-gnu')
           const bindingPackageVersion = require('@grafeo-db/js-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-arm-musleabihf')
           const bindingPackageVersion = require('@grafeo-db/js-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@grafeo-db/js-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-loong64-musl')
           const bindingPackageVersion = require('@grafeo-db/js-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-loong64-gnu')
           const bindingPackageVersion = require('@grafeo-db/js-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-riscv64-musl')
           const bindingPackageVersion = require('@grafeo-db/js-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@grafeo-db/js-linux-riscv64-gnu')
           const bindingPackageVersion = require('@grafeo-db/js-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-linux-ppc64-gnu')
         const bindingPackageVersion = require('@grafeo-db/js-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-linux-s390x-gnu')
         const bindingPackageVersion = require('@grafeo-db/js-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-openharmony-arm64')
         const bindingPackageVersion = require('@grafeo-db/js-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-openharmony-x64')
         const bindingPackageVersion = require('@grafeo-db/js-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@grafeo-db/js-openharmony-arm')
         const bindingPackageVersion = require('@grafeo-db/js-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.5.42' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.42 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.43' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.43 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/crates/bindings/node/npm/darwin-arm64/package.json
+++ b/crates/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js-darwin-arm64",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "os": [
     "darwin"
   ],

--- a/crates/bindings/node/npm/darwin-x64/package.json
+++ b/crates/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js-darwin-x64",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "os": [
     "darwin"
   ],

--- a/crates/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/crates/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js-linux-arm64-gnu",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "os": [
     "linux"
   ],

--- a/crates/bindings/node/npm/linux-arm64-musl/package.json
+++ b/crates/bindings/node/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js-linux-arm64-musl",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "os": [
     "linux"
   ],

--- a/crates/bindings/node/npm/linux-x64-gnu/package.json
+++ b/crates/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js-linux-x64-gnu",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "os": [
     "linux"
   ],

--- a/crates/bindings/node/npm/win32-x64-msvc/package.json
+++ b/crates/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js-win32-x64-msvc",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "os": [
     "win32"
   ],

--- a/crates/bindings/node/package.json
+++ b/crates/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/js",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "description": "Node.js/TypeScript bindings for Grafeo - a high-performance embeddable graph database",
   "main": "index.js",
   "types": "index.d.ts",
@@ -20,12 +20,12 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@grafeo-db/js-darwin-x64": "0.5.42",
-    "@grafeo-db/js-win32-x64-msvc": "0.5.42",
-    "@grafeo-db/js-linux-x64-gnu": "0.5.42",
-    "@grafeo-db/js-darwin-arm64": "0.5.42",
-    "@grafeo-db/js-linux-arm64-gnu": "0.5.42",
-    "@grafeo-db/js-linux-arm64-musl": "0.5.42"
+    "@grafeo-db/js-darwin-x64": "0.5.43",
+    "@grafeo-db/js-win32-x64-msvc": "0.5.43",
+    "@grafeo-db/js-linux-x64-gnu": "0.5.43",
+    "@grafeo-db/js-darwin-arm64": "0.5.43",
+    "@grafeo-db/js-linux-arm64-gnu": "0.5.43",
+    "@grafeo-db/js-linux-arm64-musl": "0.5.43"
   },
   "keywords": [
     "graph",

--- a/crates/bindings/python/pyproject.toml
+++ b/crates/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "grafeo"
-version = "0.5.42"
+version = "0.5.43"
 description = "A high-performance, embeddable graph database with Python bindings"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/crates/bindings/wasm/package-lite.json
+++ b/crates/bindings/wasm/package-lite.json
@@ -1,7 +1,7 @@
 {
   "name": "@grafeo-db/wasm-lite",
   "type": "module",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "description": "WebAssembly bindings for Grafeo - GQL-only lightweight variant",
   "keywords": [
     "graph",

--- a/crates/bindings/wasm/package.json
+++ b/crates/bindings/wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grafeo-db/wasm",
   "type": "module",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "description": "WebAssembly bindings for Grafeo - a high-performance embeddable graph database",
   "keywords": [
     "graph",

--- a/crates/grafeo-engine/src/query/planner/lpg/project.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/project.rs
@@ -1366,6 +1366,22 @@ fn collect_vars(expr: &LogicalExpression, out: &mut Vec<String>) {
             collect_vars(right, out);
         }
         LogicalExpression::Unary { operand, .. } => collect_vars(operand, out),
+        LogicalExpression::Case {
+            operand,
+            when_clauses,
+            else_clause,
+        } => {
+            if let Some(o) = operand {
+                collect_vars(o, out);
+            }
+            for (when, then) in when_clauses {
+                collect_vars(when, out);
+                collect_vars(then, out);
+            }
+            if let Some(e) = else_clause {
+                collect_vars(e, out);
+            }
+        }
         _ => {}
     }
 }
@@ -1373,9 +1389,16 @@ fn collect_vars(expr: &LogicalExpression, out: &mut Vec<String>) {
 /// True if `sort` requires injecting extra projection columns before sorting.
 ///
 /// Mirrors the logic at the top of `plan_sort`: when the sort input is a
-/// `Return` and any sort key references a variable that the RETURN clause has
-/// projected away, the planner must augment the Return with extra columns so
-/// the sort key is available at compare time.
+/// `Return` and any sort key is not fully materialised by that Return, the
+/// planner must augment the Return with extra columns so the sort key is
+/// available at compare time.
+///
+/// Two cases trigger augmenting:
+/// - Sort key `Property { v, p }` where Return does not explicitly project
+///   that property (e.g. `RETURN n ORDER BY n.title`: "n" is in Return but
+///   "n_title" is not a column, returning a full node is not enough).
+/// - Sort key whose expression references a variable `v` that is absent
+///   from Return entirely (covers wrapped references like `CASE n.tier ...`).
 ///
 /// Used by both `plan_sort` (which knows how to inject the augmenting
 /// projection) and `try_heap_topk_rewrite` (which doesn't, and bails out so
@@ -1384,18 +1407,33 @@ pub(super) fn sort_needs_augmenting_projection(sort: &SortOp) -> bool {
     let LogicalOperator::Return(ret) = sort.input.as_ref() else {
         return false;
     };
-    sort.keys.iter().any(|key| {
-        let mut vars = Vec::new();
-        collect_vars(&key.expression, &mut vars);
-        vars.iter().any(|variable| {
+    sort.keys.iter().any(|key| match &key.expression {
+        LogicalExpression::Property { variable, property } => {
+            // Sort key is v.p. Return satisfies it only if it explicitly
+            // projects Property{v,p}. Returning Variable(v) as a full node
+            // is not sufficient: the sort column "v_p" does not exist in
+            // the output, so augmenting is needed.
             !ret.items.iter().any(|item| {
-                item.alias.as_deref() == Some(variable)
-                    || matches!(
-                        &item.expression,
-                        LogicalExpression::Variable(v) if v == variable
-                    )
+                matches!(
+                    &item.expression,
+                    LogicalExpression::Property { variable: v, property: p }
+                    if v == variable && p == property
+                )
             })
-        })
+        }
+        _ => {
+            let mut vars = Vec::new();
+            collect_vars(&key.expression, &mut vars);
+            vars.iter().any(|variable| {
+                !ret.items.iter().any(|item| {
+                    item.alias.as_deref() == Some(variable)
+                        || matches!(
+                            &item.expression,
+                            LogicalExpression::Variable(v) if v == variable
+                        )
+                })
+            })
+        }
     })
 }
 

--- a/crates/grafeo-engine/tests/topk_rewrite.rs
+++ b/crates/grafeo-engine/tests/topk_rewrite.rs
@@ -263,3 +263,42 @@ fn cypher_order_by_limit_uses_topk() {
     let actual_top5: Vec<Value> = result.rows().iter().map(|row| row[0].clone()).collect();
     assert_eq!(actual_top5, expected_top5);
 }
+
+// Regression test for issue #335: ORDER BY + LIMIT on a full-node RETURN
+// was returning raw NodeIds instead of resolved maps. The heap top-K probe
+// inside try_heap_topk_rewrite mutated scalar_columns as a side effect,
+// causing the unfused re-plan of the same Return subtree to skip NodeResolve.
+#[test]
+fn order_by_limit_node_return_yields_map() {
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+    session
+        .execute("INSERT (:Article {title: 'A1', body: 'rust database internals'})")
+        .unwrap();
+
+    // Each variant must return Value::Map, not a raw integer NodeId.
+    let result = session.execute("MATCH (n:Article) RETURN n").unwrap();
+    assert!(result.rows()[0][0].as_map().is_some(), "bare RETURN n");
+
+    let result = session
+        .execute("MATCH (n:Article) RETURN n LIMIT 50")
+        .unwrap();
+    assert!(result.rows()[0][0].as_map().is_some(), "RETURN n LIMIT 50");
+
+    let result = session
+        .execute("MATCH (n:Article) RETURN n ORDER BY n.title")
+        .unwrap();
+    assert!(
+        result.rows()[0][0].as_map().is_some(),
+        "RETURN n ORDER BY n.title"
+    );
+
+    let result = session
+        .execute("MATCH (n:Article) RETURN n ORDER BY n.title LIMIT 50")
+        .unwrap();
+    assert!(
+        result.rows()[0][0].as_map().is_some(),
+        "RETURN n ORDER BY n.title LIMIT 50: col 0 = {:?}",
+        result.rows()[0][0]
+    );
+}

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -97,7 +97,7 @@ grafeo shell ./mydb
 ```
 
 ```
-Grafeo 0.5.42 - Lpg mode, 42 nodes, 87 edges
+Grafeo 0.5.43 - Lpg mode, 42 nodes, 87 edges
 Type :help for commands, :quit to exit.
 
 grafeo> MATCH (n:Person) RETURN n.name, n.age
@@ -231,7 +231,7 @@ grafeo completions powershell >> $PROFILE
 
 ```bash
 $ grafeo version
-grafeo 0.5.42
+grafeo 0.5.43
 
 Build:
   rustc:    1.91.1

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -125,7 +125,7 @@ Add to `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  grafeo: ^0.5.42
+  grafeo: ^0.5.43
 ```
 
 ### Verify Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -292,7 +292,7 @@ Choose the query language that fits the project:
     ```yaml
     # pubspec.yaml
     dependencies:
-      grafeo: ^0.5.42
+      grafeo: ^0.5.43
     ```
 
 === "WASM"

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -2,6 +2,6 @@
 
 {% block announce %}
   <a href="https://github.com/GrafeoDB/grafeo/releases">
-    Grafeo v0.5.42 is now available!
+    Grafeo v0.5.43 is now available!
   </a>
 {% endblock %}

--- a/packages/grafeo-cli-npm/package.json
+++ b/packages/grafeo-cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafeo-db/cli",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "description": "Command-line interface for Grafeo graph database",
   "license": "Apache-2.0",
   "repository": {
@@ -25,11 +25,11 @@
     "LICENSE"
   ],
   "optionalDependencies": {
-    "@grafeo-db/cli-linux-x64": "0.5.42",
-    "@grafeo-db/cli-linux-arm64": "0.5.42",
-    "@grafeo-db/cli-darwin-x64": "0.5.42",
-    "@grafeo-db/cli-darwin-arm64": "0.5.42",
-    "@grafeo-db/cli-win32-x64": "0.5.42"
+    "@grafeo-db/cli-linux-x64": "0.5.43",
+    "@grafeo-db/cli-linux-arm64": "0.5.43",
+    "@grafeo-db/cli-darwin-x64": "0.5.43",
+    "@grafeo-db/cli-darwin-arm64": "0.5.43",
+    "@grafeo-db/cli-win32-x64": "0.5.43"
   },
   "engines": {
     "node": ">=18"

--- a/packages/grafeo-cli-python/grafeo_cli/__init__.py
+++ b/packages/grafeo-cli-python/grafeo_cli/__init__.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-__version__ = "0.5.42"
+__version__ = "0.5.43"
 
 # GitHub release download URL template
 _GITHUB_RELEASE = "https://github.com/GrafeoDB/grafeo/releases/download"

--- a/packages/grafeo-cli-python/pyproject.toml
+++ b/packages/grafeo-cli-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grafeo-cli"
-version = "0.5.42"
+version = "0.5.43"
 description = "Command-line interface for Grafeo graph database"
 readme = "README.md"
 license = { text = "Apache-2.0"}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Release 0.5.43 adds the Gremlin `notRegex()` predicate and fixes a planner bug where `RETURN n ORDER BY n.p LIMIT k` could return raw NodeIds. It also bumps bindings/CLI/docs to 0.5.43, updates CI to `crate-ci/typos@v1.46.2`, and upgrades Rust deps (Arrow/Parquet 58.3.0, `dashmap` 6.2.1, `hashbrown` 0.17.1, `tokio` 1.52.3, `clap_complete` 4.6.5, `napi` 3.9.0).

- **New Features**
  - Gremlin `notRegex()` predicate for `has()` filters, e.g. `g.V().has('name', notRegex('^A.*'))`.

- **Bug Fixes**
  - Planner now augments `RETURN` when sorting by a specific property or a `CASE`-wrapped reference, ensuring `ORDER BY ... LIMIT` over `RETURN n` returns resolved maps, not NodeIds.
  - Added regression tests for `RETURN n`, `RETURN n LIMIT`, `RETURN n ORDER BY n.title`, and `RETURN n ORDER BY n.title LIMIT`.

<sup>Written for commit 8242bebf5b4e1dc417b3ed6e948df19b14513a33. Summary will update on new commits. <a href="https://cubic.dev/pr/GrafeoDB/grafeo/pull/339?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

