### PR TITLE
feat: add support for Gremlin negated text predicates

### DIFF
--- a/crates/grafeo-adapters/src/query/gremlin/ast.rs
+++ b/crates/grafeo-adapters/src/query/gremlin/ast.rs
@@ -211,6 +211,12 @@ pub enum Predicate {
     Regex(String),
     /// P.notRegex(pattern)
     NotRegex(String),
+    /// P.notContaining(substring)
+    NotContaining(String),
+    /// P.notStartingWith(prefix)
+    NotStartingWith(String),
+    /// P.notEndingWith(suffix)
+    NotEndingWith(String),
     /// P.and(predicates...)
     And(Vec<Predicate>),
     /// P.or(predicates...)

--- a/crates/grafeo-adapters/src/query/gremlin/lexer.rs
+++ b/crates/grafeo-adapters/src/query/gremlin/lexer.rs
@@ -207,6 +207,12 @@ pub enum TokenKind {
     Regex,
     /// The `notRegex()` negated regular-expression predicate.
     NotRegex,
+    /// The `notContaining()` negated substring predicate.
+    NotContaining,
+    /// The `notStartingWith()` negated prefix predicate.
+    NotStartingWith,
+    /// The `notEndingWith()` negated suffix predicate.
+    NotEndingWith,
 
     // Tokens (T.*)
     /// The `T` token namespace (e.g., `T.id`, `T.label`).
@@ -544,6 +550,9 @@ impl<'a> Lexer<'a> {
             "endingWith" => TokenKind::EndingWith,
             "regex" => TokenKind::Regex,
             "notRegex" => TokenKind::NotRegex,
+            "notContaining" => TokenKind::NotContaining,
+            "notStartingWith" => TokenKind::NotStartingWith,
+            "notEndingWith" => TokenKind::NotEndingWith,
             "T" => TokenKind::T,
             "asc" => TokenKind::Asc,
             "desc" => TokenKind::Desc,

--- a/crates/grafeo-adapters/src/query/gremlin/parser.rs
+++ b/crates/grafeo-adapters/src/query/gremlin/parser.rs
@@ -634,6 +634,9 @@ impl<'a> Parser<'a> {
             Some(TokenKind::EndingWith) => Some(TokenKind::EndingWith),
             Some(TokenKind::Regex) => Some(TokenKind::Regex),
             Some(TokenKind::NotRegex) => Some(TokenKind::NotRegex),
+            Some(TokenKind::NotContaining) => Some(TokenKind::NotContaining),
+            Some(TokenKind::NotStartingWith) => Some(TokenKind::NotStartingWith),
+            Some(TokenKind::NotEndingWith) => Some(TokenKind::NotEndingWith),
             _ => None,
         };
 
@@ -714,6 +717,18 @@ impl<'a> Parser<'a> {
             TokenKind::NotRegex => {
                 let s = self.parse_string()?;
                 Predicate::NotRegex(s)
+            }
+            TokenKind::NotContaining => {
+                let s = self.parse_string()?;
+                Predicate::NotContaining(s)
+            }
+            TokenKind::NotStartingWith => {
+                let s = self.parse_string()?;
+                Predicate::NotStartingWith(s)
+            }
+            TokenKind::NotEndingWith => {
+                let s = self.parse_string()?;
+                Predicate::NotEndingWith(s)
             }
             _ => return Err(self.error("Unknown predicate")),
         };

--- a/crates/grafeo-engine/src/query/translators/gremlin.rs
+++ b/crates/grafeo-engine/src/query/translators/gremlin.rs
@@ -2126,9 +2126,7 @@ impl GremlinTranslator {
                 operand: Box::new(LogicalExpression::Binary {
                     left: Box::new(expr),
                     op: BinaryOp::Contains,
-                    right: Box::new(LogicalExpression::Literal(Value::String(
-                        s.clone().into(),
-                    ))),
+                    right: Box::new(LogicalExpression::Literal(Value::String(s.clone().into()))),
                 }),
             }),
             ast::Predicate::NotStartingWith(s) => Ok(LogicalExpression::Unary {
@@ -2136,9 +2134,7 @@ impl GremlinTranslator {
                 operand: Box::new(LogicalExpression::Binary {
                     left: Box::new(expr),
                     op: BinaryOp::StartsWith,
-                    right: Box::new(LogicalExpression::Literal(Value::String(
-                        s.clone().into(),
-                    ))),
+                    right: Box::new(LogicalExpression::Literal(Value::String(s.clone().into()))),
                 }),
             }),
             ast::Predicate::NotEndingWith(s) => Ok(LogicalExpression::Unary {
@@ -2146,9 +2142,7 @@ impl GremlinTranslator {
                 operand: Box::new(LogicalExpression::Binary {
                     left: Box::new(expr),
                     op: BinaryOp::EndsWith,
-                    right: Box::new(LogicalExpression::Literal(Value::String(
-                        s.clone().into(),
-                    ))),
+                    right: Box::new(LogicalExpression::Literal(Value::String(s.clone().into()))),
                 }),
             }),
         }

--- a/crates/grafeo-engine/src/query/translators/gremlin.rs
+++ b/crates/grafeo-engine/src/query/translators/gremlin.rs
@@ -2121,6 +2121,36 @@ impl GremlinTranslator {
                     ))),
                 }),
             }),
+            ast::Predicate::NotContaining(s) => Ok(LogicalExpression::Unary {
+                op: UnaryOp::Not,
+                operand: Box::new(LogicalExpression::Binary {
+                    left: Box::new(expr),
+                    op: BinaryOp::Contains,
+                    right: Box::new(LogicalExpression::Literal(Value::String(
+                        s.clone().into(),
+                    ))),
+                }),
+            }),
+            ast::Predicate::NotStartingWith(s) => Ok(LogicalExpression::Unary {
+                op: UnaryOp::Not,
+                operand: Box::new(LogicalExpression::Binary {
+                    left: Box::new(expr),
+                    op: BinaryOp::StartsWith,
+                    right: Box::new(LogicalExpression::Literal(Value::String(
+                        s.clone().into(),
+                    ))),
+                }),
+            }),
+            ast::Predicate::NotEndingWith(s) => Ok(LogicalExpression::Unary {
+                op: UnaryOp::Not,
+                operand: Box::new(LogicalExpression::Binary {
+                    left: Box::new(expr),
+                    op: BinaryOp::EndsWith,
+                    right: Box::new(LogicalExpression::Literal(Value::String(
+                        s.clone().into(),
+                    ))),
+                }),
+            }),
         }
     }
 
@@ -2884,6 +2914,74 @@ mod tests {
             assert_eq!(op, BinaryOp::EndsWith);
         } else {
             panic!("Expected Binary expression");
+        }
+    }
+
+    #[test]
+    fn test_predicate_not_containing() {
+        let expr = LogicalExpression::Variable("x".to_string());
+        let pred = ast::Predicate::NotContaining("test".to_string());
+        let result = GremlinTranslator::translate_predicate(&pred, expr).unwrap();
+
+        if let LogicalExpression::Unary {
+            op: UnaryOp::Not,
+            operand,
+        } = result
+        {
+            if let LogicalExpression::Binary { op, .. } = operand.as_ref() {
+                assert_eq!(*op, BinaryOp::Contains);
+            } else {
+                panic!("Expected Binary expression inside Not");
+            }
+        } else {
+            panic!("Expected Unary Not expression");
+        }
+    }
+
+    #[test]
+    fn test_predicate_not_starting_with() {
+        let expr = LogicalExpression::Variable("x".to_string());
+        let pred = ast::Predicate::NotStartingWith("foo".to_string());
+        let result = GremlinTranslator::translate_predicate(&pred, expr).unwrap();
+
+        if let LogicalExpression::Unary {
+            op: UnaryOp::Not,
+            operand,
+        } = result
+        {
+            if let LogicalExpression::Binary { op, right, .. } = operand.as_ref() {
+                assert_eq!(*op, BinaryOp::StartsWith);
+                if let LogicalExpression::Literal(Value::String(s)) = right.as_ref() {
+                    assert_eq!(s.as_str(), "foo");
+                } else {
+                    panic!("Expected String literal on the right");
+                }
+            } else {
+                panic!("Expected Binary expression inside Not");
+            }
+        } else {
+            panic!("Expected Unary Not expression");
+        }
+    }
+
+    #[test]
+    fn test_predicate_not_ending_with() {
+        let expr = LogicalExpression::Variable("x".to_string());
+        let pred = ast::Predicate::NotEndingWith(".txt".to_string());
+        let result = GremlinTranslator::translate_predicate(&pred, expr).unwrap();
+
+        if let LogicalExpression::Unary {
+            op: UnaryOp::Not,
+            operand,
+        } = result
+        {
+            if let LogicalExpression::Binary { op, .. } = operand.as_ref() {
+                assert_eq!(*op, BinaryOp::EndsWith);
+            } else {
+                panic!("Expected Binary expression inside Not");
+            }
+        } else {
+            panic!("Expected Unary Not expression");
         }
     }
 

--- a/crates/grafeo-engine/src/query/translators/gremlin.rs
+++ b/crates/grafeo-engine/src/query/translators/gremlin.rs
@@ -2912,64 +2912,6 @@ mod tests {
     }
 
     #[test]
-    fn test_predicate_not_containing() {
-        let expr = LogicalExpression::Variable("x".to_string());
-        let pred = ast::Predicate::NotContaining("test".to_string());
-        let result = GremlinTranslator::translate_predicate(&pred, expr).unwrap();
-
-        let LogicalExpression::Unary { op, operand } = result else {
-            unreachable!()
-        };
-        assert_eq!(op, UnaryOp::Not);
-        assert!(matches!(
-            operand.as_ref(),
-            LogicalExpression::Binary {
-                op: BinaryOp::Contains,
-                ..
-            }
-        ));
-    }
-
-    #[test]
-    fn test_predicate_not_starting_with() {
-        let expr = LogicalExpression::Variable("x".to_string());
-        let pred = ast::Predicate::NotStartingWith("foo".to_string());
-        let result = GremlinTranslator::translate_predicate(&pred, expr).unwrap();
-
-        let LogicalExpression::Unary { op, operand } = result else {
-            unreachable!()
-        };
-        assert_eq!(op, UnaryOp::Not);
-        let LogicalExpression::Binary { op, right, .. } = operand.as_ref() else {
-            unreachable!()
-        };
-        assert_eq!(*op, BinaryOp::StartsWith);
-        let LogicalExpression::Literal(Value::String(s)) = right.as_ref() else {
-            unreachable!()
-        };
-        assert_eq!(s.as_str(), "foo");
-    }
-
-    #[test]
-    fn test_predicate_not_ending_with() {
-        let expr = LogicalExpression::Variable("x".to_string());
-        let pred = ast::Predicate::NotEndingWith(".txt".to_string());
-        let result = GremlinTranslator::translate_predicate(&pred, expr).unwrap();
-
-        let LogicalExpression::Unary { op, operand } = result else {
-            unreachable!()
-        };
-        assert_eq!(op, UnaryOp::Not);
-        assert!(matches!(
-            operand.as_ref(),
-            LogicalExpression::Binary {
-                op: BinaryOp::EndsWith,
-                ..
-            }
-        ));
-    }
-
-    #[test]
     fn test_predicate_between_produces_and_of_ge_lt() {
         // between(10, 20) should produce: x >= 10 AND x < 20
         let expr = LogicalExpression::Variable("x".to_string());

--- a/crates/grafeo-engine/src/query/translators/gremlin.rs
+++ b/crates/grafeo-engine/src/query/translators/gremlin.rs
@@ -2917,15 +2917,16 @@ mod tests {
         let pred = ast::Predicate::NotContaining("test".to_string());
         let result = GremlinTranslator::translate_predicate(&pred, expr).unwrap();
 
+        let LogicalExpression::Unary { op, operand } = result else {
+            unreachable!()
+        };
+        assert_eq!(op, UnaryOp::Not);
         assert!(matches!(
-            &result,
-            LogicalExpression::Unary {
-                op: UnaryOp::Not,
-                operand,
-            } if matches!(
-                operand.as_ref(),
-                LogicalExpression::Binary { op: BinaryOp::Contains, .. }
-            )
+            operand.as_ref(),
+            LogicalExpression::Binary {
+                op: BinaryOp::Contains,
+                ..
+            }
         ));
     }
 
@@ -2935,23 +2936,18 @@ mod tests {
         let pred = ast::Predicate::NotStartingWith("foo".to_string());
         let result = GremlinTranslator::translate_predicate(&pred, expr).unwrap();
 
-        assert!(matches!(
-            &result,
-            LogicalExpression::Unary {
-                op: UnaryOp::Not,
-                operand,
-            } if matches!(
-                operand.as_ref(),
-                LogicalExpression::Binary {
-                    op: BinaryOp::StartsWith,
-                    right,
-                    ..
-                } if matches!(
-                    right.as_ref(),
-                    LogicalExpression::Literal(Value::String(s)) if s.as_str() == "foo"
-                )
-            )
-        ));
+        let LogicalExpression::Unary { op, operand } = result else {
+            unreachable!()
+        };
+        assert_eq!(op, UnaryOp::Not);
+        let LogicalExpression::Binary { op, right, .. } = operand.as_ref() else {
+            unreachable!()
+        };
+        assert_eq!(*op, BinaryOp::StartsWith);
+        let LogicalExpression::Literal(Value::String(s)) = right.as_ref() else {
+            unreachable!()
+        };
+        assert_eq!(s.as_str(), "foo");
     }
 
     #[test]
@@ -2960,15 +2956,16 @@ mod tests {
         let pred = ast::Predicate::NotEndingWith(".txt".to_string());
         let result = GremlinTranslator::translate_predicate(&pred, expr).unwrap();
 
+        let LogicalExpression::Unary { op, operand } = result else {
+            unreachable!()
+        };
+        assert_eq!(op, UnaryOp::Not);
         assert!(matches!(
-            &result,
-            LogicalExpression::Unary {
-                op: UnaryOp::Not,
-                operand,
-            } if matches!(
-                operand.as_ref(),
-                LogicalExpression::Binary { op: BinaryOp::EndsWith, .. }
-            )
+            operand.as_ref(),
+            LogicalExpression::Binary {
+                op: BinaryOp::EndsWith,
+                ..
+            }
         ));
     }
 

--- a/crates/grafeo-engine/src/query/translators/gremlin.rs
+++ b/crates/grafeo-engine/src/query/translators/gremlin.rs
@@ -2917,19 +2917,16 @@ mod tests {
         let pred = ast::Predicate::NotContaining("test".to_string());
         let result = GremlinTranslator::translate_predicate(&pred, expr).unwrap();
 
-        if let LogicalExpression::Unary {
-            op: UnaryOp::Not,
-            operand,
-        } = result
-        {
-            if let LogicalExpression::Binary { op, .. } = operand.as_ref() {
-                assert_eq!(*op, BinaryOp::Contains);
-            } else {
-                panic!("Expected Binary expression inside Not");
-            }
-        } else {
-            panic!("Expected Unary Not expression");
-        }
+        assert!(matches!(
+            &result,
+            LogicalExpression::Unary {
+                op: UnaryOp::Not,
+                operand,
+            } if matches!(
+                operand.as_ref(),
+                LogicalExpression::Binary { op: BinaryOp::Contains, .. }
+            )
+        ));
     }
 
     #[test]
@@ -2938,24 +2935,23 @@ mod tests {
         let pred = ast::Predicate::NotStartingWith("foo".to_string());
         let result = GremlinTranslator::translate_predicate(&pred, expr).unwrap();
 
-        if let LogicalExpression::Unary {
-            op: UnaryOp::Not,
-            operand,
-        } = result
-        {
-            if let LogicalExpression::Binary { op, right, .. } = operand.as_ref() {
-                assert_eq!(*op, BinaryOp::StartsWith);
-                if let LogicalExpression::Literal(Value::String(s)) = right.as_ref() {
-                    assert_eq!(s.as_str(), "foo");
-                } else {
-                    panic!("Expected String literal on the right");
-                }
-            } else {
-                panic!("Expected Binary expression inside Not");
-            }
-        } else {
-            panic!("Expected Unary Not expression");
-        }
+        assert!(matches!(
+            &result,
+            LogicalExpression::Unary {
+                op: UnaryOp::Not,
+                operand,
+            } if matches!(
+                operand.as_ref(),
+                LogicalExpression::Binary {
+                    op: BinaryOp::StartsWith,
+                    right,
+                    ..
+                } if matches!(
+                    right.as_ref(),
+                    LogicalExpression::Literal(Value::String(s)) if s.as_str() == "foo"
+                )
+            )
+        ));
     }
 
     #[test]
@@ -2964,19 +2960,16 @@ mod tests {
         let pred = ast::Predicate::NotEndingWith(".txt".to_string());
         let result = GremlinTranslator::translate_predicate(&pred, expr).unwrap();
 
-        if let LogicalExpression::Unary {
-            op: UnaryOp::Not,
-            operand,
-        } = result
-        {
-            if let LogicalExpression::Binary { op, .. } = operand.as_ref() {
-                assert_eq!(*op, BinaryOp::EndsWith);
-            } else {
-                panic!("Expected Binary expression inside Not");
-            }
-        } else {
-            panic!("Expected Unary Not expression");
-        }
+        assert!(matches!(
+            &result,
+            LogicalExpression::Unary {
+                op: UnaryOp::Not,
+                operand,
+            } if matches!(
+                operand.as_ref(),
+                LogicalExpression::Binary { op: BinaryOp::EndsWith, .. }
+            )
+        ));
     }
 
     #[test]

--- a/crates/grafeo-engine/tests/gremlin.rs
+++ b/crates/grafeo-engine/tests/gremlin.rs
@@ -1471,6 +1471,49 @@ fn test_has_property_not_regex_substring_match() {
 }
 
 // ============================================================================
+// Text Predicates: notContaining(), notStartingWith(), notEndingWith()
+// ============================================================================
+
+#[test]
+fn test_has_property_not_containing() {
+    let db = create_social_network();
+    let result = db
+        .execute_gremlin("g.V().hasLabel('Person').has('city', notContaining('er'))")
+        .unwrap();
+    assert_eq!(
+        result.row_count(),
+        1,
+        "Only Paris does not contain 'er'"
+    );
+}
+
+#[test]
+fn test_has_property_not_starting_with() {
+    let db = create_social_network();
+    let result = db
+        .execute_gremlin("g.V().hasLabel('Person').has('city', notStartingWith('Am'))")
+        .unwrap();
+    assert_eq!(
+        result.row_count(),
+        2,
+        "Berlin and Paris do not start with 'Am'"
+    );
+}
+
+#[test]
+fn test_has_property_not_ending_with() {
+    let db = create_social_network();
+    let result = db
+        .execute_gremlin("g.V().hasLabel('Person').has('city', notEndingWith('is'))")
+        .unwrap();
+    assert_eq!(
+        result.row_count(),
+        2,
+        "Amsterdam and Berlin do not end with 'is'"
+    );
+}
+
+// ============================================================================
 // Dedup with Keys
 // ============================================================================
 

--- a/crates/grafeo-engine/tests/gremlin.rs
+++ b/crates/grafeo-engine/tests/gremlin.rs
@@ -1480,11 +1480,7 @@ fn test_has_property_not_containing() {
     let result = db
         .execute_gremlin("g.V().hasLabel('Person').has('city', notContaining('er'))")
         .unwrap();
-    assert_eq!(
-        result.row_count(),
-        1,
-        "Only Paris does not contain 'er'"
-    );
+    assert_eq!(result.row_count(), 1, "Only Paris does not contain 'er'");
 }
 
 #[test]

--- a/tests/spec/lpg/gremlin/predicates_extended.gtest
+++ b/tests/spec/lpg/gremlin/predicates_extended.gtest
@@ -168,6 +168,30 @@ tests:
         - [1]
 
   # ---------------------------------------------------------------------------
+  # notContaining() / notStartingWith() / notEndingWith() predicates
+  # ---------------------------------------------------------------------------
+
+  - name: not_containing
+    query: "g.V().hasLabel('Person').has('city', notContaining('er')).count()"
+    expect:
+      rows:
+        - [1]
+
+  - name: not_starting_with
+    query: "g.V().hasLabel('Person').has('city', notStartingWith('Am')).values('name')"
+    expect:
+      rows:
+        - [Gus]
+        - [Vincent]
+
+  - name: not_ending_with
+    query: "g.V().hasLabel('Person').has('city', notEndingWith('is')).values('name')"
+    expect:
+      rows:
+        - [Alix]
+        - [Gus]
+
+  # ---------------------------------------------------------------------------
   # Compound predicates P.and(), P.or(), P.not()
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Adds support for Gremlin negated text predicates `notContaining`, `notStartingWith`, and `notEndingWith`.

## How was it tested?

Local `cargo test --all-features --workspace`.

## Community PR checklist

- [x] **No unsolicited architecture changes.** New crates, new workspace dependencies, changes to `grafeo-core`/`grafeo-engine` internals, or new feature flags were either (a) requested in the linked issue or (b) discussed and approved in a GitHub Discussion before this PR was opened.
- [x] **No changes to shared infrastructure.** CI workflows (`.github/workflows/`), the root `Cargo.toml`, `codecov.yml`, and `scripts/` are not modified unless the change is the explicit purpose of this PR.
- [x] **No naming or concept conflicts.** I have searched the codebase and existing issues/discussions to confirm that any new types, modules, or subsystem names do not duplicate or conflict with existing ones.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Gremlin negated text predicates: `notContaining`, `notStartingWith`, and `notEndingWith`. Enables negative substring, prefix, and suffix filters in `has()`, and removes redundant Gremlin tests.

- **New Features**
  - Lexer, parser, and AST recognize `notContaining`, `notStartingWith`, `notEndingWith`.
  - Translator emits logical NOT of `Contains`/`StartsWith`/`EndsWith`.
  - Expanded translator unit tests and engine/spec tests for `has('prop', not...())` cases.

<sup>Written for commit 1d458c7f0e10a8a7c464a957295face2573a8dde. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

