### PR TITLE
fix(compact): preserve base-tier adjacency when source node is dirty

### DIFF
--- a/crates/grafeo-core/src/graph/compact/layered.rs
+++ b/crates/grafeo-core/src/graph/compact/layered.rs
@@ -579,8 +579,15 @@ impl GraphStore for LayeredStore {
 
         let mut results = Vec::new();
 
-        // Base neighbors (minus deleted).
-        if !deleted_nodes.contains(&node) && !self.is_node_dirty(node) {
+        // Base neighbors (minus deleted). `is_node_dirty` is not a reason
+        // to skip the base: `ensure_in_overlay` promotes a node's labels
+        // and properties but never copies its adjacency, so base edges
+        // remain authoritative for any dirty node that originated in the
+        // snapshot. Per-edge deletions are still respected via
+        // `deleted_from_base_edges` inside `edges_from`-style call sites,
+        // and `dedup` below collapses any overlap with promoted overlay
+        // adjacency.
+        if !deleted_nodes.contains(&node) {
             for nid in self.base.load().neighbors(node, direction) {
                 if !deleted_nodes.contains(&nid) {
                     results.push(nid);
@@ -610,8 +617,16 @@ impl GraphStore for LayeredStore {
 
         let mut results = Vec::new();
 
-        // Base edges (minus deleted).
-        if !deleted_nodes.contains(&node) && !self.is_node_dirty(node) {
+        // Base edges (minus deleted). The base layer must be consulted
+        // even when the source node is dirty: `ensure_in_overlay` copies
+        // labels and properties into the overlay but leaves adjacency in
+        // the base, so a property write — or merely being the endpoint
+        // of a freshly created overlay edge — must not erase the node's
+        // pre-existing snapshot edges. Promoted edges (those in both
+        // tiers because their properties were modified) live at the same
+        // `EdgeId` in base and overlay and are folded together by the
+        // dedup-by-eid pass below.
+        if !deleted_nodes.contains(&node) {
             for (target, eid) in self.base.load().edges_from(node, direction) {
                 if !deleted_nodes.contains(&target) && !deleted_edges.contains(&eid) {
                     results.push((target, eid));
@@ -2919,13 +2934,26 @@ mod tests {
         layered.set_node_property(paris, "name", Value::from("Paris"));
         let _ = layered.create_edge(first, paris, "VISITS");
 
-        // Neighbors should include BOTH the original Amsterdam and the new Paris.
-        // Once the node is dirty, base neighbors are not re-read (ensure_in_overlay
-        // copied them), so both endpoints come from the overlay.
+        // Neighbors should include BOTH the original Amsterdam (a base edge
+        // that pre-dates promotion) and the new Paris (an overlay edge added
+        // after promotion). `ensure_in_overlay` only copies the node's labels
+        // and properties — never its adjacency — so the base layer remains
+        // authoritative for pre-promotion edges and must be merged with the
+        // overlay's post-promotion edges.
         let outgoing = layered.neighbors(first, Direction::Outgoing);
         assert!(
             outgoing.contains(&paris),
             "overlay-created edge target should appear in neighbors"
+        );
+        let cities = layered.nodes_by_label("City");
+        let amsterdam = cities
+            .iter()
+            .copied()
+            .find(|&c| c != paris)
+            .expect("base City Amsterdam should still be present");
+        assert!(
+            outgoing.contains(&amsterdam),
+            "base edge target should still appear in neighbors after promotion"
         );
     }
 
@@ -3489,19 +3517,108 @@ mod tests {
         let persons = layered.nodes_by_label("Person");
         let first = persons[0];
 
-        // Promote first to the overlay and add a new outgoing overlay edge.
+        // Capture the base-tier outgoing edges before any promotion.
+        let base_outgoing: Vec<(NodeId, EdgeId)> =
+            layered.edges_from(first, Direction::Outgoing);
+        assert!(
+            !base_outgoing.is_empty(),
+            "test fixture should give the first Person a base edge"
+        );
+
+        // Promote `first` into the overlay (ensure_in_overlay copies labels and
+        // properties only — never adjacency) and add a fresh overlay-only edge.
         layered.set_node_property(first, "city", Value::from("Berlin"));
         let prague = layered.create_node(&["City"]);
         layered.create_edge(first, prague, "VISITS");
 
         let outgoing = layered.edges_from(first, Direction::Outgoing);
-        // Original base edge was promoted during ensure_in_overlay? No: only the
-        // node is promoted, so the base edge is still served by base. But because
-        // the source is now dirty, the base-edge branch is skipped in edges_from.
-        // Only the overlay edge is returned.
+
+        // The new overlay edge must be visible …
         assert!(
             outgoing.iter().any(|(target, _)| *target == prague),
             "new overlay edge should appear in edges_from"
+        );
+
+        // … and every pre-promotion base edge must remain visible. ensure_in_overlay
+        // only promotes the node; base adjacency is still authoritative for edges
+        // that pre-date the promotion, and must not silently disappear once the
+        // source node becomes dirty.
+        for (target, eid) in &base_outgoing {
+            assert!(
+                outgoing
+                    .iter()
+                    .any(|(t, e)| t == target && e == eid),
+                "base edge {eid:?} (→ {target:?}) must remain visible after promotion"
+            );
+        }
+    }
+
+    /// Regression for property-anchored edge lookups across the snapshot
+    /// boundary: when a base node is promoted into the overlay (e.g. by
+    /// `set_node_property` or by becoming the endpoint of a new overlay
+    /// edge), its pre-existing base-tier edges must remain reachable via
+    /// `neighbors` and `edges_from` in BOTH directions. Otherwise GQL
+    /// patterns like `MATCH (a {id: $x})-[:T]->(b {id: $y})` start
+    /// returning zero rows once any overlay write has touched either
+    /// endpoint, which the planner uses to walk the edge from.
+    #[test]
+    fn test_base_edge_visible_from_promoted_endpoint() {
+        let layered = build_test_layered();
+        let persons = layered.nodes_by_label("Person");
+        let cities = layered.nodes_by_label("City");
+        let alix = persons[0];
+        let amsterdam = cities[0];
+
+        // Sanity: the base edge alix -LIVES_IN-> amsterdam exists pre-promotion.
+        let pre_out = layered.edges_from(alix, Direction::Outgoing);
+        let pre_in = layered.edges_from(amsterdam, Direction::Incoming);
+        let pre_neigh_out = layered.neighbors(alix, Direction::Outgoing);
+        let pre_neigh_in = layered.neighbors(amsterdam, Direction::Incoming);
+        assert!(pre_out.iter().any(|(t, _)| *t == amsterdam));
+        assert!(pre_in.iter().any(|(t, _)| *t == alix));
+        assert!(pre_neigh_out.contains(&amsterdam));
+        assert!(pre_neigh_in.contains(&alix));
+
+        // Promote BOTH endpoints into the overlay by way of an unrelated
+        // overlay write. The new edge intentionally points at a brand-new
+        // overlay node so the LIVES_IN edge between alix and amsterdam is
+        // not touched in any way.
+        let oslo = layered.create_node(&["City"]);
+        layered.create_edge(alix, oslo, "VISITS"); // promotes alix
+        layered.set_node_property(amsterdam, "touched", Value::Bool(true)); // promotes amsterdam
+
+        // Both endpoints are now dirty.
+        assert!(layered.is_node_dirty(alix));
+        assert!(layered.is_node_dirty(amsterdam));
+
+        // The pre-existing base edge must still be reachable from either side,
+        // both as an edge (with its original EdgeId) and as a neighbor.
+        let post_out = layered.edges_from(alix, Direction::Outgoing);
+        let post_in = layered.edges_from(amsterdam, Direction::Incoming);
+        let post_neigh_out = layered.neighbors(alix, Direction::Outgoing);
+        let post_neigh_in = layered.neighbors(amsterdam, Direction::Incoming);
+
+        let base_eid = pre_out
+            .iter()
+            .find(|(t, _)| *t == amsterdam)
+            .map(|(_, e)| *e)
+            .expect("pre-promotion fixture has a base LIVES_IN edge");
+
+        assert!(
+            post_out.iter().any(|(t, e)| *t == amsterdam && *e == base_eid),
+            "base LIVES_IN edge must remain visible via edges_from(src, Outgoing) after src is promoted"
+        );
+        assert!(
+            post_in.iter().any(|(t, e)| *t == alix && *e == base_eid),
+            "base LIVES_IN edge must remain visible via edges_from(dst, Incoming) after dst is promoted"
+        );
+        assert!(
+            post_neigh_out.contains(&amsterdam),
+            "base neighbor must remain visible via neighbors(src, Outgoing) after src is promoted"
+        );
+        assert!(
+            post_neigh_in.contains(&alix),
+            "base neighbor must remain visible via neighbors(dst, Incoming) after dst is promoted"
         );
     }
 

--- a/crates/grafeo-engine/tests/post_compact_overlay_visibility.rs
+++ b/crates/grafeo-engine/tests/post_compact_overlay_visibility.rs
@@ -95,6 +95,79 @@ fn post_compact_edge_between_base_and_overlay_nodes() {
     );
 }
 
+/// Regression: a property-anchored edge that lives entirely in the
+/// snapshot tier must remain reachable after an unrelated overlay write
+/// promotes one of its endpoints. The reproduction is the GQL pattern
+/// `MATCH (a {id: $x})-[:T]->(b {id: $y})` — the planner may walk from
+/// either anchor, so both promotion directions need to work.
+///
+/// Before the fix, `LayeredStore::edges_from` and `neighbors` skipped the
+/// base layer whenever the source node was marked dirty. `ensure_in_overlay`
+/// only copies labels and properties into the overlay, never adjacency, so
+/// a dirty endpoint silently lost all of its pre-compact edges.
+#[test]
+fn post_compact_property_anchored_edge_survives_unrelated_overlay_write() {
+    let mut db = GrafeoDB::new_in_memory();
+    let a = db.create_node(&["A"]);
+    let b = db.create_node(&["B"]);
+    db.set_node_property(a, "id", Value::Int64(1));
+    db.set_node_property(b, "id", Value::Int64(2));
+    db.create_edge(a, b, "T");
+    db.compact().expect("compact");
+
+    // Both endpoints are now entirely in the snapshot tier and the
+    // BUSINESS_MEMBER-shaped pattern resolves cleanly.
+    assert_eq!(
+        row_count(
+            &db,
+            "MATCH (a:A {id: 1})-[:T]->(b:B {id: 2}) RETURN true"
+        ),
+        1,
+        "double-anchor edge query should match before any overlay write"
+    );
+
+    // Unrelated overlay write that promotes `a` (it becomes the endpoint of
+    // a brand-new overlay edge). The original snapshot-tier `T` edge between
+    // `a` and `b` is not touched in any way.
+    let c = db.create_node(&["C"]);
+    db.set_node_property(c, "id", Value::Int64(99));
+    db.create_edge(a, c, "UNRELATED");
+
+    assert_eq!(
+        row_count(
+            &db,
+            "MATCH (a:A {id: 1})-[:T]->(b:B {id: 2}) RETURN true"
+        ),
+        1,
+        "snapshot-tier T edge must still match after an unrelated overlay write \
+         promotes its source endpoint"
+    );
+
+    // And the same when the destination endpoint is the one that gets
+    // promoted — the planner may anchor on either side.
+    let mut db = GrafeoDB::new_in_memory();
+    let a = db.create_node(&["A"]);
+    let b = db.create_node(&["B"]);
+    db.set_node_property(a, "id", Value::Int64(1));
+    db.set_node_property(b, "id", Value::Int64(2));
+    db.create_edge(a, b, "T");
+    db.compact().expect("compact");
+
+    let c = db.create_node(&["C"]);
+    db.set_node_property(c, "id", Value::Int64(99));
+    db.create_edge(c, b, "UNRELATED"); // promotes b
+
+    assert_eq!(
+        row_count(
+            &db,
+            "MATCH (a:A {id: 1})-[:T]->(b:B {id: 2}) RETURN true"
+        ),
+        1,
+        "snapshot-tier T edge must still match after an unrelated overlay write \
+         promotes its destination endpoint"
+    );
+}
+
 #[test]
 fn post_compact_node_property_survives_reread() {
     let mut db = GrafeoDB::new_in_memory();


### PR DESCRIPTION
Fixes #345.

## Summary

`LayeredStore::edges_from` and `neighbors` short-circuited the base layer whenever the source node was marked dirty. `ensure_in_overlay` (the only path that flags a node dirty in this context) copies labels and properties into the overlay but never copies adjacency, so a snapshot-tier edge whose endpoint was later touched by **any** overlay write — a property update, or merely being the endpoint of an unrelated new edge — silently vanished from reads.

In GQL this surfaces as property-anchored edge patterns such as `MATCH (a {id: $x})-[:T]->(b {id: $y})` returning zero rows once any overlay write has occurred, because the planner may walk from either anchor and one of them is now dirty.

See #345 for the full root-cause analysis, minimal reproduction, and observed impact.

## Fix

Drop the `is_node_dirty` guard in both methods. Safety of the change:

* Per-edge deletions are still authoritative via `deleted_from_base_edges`.
* Promoted edges (whose properties were modified, so they live at the same `EdgeId` in base and overlay) are collapsed by the existing `dedup_by_key(eid)` pass at the end of `edges_from`.
* `delete_node_edges` walks `base.load().edges_from(...)` directly and was never affected by the guard.
* As a side benefit, `sum_of(edges_from(n).len())` is now consistent with `edge_count()` for dirty source nodes (it wasn't before).

The minor cost: traversals from a dirty source node now read both base and overlay adjacency rather than just overlay. That's the necessary cost of returning the correct answer.

## Regression coverage

* **New** `test_base_edge_visible_from_promoted_endpoint` — promotes both endpoints via unrelated overlay writes and asserts the original base edge remains reachable from both directions, via both `edges_from` and `neighbors`.
* **New** `post_compact_property_anchored_edge_survives_unrelated_overlay_write` — GQL integration test that mirrors the production repro for both promotion directions.
* **Strengthened** `test_edges_from_dirty_source_merges_layers` and `test_neighbors_from_promoted_node_with_new_overlay_edges` — the existing tests asserted only the new overlay edge and explicitly documented the bug in their comments. They now assert the merge behavior their names promise.

All four new/strengthened tests fail on the pre-fix code (confirmed by running them against `main` before applying the fix).

## Test plan

- [x] `cargo test -p grafeo-core --features "compact-store lpg"` — 2017 + 27 + 5 + 61 tests pass.
- [x] `cargo test -p grafeo-engine --features "compact-store lpg gql" --test post_compact_overlay_visibility` — 6/6 pass (5 existing + 1 new).
- [x] `cargo test -p grafeo-engine --features "compact-store lpg gql"` across `post_compact_index`, `post_compact_numeric_content`, `compact_store_integration`, `compact_roundtrip_proptest`, `compact_store_tiered_spill`, `snapshot`, `database_api`, `backward_compatibility`, `mvcc_integration`, `versioning_coverage`, `temporal_properties`, `savepoint_undo`, `label_rollback`, `set_property_rollback`, `grafeo_file`, `golden_format`, `schema_wal_replay`, `wal_recovery` — all pass.
- [ ] Pre-existing compile errors in `query_correctness.rs` and `merge_rollback.rs` (both call removed/renamed methods `execute_sql`/`execute_cypher`) are reproducible on clean `main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves base-tier adjacency when a node becomes dirty so existing snapshot edges remain visible. Restores correct results for property-anchored edge queries in GQL after overlay writes to either endpoint.

- **Bug Fixes**
  - Always read base adjacency in `neighbors` and `edges_from`, even when the source node is dirty; merge with overlay, respect per-edge deletions, and dedup by `EdgeId`.
  - Fixes double-anchored patterns like MATCH (a {id: ...})-[:T]->(b {id: ...}) returning zero rows after unrelated overlay writes.
  - Adds regression coverage (unit + GQL tests) for promoted endpoints in both directions.
  - Minor trade-off: traversals from dirty nodes now read both base and overlay.

<sup>Written for commit 70c9b92a83bb25a0492af28b5309c680b522799d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

