### PR TITLE
fix(planner): remove probe state-pollution in heap top-K rewrite (#347, #335)

### DIFF
--- a/crates/grafeo-engine/src/query/planner/common.rs
+++ b/crates/grafeo-engine/src/query/planner/common.rs
@@ -366,14 +366,49 @@ fn find_shared_join_keys(left: &[String], right: &[String]) -> (Vec<usize>, Vec<
     (probe_keys, build_keys)
 }
 
+/// Column name that `resolve_expression_to_column` will look up for `expr`.
+///
+/// The naming scheme is the source of truth for synthetic columns that
+/// aggregate/sort planners inject so that downstream resolution finds them:
+///
+/// - `Variable(name)` → `"name"`
+/// - `Property { variable, property }` → `"{variable}_{property}"` (LPG projections)
+/// - Anything else → `"__expr_{expr:?}"`
+///
+/// Both the producers (Aggregate/Sort augmenting projections, the `_ =>` arm in
+/// `plan_sort`'s pre-Return loop, the equivalents in `aggregate.rs` and the RDF
+/// planner) and the consumer (`resolve_expression_to_column`) must agree on
+/// this formula. Keep them in sync by funnelling through this function — and
+/// `resolve_expression_to_column` itself — rather than re-deriving the string
+/// at each call site.
+pub(crate) fn resolved_column_name(expr: &LogicalExpression) -> String {
+    match expr {
+        LogicalExpression::Variable(name) => name.clone(),
+        LogicalExpression::Property { variable, property } => {
+            format!("{variable}_{property}")
+        }
+        _ => format!("__expr_{expr:?}"),
+    }
+}
+
+/// Output column name for a Return/Project item or sort-key projection.
+///
+/// Returns `alias` when set, otherwise falls back to `expression_to_string(expr)`.
+/// `plan_return_projection`, `plan_project`, and the RDF planner all label
+/// their output columns with this rule — extracting it here keeps the rule in
+/// one place so predictive callers (e.g. the heap top-K rewrite) cannot drift
+/// from the actual planner.
+pub(crate) fn output_column_name(alias: Option<&str>, expr: &LogicalExpression) -> String {
+    alias
+        .map(str::to_string)
+        .unwrap_or_else(|| expression_to_string(expr))
+}
+
 /// Resolves a logical expression to a column index in the given variable-column map.
 ///
-/// Handles three expression kinds:
-/// - `Variable(name)`: direct lookup in `variable_columns`
-/// - `Property { variable, property }`: lookup of `"{variable}_{property}"` (LPG projections)
-/// - Complex expressions: lookup of `"__expr_{expr:?}"` (synthetic columns)
-///
-/// `context` is appended to error messages (e.g. `" for ORDER BY"`, or `""` for aggregations).
+/// Mirrors [`resolved_column_name`]: the column name looked up is whatever that
+/// function returns for `expr`. `context` is appended to error messages
+/// (e.g. `" for ORDER BY"`, or `""` for aggregations).
 ///
 /// NOTE: The expression *collection* loops (which build the synthetic columns that this
 /// function resolves) are intentionally NOT shared, because the LPG and RDF planners use
@@ -383,28 +418,18 @@ pub(crate) fn resolve_expression_to_column(
     variable_columns: &std::collections::HashMap<String, usize>,
     context: &str,
 ) -> Result<usize> {
-    match expr {
-        LogicalExpression::Variable(name) => variable_columns
-            .get(name)
-            .copied()
-            .ok_or_else(|| Error::Internal(format!("Variable '{name}' not found{context}"))),
-        LogicalExpression::Property { variable, property } => {
-            let col_name = format!("{variable}_{property}");
-            variable_columns.get(&col_name).copied().ok_or_else(|| {
-                Error::Internal(format!(
-                    "Property column '{col_name}' not found{context} (from {variable}.{property})"
-                ))
-            })
+    let col_name = resolved_column_name(expr);
+    variable_columns.get(&col_name).copied().ok_or_else(|| match expr {
+        LogicalExpression::Variable(name) => {
+            Error::Internal(format!("Variable '{name}' not found{context}"))
         }
-        _ => {
-            let col_name = format!("__expr_{expr:?}");
-            variable_columns.get(&col_name).copied().ok_or_else(|| {
-                Error::Internal(format!(
-                    "Cannot resolve expression to column{context}: {expr:?}"
-                ))
-            })
-        }
-    }
+        LogicalExpression::Property { variable, property } => Error::Internal(format!(
+            "Property column '{col_name}' not found{context} (from {variable}.{property})"
+        )),
+        _ => Error::Internal(format!(
+            "Cannot resolve expression to column{context}: {expr:?}"
+        )),
+    })
 }
 
 /// Converts a logical expression to a human-readable string for column naming.

--- a/crates/grafeo-engine/src/query/planner/lpg/aggregate.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/aggregate.rs
@@ -6,7 +6,7 @@ use super::{
     GraphStoreSearch, HashAggregateOperator, HashMap, LazyFactorizedChainOperator,
     LogicalAggregateFunction, LogicalExpression, LogicalType, Operator, PhysicalAggregateExpr,
     ProjectExpr, ProjectOperator, Result, SimpleAggregateOperator, convert_aggregate_function,
-    expression_to_string,
+    expression_to_string, resolved_column_name,
 };
 
 impl super::Planner {
@@ -55,7 +55,7 @@ impl super::Planner {
         for expr in &agg.group_by {
             match expr {
                 LogicalExpression::Property { variable, property } => {
-                    let col_name = format!("{}_{}", variable, property);
+                    let col_name = resolved_column_name(expr);
                     if !variable_columns.contains_key(&col_name) {
                         extra_projections.push(ExtraProjection::Property {
                             variable: variable.clone(),
@@ -71,7 +71,7 @@ impl super::Planner {
                 _ => {
                     // Complex expression (Labels, Type, FunctionCall, IndexAccess,
                     // CASE, Binary, etc.): project as computed column
-                    let col_name = format!("__expr_{:?}", expr);
+                    let col_name = resolved_column_name(expr);
                     if !variable_columns.contains_key(&col_name) {
                         let filter_expr = self.convert_expression(expr)?;
                         extra_projections.push(ExtraProjection::Expression { filter_expr });
@@ -89,7 +89,7 @@ impl super::Planner {
                 let Some(expr) = expr_opt else { continue };
                 match expr {
                     LogicalExpression::Property { variable, property } => {
-                        let col_name = format!("{}_{}", variable, property);
+                        let col_name = resolved_column_name(expr);
                         if !variable_columns.contains_key(&col_name) {
                             extra_projections.push(ExtraProjection::Property {
                                 variable: variable.clone(),
@@ -104,7 +104,7 @@ impl super::Planner {
                     }
                     _ => {
                         // Complex expression (CASE, Binary, etc.): project as computed column
-                        let col_name = format!("__expr_{:?}", expr);
+                        let col_name = resolved_column_name(expr);
                         if !variable_columns.contains_key(&col_name) {
                             let filter_expr = self.convert_expression(expr)?;
                             extra_projections.push(ExtraProjection::Expression { filter_expr });

--- a/crates/grafeo-engine/src/query/planner/lpg/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/mod.rs
@@ -140,7 +140,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::query::planner::common;
-use crate::query::planner::common::expression_to_string;
+use crate::query::planner::common::{expression_to_string, output_column_name, resolved_column_name};
 use crate::query::planner::{
     PhysicalPlan, convert_aggregate_function, convert_binary_op, convert_filter_expression,
     convert_unary_op, value_to_logical_type,

--- a/crates/grafeo-engine/src/query/planner/lpg/project.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/project.rs
@@ -6,7 +6,7 @@ use super::{
     Arc, Error, FilterExpression, GraphStoreSearch, HashMap, LimitOp, LogicalExpression,
     LogicalOperator, LogicalType, NullOrder, Operator, PhysicalSortKey, ProjectExpr,
     ProjectOperator, Result, ReturnOp, SkipOp, SortDirection, SortOp, SortOperator, SortOrder,
-    common, expression_to_string, value_to_logical_type,
+    common, expression_to_string, output_column_name, resolved_column_name, value_to_logical_type,
 };
 
 impl super::Planner {
@@ -80,12 +80,7 @@ impl super::Planner {
         // Extract column names from return items
         let columns: Vec<String> = items
             .iter()
-            .map(|item| {
-                item.alias.clone().unwrap_or_else(|| {
-                    // Generate a default name from the expression
-                    expression_to_string(&item.expression)
-                })
-            })
+            .map(|item| output_column_name(item.alias.as_deref(), &item.expression))
             .collect();
 
         // Check if we need a project operator (for property access or expression evaluation)
@@ -419,11 +414,7 @@ impl super::Planner {
         }
 
         for projection in &project.projections {
-            // Determine the output column name (alias or expression string)
-            let col_name = projection
-                .alias
-                .clone()
-                .unwrap_or_else(|| expression_to_string(&projection.expression));
+            let col_name = output_column_name(projection.alias.as_deref(), &projection.expression);
 
             match &projection.expression {
                 LogicalExpression::Variable(name) => {
@@ -659,7 +650,7 @@ impl super::Planner {
                         if already_in_return {
                             continue;
                         }
-                        let col_name = format!("{}_{}", variable, property);
+                        let col_name = resolved_column_name(&key.expression);
                         if seen.insert(col_name.clone()) {
                             augmented_items.push(crate::query::plan::ReturnItem {
                                 expression: key.expression.clone(),
@@ -669,7 +660,7 @@ impl super::Planner {
                         }
                     }
                     expr => {
-                        let col_name = format!("__expr_{expr:?}");
+                        let col_name = resolved_column_name(expr);
                         if seen.insert(col_name.clone()) {
                             augmented_items.push(crate::query::plan::ReturnItem {
                                 expression: expr.clone(),
@@ -719,13 +710,11 @@ impl super::Planner {
         // on a non-entity column.
         if let LogicalOperator::Return(ret) = sort.input.as_ref() {
             for item in &ret.items {
-                if let LogicalExpression::Property { variable, property } = &item.expression {
-                    let sort_col_name = format!("{variable}_{property}");
+                if matches!(&item.expression, LogicalExpression::Property { .. }) {
+                    let sort_col_name = resolved_column_name(&item.expression);
                     if !variable_columns.contains_key(&sort_col_name) {
-                        let output_name = item
-                            .alias
-                            .clone()
-                            .unwrap_or_else(|| expression_to_string(&item.expression));
+                        let output_name =
+                            output_column_name(item.alias.as_deref(), &item.expression);
                         if let Some(&col_idx) = variable_columns.get(&output_name) {
                             variable_columns.insert(sort_col_name, col_idx);
                         }
@@ -754,7 +743,7 @@ impl super::Planner {
         for key in &sort.keys {
             match &key.expression {
                 LogicalExpression::Property { variable, property } => {
-                    let col_name = format!("{}_{}", variable, property);
+                    let col_name = resolved_column_name(&key.expression);
                     if !variable_columns.contains_key(&col_name) {
                         extra_projections.push(SortExtraProjection::Property {
                             variable: variable.clone(),
@@ -773,27 +762,24 @@ impl super::Planner {
                     // If this is a vector/text score function and the scan already projected
                     // a score column, register a direct alias so resolve_sort_expression
                     // picks it up without injecting a new projection.
+                    let col_name = resolved_column_name(&key.expression);
                     if let Some(score_col) =
                         self.find_projected_score(&key.expression, &input_columns)
                     {
-                        let col_name = format!("__expr_{:?}", key.expression);
                         if !variable_columns.contains_key(&col_name)
                             && let Some(&existing_idx) = variable_columns.get(&score_col)
                         {
                             variable_columns.insert(col_name, existing_idx);
                         }
-                    } else {
-                        let col_name = format!("__expr_{:?}", key.expression);
-                        if !variable_columns.contains_key(&col_name) {
-                            let filter_expr = self.convert_expression(&key.expression)?;
-                            extra_projections.push(SortExtraProjection::Expression {
-                                filter_expr,
-                                col_name: col_name.clone(),
-                            });
-                            variable_columns.insert(col_name, next_col_idx);
-                            next_col_idx += 1;
-                            expr_extra_count += 1;
-                        }
+                    } else if !variable_columns.contains_key(&col_name) {
+                        let filter_expr = self.convert_expression(&key.expression)?;
+                        extra_projections.push(SortExtraProjection::Expression {
+                            filter_expr,
+                            col_name: col_name.clone(),
+                        });
+                        variable_columns.insert(col_name, next_col_idx);
+                        next_col_idx += 1;
+                        expr_extra_count += 1;
                     }
                 }
             }

--- a/crates/grafeo-engine/src/query/planner/lpg/project.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/project.rs
@@ -701,27 +701,7 @@ impl super::Planner {
             .map(|(i, name)| (name.clone(), i))
             .collect();
 
-        // When the sort input is a Return, some sort key expressions may
-        // already be computed by the Return under an alias. For example,
-        // RETURN caller.name AS caller ORDER BY caller.name: the property
-        // access is already materialized in column "caller". Register the
-        // sort-style name ("caller_name") so the loop below resolves to the
-        // existing column instead of adding a broken extra PropertyAccess
-        // on a non-entity column.
-        if let LogicalOperator::Return(ret) = sort.input.as_ref() {
-            for item in &ret.items {
-                if matches!(&item.expression, LogicalExpression::Property { .. }) {
-                    let sort_col_name = resolved_column_name(&item.expression);
-                    if !variable_columns.contains_key(&sort_col_name) {
-                        let output_name =
-                            output_column_name(item.alias.as_deref(), &item.expression);
-                        if let Some(&col_idx) = variable_columns.get(&output_name) {
-                            variable_columns.insert(sort_col_name, col_idx);
-                        }
-                    }
-                }
-            }
-        }
+        register_return_property_sort_aliases(sort.input.as_ref(), &mut variable_columns);
 
         // Collect extra projections in a single ordered list so that column
         // index assignment matches the order they are added to the ProjectOperator.
@@ -1286,11 +1266,23 @@ impl super::Planner {
             return Ok(None);
         };
 
+        // Build the same variable-column lookup `plan_sort` builds, including
+        // the property-alias entries (so `ORDER BY v.p` resolves to a Return
+        // item that materialises `v.p` under its human-readable column name).
+        // Without this, `RETURN n.title ORDER BY n.title LIMIT k` would skip
+        // the rewrite even though the unfused path handles it fine.
+        let mut variable_columns: HashMap<String, usize> = predicted_columns
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (n.clone(), i))
+            .collect();
+        register_return_property_sort_aliases(sort.input.as_ref(), &mut variable_columns);
+
         // Resolve sort keys against the prediction. If any key fails to
         // resolve, fall through with NO planner state mutated. Holding the
         // result lets us skip a second resolve after planning — the
         // `debug_assert_eq!` below proves the column indices are valid.
-        let Ok(physical_keys) = resolve_logical_to_physical_keys(&sort.keys, &predicted_columns)
+        let Ok(physical_keys) = resolve_logical_to_physical_keys(&sort.keys, &variable_columns)
         else {
             return Ok(None);
         };
@@ -1343,6 +1335,39 @@ fn predict_subtree_columns(op: &LogicalOperator) -> Option<Vec<String>> {
     }
 }
 
+/// When `sort_input` is a `Return` materializing property accesses, the Return's
+/// output column for `v.p` is named `"v.p"` (via `output_column_name`'s
+/// fallback to `expression_to_string`), but the ORDER BY resolver looks for
+/// `"v_p"` (via `resolved_column_name`). Register an alias so the resolver
+/// finds the existing column instead of treating the key as missing.
+///
+/// Without this, `RETURN v.p ORDER BY v.p [LIMIT k]` would either fall
+/// through to an unfused path (TopK rewrite skipped) or attempt to inject a
+/// `PropertyAccess` against a non-entity column. Both `plan_sort` (which
+/// builds a real `variable_columns` from planned output) and
+/// `try_heap_topk_rewrite` (which builds one from predicted output) invoke
+/// this before sort-key resolution so the two paths agree.
+fn register_return_property_sort_aliases(
+    sort_input: &LogicalOperator,
+    variable_columns: &mut HashMap<String, usize>,
+) {
+    let LogicalOperator::Return(ret) = sort_input else {
+        return;
+    };
+    for item in &ret.items {
+        if matches!(&item.expression, LogicalExpression::Property { .. }) {
+            let sort_col_name = resolved_column_name(&item.expression);
+            if variable_columns.contains_key(&sort_col_name) {
+                continue;
+            }
+            let output_name = output_column_name(item.alias.as_deref(), &item.expression);
+            if let Some(&col_idx) = variable_columns.get(&output_name) {
+                variable_columns.insert(sort_col_name, col_idx);
+            }
+        }
+    }
+}
+
 /// Resolves logical sort keys to physical sort keys for `TopKOperator`.
 ///
 /// For each logical key:
@@ -1351,27 +1376,20 @@ fn predict_subtree_columns(op: &LogicalOperator) -> Option<Vec<String>> {
 ///   - Maps `Option<NullsOrdering>` → physical `NullOrder` (default `NullsLast`,
 ///     matching `SortKey::ascending`'s default).
 ///
-/// Returns `Err` if any key references a column not present in `columns`.
+/// Returns `Err` if any key fails to resolve in `variable_columns`.
 /// Callers translate that to `Ok(None)` to fall through to the unfused path.
 fn resolve_logical_to_physical_keys(
     keys: &[crate::query::plan::SortKey],
-    columns: &[String],
+    variable_columns: &HashMap<String, usize>,
 ) -> Result<Vec<grafeo_core::execution::operators::SortKey>> {
     use crate::query::plan::{NullsOrdering, SortOrder};
     use grafeo_core::execution::operators::{NullOrder, SortDirection, SortKey as PhysSortKey};
-    use std::collections::HashMap;
-
-    let variable_columns: HashMap<String, usize> = columns
-        .iter()
-        .enumerate()
-        .map(|(i, n)| (n.clone(), i))
-        .collect();
 
     let mut out = Vec::with_capacity(keys.len());
     for key in keys {
         let col = crate::query::planner::common::resolve_expression_to_column(
             &key.expression,
-            &variable_columns,
+            variable_columns,
             " for ORDER BY",
         )?;
 

--- a/crates/grafeo-engine/src/query/planner/lpg/project.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/project.rs
@@ -1221,10 +1221,10 @@ impl super::Planner {
     /// Attempts to rewrite `Limit` over `Sort` into a single [`TopKOperator`].
     ///
     /// Phase 1: heap-based, O(k) memory, accepts any input shape but bails
-    /// on the augmenting-projection case (see
-    /// [`sort_needs_augmenting_projection`]). Called from
-    /// [`Self::plan_limit`] when the input is a `Sort`, after the more
-    /// specific vector/text rewrite ([`Self::try_topk_rewrite`]).
+    /// when the sort keys cannot be resolved against the columns the input
+    /// subtree will produce. Called from [`Self::plan_limit`] when the input
+    /// is a `Sort`, after the more specific vector/text rewrite
+    /// ([`Self::try_topk_rewrite`]).
     ///
     /// PROFILE-mode plans skip this rewrite via the gate in `plan_limit`:
     /// `build_profile_tree` walks the logical tree expecting one entry per
@@ -1236,13 +1236,36 @@ impl super::Planner {
     ///
     /// 1. `count` is not a literal (parameter `LIMIT $k` falls through).
     /// 2. `count` is zero (no rewrite needed).
-    /// 3. Sort needs an augmenting projection (`plan_sort` handles it).
-    /// 4. Any sort key fails to resolve against the planned input columns.
+    /// 3. The input subtree's output columns can't be predicted (current scope:
+    ///    only Return is supported; anything else falls through).
+    /// 4. Any sort key fails to resolve against the predicted columns.
     ///
-    /// Otherwise plans the inner subtree as-is (reusing filter pushdown,
-    /// expand-chain fusion, NodeList absorption) and wraps it in a
-    /// `TopKOperator`. `derive_schema_from_columns` is the same helper
-    /// `plan_limit`'s unfused path uses.
+    /// ## Why predict first, plan second
+    ///
+    /// Earlier shapes of this function ran `plan_operator(&sort.input)` first
+    /// and only resolved sort keys against the result. That call has side
+    /// effects on `Planner::scalar_columns` and `Planner::edge_columns` —
+    /// `plan_return_projection` registers each output column as scalar so an
+    /// enclosing Apply doesn't try to re-resolve it as a NodeId. When the
+    /// resolve step then failed and we returned `Ok(None)`, the caller fell
+    /// through to `plan_sort`'s unfused path and *re-planned the same Return*,
+    /// but now with the polluted state — and `plan_return_projection`'s
+    /// `Variable(name)` arm flips from `NodeResolve` to a raw `Column`
+    /// passthrough when it sees the name already in `scalar_columns`. Result:
+    /// `MATCH (n) RETURN n ORDER BY <complex> LIMIT k` returned raw `Int64`
+    /// NodeIds instead of resolved maps (issues #335 and #347).
+    ///
+    /// We now resolve sort keys against *predicted* columns derived from
+    /// `ret.items` alone — `output_column_name` is the single source of truth
+    /// — without touching the planner. Only when resolution succeeds do we
+    /// plan for real, so the canonical plan is built exactly once and no
+    /// shared planner state is mutated speculatively.
+    ///
+    /// `sort_needs_augmenting_projection` is no longer a gate here: the
+    /// predictive resolve subsumes it (a sort key that needs augmenting will
+    /// never be in the predicted column set, so resolution fails and we bail).
+    /// `plan_sort` still uses that function to choose between pre-Return and
+    /// post-Return augmenting, which is a separate concern.
     fn try_heap_topk_rewrite(
         &self,
         sort: &SortOp,
@@ -1255,15 +1278,30 @@ impl super::Planner {
         if k == 0 {
             return Ok(None);
         }
-        if sort_needs_augmenting_projection(sort) {
-            return Ok(None);
-        }
 
-        let (input_op, columns) = self.plan_operator(&sort.input)?;
-
-        let Ok(physical_keys) = resolve_logical_to_physical_keys(&sort.keys, &columns) else {
+        // Predict the columns `sort.input` will produce. Currently only Return
+        // is predicted; other shapes (Filter/Project/Skip wrapping Return, etc.)
+        // could be added incrementally, falling through is always safe.
+        let Some(predicted_columns) = predict_subtree_columns(sort.input.as_ref()) else {
             return Ok(None);
         };
+
+        // Resolve sort keys against the prediction. If any key fails to
+        // resolve, fall through with NO planner state mutated. Holding the
+        // result lets us skip a second resolve after planning — the
+        // `debug_assert_eq!` below proves the column indices are valid.
+        let Ok(physical_keys) = resolve_logical_to_physical_keys(&sort.keys, &predicted_columns)
+        else {
+            return Ok(None);
+        };
+
+        // Commit: plan the input for real. State mutations now happen exactly
+        // once, as part of the canonical plan we are about to return.
+        let (input_op, columns) = self.plan_operator(&sort.input)?;
+        debug_assert_eq!(
+            columns, predicted_columns,
+            "predict_subtree_columns drifted from plan_operator's output columns"
+        );
 
         let schema = self.derive_schema_from_columns(&columns);
         let op: Box<dyn Operator> = Box::new(grafeo_core::execution::operators::TopKOperator::new(
@@ -1273,6 +1311,35 @@ impl super::Planner {
             schema,
         ));
         Ok(Some((op, columns)))
+    }
+}
+
+/// Predicts the output column names of `op` without planning it.
+///
+/// Returns `None` when the shape is one we don't predict — callers must treat
+/// that as "skip the rewrite" and fall through to the canonical planning path.
+/// Each branch mirrors the column-naming rule used by the corresponding
+/// `plan_*` method. Adding more shapes here is purely a TopK-coverage
+/// improvement; the rewrite degrades to "skip" if a shape is missing.
+fn predict_subtree_columns(op: &LogicalOperator) -> Option<Vec<String>> {
+    match op {
+        LogicalOperator::Return(ret) => {
+            // `RETURN *` expands from input columns inside `plan_return_projection`,
+            // so the output column count depends on what the input produces.
+            // Without planning the input we can't know it — skip.
+            if ret.items.len() == 1
+                && matches!(&ret.items[0].expression, LogicalExpression::Variable(n) if n == "*")
+            {
+                return None;
+            }
+            Some(
+                ret.items
+                    .iter()
+                    .map(|item| output_column_name(item.alias.as_deref(), &item.expression))
+                    .collect(),
+            )
+        }
+        _ => None,
     }
 }
 

--- a/crates/grafeo-engine/src/query/planner/rdf/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/rdf/mod.rs
@@ -445,11 +445,7 @@ impl RdfPlanner {
         let columns: Vec<String> = ret
             .items
             .iter()
-            .map(|item| {
-                item.alias
-                    .clone()
-                    .unwrap_or_else(|| expression_to_string(&item.expression))
-            })
+            .map(|item| output_column_name(item.alias.as_deref(), &item.expression))
             .collect();
 
         Ok((input_op, columns, input_types))
@@ -609,7 +605,7 @@ impl RdfPlanner {
             match &key.expression {
                 LogicalExpression::Variable(_) => {}
                 _ => {
-                    let col_name = format!("__expr_{:?}", key.expression);
+                    let col_name = resolved_column_name(&key.expression);
                     if !variable_columns.contains_key(&col_name) {
                         let filter_expr = convert_filter_expression(&key.expression)?;
                         expression_projections.push((filter_expr, col_name.clone()));
@@ -825,7 +821,7 @@ impl RdfPlanner {
             match expr {
                 LogicalExpression::Variable(_) => {}
                 _ => {
-                    let col_name = format!("__expr_{:?}", expr);
+                    let col_name = resolved_column_name(expr);
                     if !variable_columns.contains_key(&col_name) {
                         let filter_expr = convert_filter_expression(expr)?;
                         expression_projections.push((filter_expr, col_name.clone()));
@@ -843,7 +839,7 @@ impl RdfPlanner {
                 match expr {
                     LogicalExpression::Variable(_) => {}
                     _ => {
-                        let col_name = format!("__expr_{:?}", expr);
+                        let col_name = resolved_column_name(expr);
                         if !variable_columns.contains_key(&col_name) {
                             let filter_expr = convert_filter_expression(expr)?;
                             expression_projections.push((filter_expr, col_name.clone()));
@@ -5313,7 +5309,7 @@ fn resolve_expression(
 }
 
 // expression_to_string is now in planner/common.rs
-use crate::query::planner::common::expression_to_string;
+use crate::query::planner::common::{expression_to_string, output_column_name, resolved_column_name};
 
 /// Converts a value to its string representation.
 fn value_to_string(value: &Value) -> String {

--- a/crates/grafeo-engine/tests/topk_rewrite.rs
+++ b/crates/grafeo-engine/tests/topk_rewrite.rs
@@ -263,3 +263,154 @@ fn cypher_order_by_limit_uses_topk() {
     let actual_top5: Vec<Value> = result.rows().iter().map(|row| row[0].clone()).collect();
     assert_eq!(actual_top5, expected_top5);
 }
+
+// Regression tests for the probe-state-pollution bug class.
+//
+// `try_heap_topk_rewrite` used to plan the input subtree as a speculative
+// probe, then fall through to the unfused path when sort-key resolution
+// failed. The probe mutated `Planner::scalar_columns`, so the unfused
+// re-planning saw a polluted set and chose `ProjectExpr::Column` (raw
+// passthrough) instead of `ProjectExpr::NodeResolve` for `Variable(n)`
+// Return items. Result: `RETURN n ORDER BY <key> LIMIT k` returned raw
+// `Int64` NodeIds instead of resolved maps for any sort key whose column
+// the resolver couldn't find by name — i.e. anything that isn't a bare
+// Variable or a Property already projected by Return.
+//
+// Issues #335 (Property keys) and #347 (FunctionCall keys, specifically
+// text_score) were reported separately. Both share the same root cause,
+// and the class extends to Case, Binary, and IndexAccess sort keys as
+// well. The fix replaces the probe with predictive column resolution
+// (see `try_heap_topk_rewrite`), so the canonical plan is built exactly
+// once and no shared state is mutated speculatively.
+//
+// Each test asserts that the entity-variable Return item still resolves
+// to a `Value::Map`, regardless of the sort key's shape.
+
+#[test]
+fn order_by_limit_property_key_yields_map() {
+    // Original #335 reproduction. Property sort key not materialized in Return.
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+    session
+        .execute("INSERT (:Article {title: 'A1', body: 'rust database internals'})")
+        .unwrap();
+
+    for (label, query) in [
+        ("bare RETURN n", "MATCH (n:Article) RETURN n"),
+        ("RETURN n LIMIT k", "MATCH (n:Article) RETURN n LIMIT 50"),
+        ("RETURN n ORDER BY n.p", "MATCH (n:Article) RETURN n ORDER BY n.title"),
+        (
+            "RETURN n ORDER BY n.p LIMIT k",
+            "MATCH (n:Article) RETURN n ORDER BY n.title LIMIT 50",
+        ),
+    ] {
+        let result = session.execute(query).unwrap();
+        assert!(
+            result.rows()[0][0].as_map().is_some(),
+            "{label}: expected Value::Map, got {:?}",
+            result.rows()[0][0]
+        );
+    }
+}
+
+#[cfg(feature = "text-index")]
+#[test]
+fn order_by_limit_text_score_key_yields_map() {
+    // Issue #347. text_score is a FunctionCall sort key; the previous
+    // predicate-based fix only handled Property keys.
+    use std::collections::HashMap;
+
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+    session
+        .execute("INSERT (:Article {title: 'A1', body: 'rust database internals'})")
+        .unwrap();
+    db.create_text_index("Article", "body").expect("index");
+
+    let params = HashMap::from([("sub".to_string(), Value::from("database"))]);
+
+    // Without LIMIT: already worked, asserting it stays correct.
+    let result = session
+        .execute_with_params(
+            "MATCH (s:Article) RETURN s, text_score(s.body, $sub) \
+             ORDER BY text_score(s.body, $sub) DESC",
+            params.clone(),
+        )
+        .unwrap();
+    assert!(
+        result.rows()[0][0].as_map().is_some(),
+        "without LIMIT: expected Map, got {:?}",
+        result.rows()[0][0]
+    );
+
+    // With LIMIT: the failing case in #347.
+    let result = session
+        .execute_with_params(
+            "MATCH (s:Article) RETURN s, text_score(s.body, $sub) \
+             ORDER BY text_score(s.body, $sub) DESC LIMIT 50",
+            params.clone(),
+        )
+        .unwrap();
+    assert!(
+        result.rows()[0][0].as_map().is_some(),
+        "with LIMIT: expected Map, got {:?}",
+        result.rows()[0][0]
+    );
+}
+
+#[test]
+fn order_by_limit_case_key_yields_map() {
+    // Case sort key references a variable n that IS in Return as Variable(n).
+    // The previous variable-membership predicate would say "no augmenting
+    // needed" and let the probe run.
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+    session
+        .execute("INSERT (:Article {title: 'A1', tier: 1})")
+        .unwrap();
+    session
+        .execute("INSERT (:Article {title: 'A2', tier: 2})")
+        .unwrap();
+
+    let result = session
+        .execute(
+            "MATCH (n:Article) RETURN n \
+             ORDER BY CASE n.tier WHEN 1 THEN 0 ELSE 1 END LIMIT 50",
+        )
+        .unwrap();
+
+    assert_eq!(result.row_count(), 2);
+    for (i, row) in result.rows().iter().enumerate() {
+        assert!(
+            row[0].as_map().is_some(),
+            "row {i}: expected Map, got {:?}",
+            row[0]
+        );
+    }
+}
+
+#[test]
+fn order_by_limit_binary_key_yields_map() {
+    // Binary expression sort key, variable in Return.
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+    session
+        .execute("INSERT (:Item {a: 3, b: 5})")
+        .unwrap();
+    session
+        .execute("INSERT (:Item {a: 1, b: 2})")
+        .unwrap();
+
+    let result = session
+        .execute("MATCH (n:Item) RETURN n ORDER BY n.a + n.b DESC LIMIT 50")
+        .unwrap();
+
+    assert_eq!(result.row_count(), 2);
+    for (i, row) in result.rows().iter().enumerate() {
+        assert!(
+            row[0].as_map().is_some(),
+            "row {i}: expected Map, got {:?}",
+            row[0]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #347 and the broader bug class also surfaced in #335. `try_heap_topk_rewrite` planned the input subtree as a speculative probe, then fell through to the unfused path when sort-key resolution failed. The probe mutated `Planner::scalar_columns` via the side effects in `plan_return_projection`, and the unfused re-planning of the same `Return` then chose `ProjectExpr::Column` (raw passthrough) instead of `ProjectExpr::NodeResolve` — `MATCH (n) RETURN n ORDER BY <key> LIMIT k` returned a raw `Int64` NodeId instead of a resolved map for any sort key whose resolver column name wasn't materialised by Return.

## Relation to the prior #335 fix

The earlier fix for #335 (PR #337, closed; the predicate change was cherry-picked into `release/0.5.43` as 530edc5f) patched the gate predicate `sort_needs_augmenting_projection` to return `true` for `Property` sort keys. That kept the probe from running for that one shape, but the underlying mechanism — the probe mutating planner state on fall-through — was untouched, and the same root cause re-fires for any other sort-key shape the predicate doesn't gate. #347 surfaced it with `text_score` (a `FunctionCall`); the audit in this PR found the same break for `Case` and `Binary` sort keys, neither of which has a GH issue but both reproduce on `main` today.

`main` does not currently contain the `release/0.5.43` predicate cherry-pick, so this PR is what fixes #335 and #347 on `main`. The cherry-picked release-branch fix and this PR are not in conflict — this one removes the architectural condition that made the predicate-as-gate necessary in the first place, so future sort-key shapes don't need new carve-outs.

## Changes (commit-by-commit)

1. **`refactor(planner): centralize column-naming formulas`** — extracts two helpers in `query/planner/common.rs`:
   - `output_column_name(alias, expr)` for Return/Project item names.
   - `resolved_column_name(expr)` symmetric with `resolve_expression_to_column`'s lookup.

   Replaces 15 duplicated `alias.unwrap_or_else(|| expression_to_string(...))` and `format!("{v}_{p}")` / `format!("__expr_{expr:?}")` callsites across `lpg/{aggregate,project}.rs`, `rdf/mod.rs`, and `common.rs`. Pure refactor — no behavior change.

2. **`fix(planner): remove probe state-pollution in try_heap_topk_rewrite (#347, #335)`** — replaces the probe with predictive column resolution. `predict_subtree_columns` derives Return's output columns from `ret.items` via the shared `output_column_name` helper (no planner mutation), and sort keys resolve against the prediction before any planning happens. A `debug_assert_eq!` between predicted and actual columns guards against future drift if a new shape is added. `RETURN *` is explicitly skipped (input columns aren't knowable without planning) — mirrors the same check in `plan_return_projection`.

3. **`test(topk_rewrite): regression coverage for probe state-pollution`** — four tests, one per sort-key shape that triggered the bug class:
   - `order_by_limit_property_key_yields_map` (issue #335)
   - `order_by_limit_text_score_key_yields_map` (issue #347, behind `text-index`)
   - `order_by_limit_case_key_yields_map` (Case expression — no GH issue, found via audit)
   - `order_by_limit_binary_key_yields_map` (Binary expression — no GH issue, found via audit)

   Each asserts the entity Return item resolves to `Value::Map`. Verified to fail on the parent commit (without the fix) with `expected Map, got Int64(0)`.

4. **`fix(planner): restore TopK coverage for property-alias-mismatch case`** — `RETURN v.p ORDER BY v.p LIMIT k` was getting routed through the unfused path because Return outputs the column under `"v.p"` (via `expression_to_string` fallback) but the resolver looks up `"v_p"` (via `resolved_column_name`). `plan_sort` already handles this in its prelude; that prelude logic is now extracted as `register_return_property_sort_aliases` and called from both `plan_sort` (unchanged behavior) and `try_heap_topk_rewrite` (new — closes the coverage gap).

## Test plan

- [x] `cargo test -p grafeo-engine --no-default-features --features "lpg gql ai parallel" --test topk_rewrite` — 11 tests pass (7 existing + 4 new regression).
- [x] Targeted sweep on the planner-adjacent suites — `planner_lpg_coverage` (26), `planner_coverage` (34), `project_coverage` (18), `hybrid_query` (34), `spec_compliance` (106), `mutation_planning` (39), `factorized_aggregation_test`, `seam_aggregates_expressions` (25), `null_and_coercion` (27), `push_pipeline_integration` (42), `expression_and_projection` (65) — all green.
- [x] Confirmed the 4 new regression tests fail on the refactor-only commit with the `Value::Int64(0)` symptom — proving the bug class extends beyond what was reported in #335 and #347.
- [x] Verified `cypher_order_by_limit_uses_topk` (`RETURN n.r ORDER BY n.r DESC LIMIT 5`) still passes — this is the shape that now fires TopK after the alias-mismatch fix.
- [x] Pre-existing failures on `upstream/main` (`merge_rollback`, `query_correctness`, `regression_external` compile errors; `gql_spec_compliance` LIKE tests) confirmed independent of this branch.

## Notes for the reviewer

- **No API surface change.** All edits are internal to `query/planner/`. Tests assert correctness via the existing `session.execute()` path.
- **A separate follow-up PR (#350)** addresses a related but independent issue — column-name collisions for unaliased complex expressions in `RETURN`. Submitted separately because it's a user-visible behavior change in column naming and deserves its own review and CHANGELOG note.