### PR TITLE
fix(planner): distinct column names for unaliased complex expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Grafeo, for future reference (and enjoyment).
 
+## [Unreleased]
+
+### Changed
+
+- **Auto-generated column names for unaliased complex expressions are now informative.** `expression_to_string` previously collapsed `Binary`/`Unary`/`Case`/`Labels`/`Type`/`Id`/`Slice`/`List`/`Map`/subquery shapes to the literal string `"expr"`, so two un-aliased items in one `RETURN` clause silently produced columns sharing a name (and Python/MCP dict-style result accessors would shadow). Each `LogicalExpression` variant now produces a distinct Cypher-style rendering: `n.a + n.b` → `"(n.a + n.b)"`, `id(a)` → `"id(a)"`, `count(*)` → `"count(*)"`, `labels(n)` → `"labels(n)"`, etc. Heavy expressions (`Case`, subqueries, comprehensions, `reduce`) collapse to short generic labels (`"case"`, `"exists"`, `"count"`, `"subquery"`, `"reduce"`, `"list_comprehension"`, `"pattern_comprehension"`); two unaliased instances of the same kind still collide and should be aliased explicitly. **This is a user-visible change**: callers matching column names by literal string against the old `"expr"`/`"name(...)"` outputs need to either update those checks or alias the expressions in the query.
+
 ## [0.5.42] - 2026-05-04
 
 End-to-end tiered storage: section data (LPG, RDF Ring, vector topology) can spill to mmap-backed disk under memory pressure or explicit configuration, with per-section tier overrides, introspection, and reload. Plus per-block columnar zone maps for selective range scans, paged HNSW topology, packed RDF Ring on disk, a WAL overlay for mutating mmap'd compact stores and a streaming top-K operator that fuses `ORDER BY ... LIMIT` into a single bounded-heap pass.

--- a/crates/grafeo-engine/src/query/planner/common.rs
+++ b/crates/grafeo-engine/src/query/planner/common.rs
@@ -5,7 +5,7 @@
 //! Each function takes already-planned input operators and column lists,
 //! plus a schema derivation function to handle LPG vs RDF type differences.
 
-use crate::query::plan::LogicalExpression;
+use crate::query::plan::{BinaryOp, LogicalExpression, UnaryOp};
 use grafeo_common::types::LogicalType;
 use grafeo_common::utils::error::{Error, Result};
 use grafeo_core::execution::operators::{
@@ -408,6 +408,21 @@ pub(crate) fn resolve_expression_to_column(
 }
 
 /// Converts a logical expression to a human-readable string for column naming.
+///
+/// Used by `output_column_name` as the fallback when a Return/Project item
+/// has no explicit alias. The goal is two-fold:
+///
+/// 1. The string should look like the source expression (users see it as a
+///    column header).
+/// 2. Two structurally distinct expressions should produce distinct strings,
+///    so `RETURN n.a + n.b, n.c + n.d` doesn't yield two columns named the
+///    same thing — downstream lookups by name would silently shadow.
+///
+/// We can't fully meet (2) without sacrificing (1); heavy expressions
+/// (CASE / subqueries / comprehensions) collapse to a short generic label.
+/// Two such expressions in one Return without aliases will still collide —
+/// the right answer there is to alias them. This function covers every
+/// arithmetic/logical/scalar shape users commonly write inline.
 pub(crate) fn expression_to_string(expr: &LogicalExpression) -> String {
     match expr {
         LogicalExpression::Variable(name) => name.clone(),
@@ -415,7 +430,17 @@ pub(crate) fn expression_to_string(expr: &LogicalExpression) -> String {
             format!("{variable}.{property}")
         }
         LogicalExpression::Literal(value) => format!("{value:?}"),
-        LogicalExpression::FunctionCall { name, .. } => format!("{name}(...)"),
+        LogicalExpression::Parameter(name) => format!("${name}"),
+        LogicalExpression::FunctionCall { name, args, .. } => {
+            // Include argument signatures so `count(n)` and `count(m)` don't
+            // collapse to the same column. Empty arg lists keep the "()" form.
+            let inner = args
+                .iter()
+                .map(expression_to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{name}({inner})")
+        }
         LogicalExpression::IndexAccess { base, index } => {
             format!(
                 "{}[{}]",
@@ -423,7 +448,87 @@ pub(crate) fn expression_to_string(expr: &LogicalExpression) -> String {
                 expression_to_string(index)
             )
         }
-        _ => "expr".to_string(),
+        LogicalExpression::SliceAccess { base, start, end } => {
+            let s = start
+                .as_deref()
+                .map(expression_to_string)
+                .unwrap_or_default();
+            let e = end.as_deref().map(expression_to_string).unwrap_or_default();
+            format!("{}[{s}..{e}]", expression_to_string(base))
+        }
+        LogicalExpression::Binary { op, left, right } => {
+            format!(
+                "({} {} {})",
+                expression_to_string(left),
+                binary_op_symbol(*op),
+                expression_to_string(right)
+            )
+        }
+        LogicalExpression::Unary { op, operand } => match op {
+            UnaryOp::IsNull => format!("({} IS NULL)", expression_to_string(operand)),
+            UnaryOp::IsNotNull => format!("({} IS NOT NULL)", expression_to_string(operand)),
+            UnaryOp::Not => format!("(NOT {})", expression_to_string(operand)),
+            UnaryOp::Neg => format!("(-{})", expression_to_string(operand)),
+        },
+        LogicalExpression::Labels(v) => format!("labels({v})"),
+        LogicalExpression::Type(v) => format!("type({v})"),
+        LogicalExpression::Id(v) => format!("id({v})"),
+        LogicalExpression::List(items) => {
+            let inner = items
+                .iter()
+                .map(expression_to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("[{inner}]")
+        }
+        LogicalExpression::Map(entries) => {
+            let inner = entries
+                .iter()
+                .map(|(k, v)| format!("{k}: {}", expression_to_string(v)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{{{inner}}}")
+        }
+        LogicalExpression::MapProjection { base, .. } => format!("{base}{{...}}"),
+        // Heavy expressions — short generic labels. Two unaliased instances
+        // in the same Return still collide; the user should alias them.
+        LogicalExpression::Case { .. } => "case".to_string(),
+        LogicalExpression::ExistsSubquery(_) => "exists".to_string(),
+        LogicalExpression::CountSubquery(_) => "count".to_string(),
+        LogicalExpression::ValueSubquery(_) => "subquery".to_string(),
+        LogicalExpression::Reduce { .. } => "reduce".to_string(),
+        LogicalExpression::ListComprehension { .. } => "list_comprehension".to_string(),
+        LogicalExpression::ListPredicate { kind, .. } => format!("{kind:?}").to_lowercase(),
+        LogicalExpression::PatternComprehension { .. } => "pattern_comprehension".to_string(),
+    }
+}
+
+/// Cypher-style symbol for a `BinaryOp`. Used by `expression_to_string` so
+/// auto-generated column names read like the source expression.
+fn binary_op_symbol(op: BinaryOp) -> &'static str {
+    match op {
+        BinaryOp::Eq => "=",
+        BinaryOp::Ne => "<>",
+        BinaryOp::Lt => "<",
+        BinaryOp::Le => "<=",
+        BinaryOp::Gt => ">",
+        BinaryOp::Ge => ">=",
+        BinaryOp::And => "AND",
+        BinaryOp::Or => "OR",
+        BinaryOp::Xor => "XOR",
+        BinaryOp::Add => "+",
+        BinaryOp::Sub => "-",
+        BinaryOp::Mul => "*",
+        BinaryOp::Div => "/",
+        BinaryOp::Mod => "%",
+        BinaryOp::Concat => "||",
+        BinaryOp::StartsWith => "STARTS WITH",
+        BinaryOp::EndsWith => "ENDS WITH",
+        BinaryOp::Contains => "CONTAINS",
+        BinaryOp::In => "IN",
+        BinaryOp::Like => "LIKE",
+        BinaryOp::Regex => "=~",
+        BinaryOp::Pow => "^",
     }
 }
 

--- a/crates/grafeo-engine/tests/expression_and_projection.rs
+++ b/crates/grafeo-engine/tests/expression_and_projection.rs
@@ -2321,3 +2321,82 @@ fn edge_variable_multi_hop_returns_map() {
         rows[0][3]
     );
 }
+
+// ============================================================================
+// Column naming for un-aliased complex expressions in RETURN
+// ============================================================================
+
+// `expression_to_string` fills in the column name when a Return/Project item
+// has no explicit alias. It used to collapse Binary/Unary/Case/Id/Labels/Type
+// (and others) to the literal string "expr", so any two such items in one
+// RETURN clause produced two columns with identical names — and result-by-name
+// lookups silently shadowed.
+//
+// These tests pin the naming for the common shapes a user is likely to type.
+// They don't assert exact strings (those are implementation-leaky); they
+// assert pairwise distinctness, which is what callers depend on.
+
+#[test]
+fn return_two_unaliased_binary_expressions_have_distinct_column_names() {
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+    session
+        .execute("INSERT (:Item {a: 1, b: 2, c: 3, d: 4})")
+        .unwrap();
+
+    let result = session
+        .execute("MATCH (n:Item) RETURN n.a + n.b, n.c + n.d")
+        .unwrap();
+
+    assert_eq!(result.columns.len(), 2);
+    assert_ne!(
+        result.columns[0], result.columns[1],
+        "two distinct binary expressions must get distinct column names, got: {:?}",
+        result.columns
+    );
+}
+
+#[test]
+fn return_two_unaliased_id_calls_have_distinct_column_names() {
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+    session
+        .execute("INSERT (:Person {name: 'Alix'})-[:KNOWS]->(:Person {name: 'Gus'})")
+        .unwrap();
+
+    let result = session
+        .execute("MATCH (a)-[r]->(b) RETURN id(a), id(b)")
+        .unwrap();
+
+    assert_eq!(result.columns.len(), 2);
+    assert_ne!(
+        result.columns[0], result.columns[1],
+        "id(a) and id(b) must get distinct column names, got: {:?}",
+        result.columns
+    );
+}
+
+#[test]
+fn return_mixed_scalar_intrinsics_have_distinct_column_names() {
+    // labels(n), type(r), and id(n) used to all collapse to "expr".
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+    session
+        .execute("INSERT (:Person {name: 'Alix'})-[:KNOWS]->(:Person {name: 'Gus'})")
+        .unwrap();
+
+    let result = session
+        .execute("MATCH (a)-[r]->(b) RETURN labels(a), type(r), id(a)")
+        .unwrap();
+
+    assert_eq!(result.columns.len(), 3);
+    let mut sorted = result.columns.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(
+        sorted.len(),
+        result.columns.len(),
+        "labels/type/id must each get a distinct column name, got: {:?}",
+        result.columns
+    );
+}


### PR DESCRIPTION
## Summary

`expression_to_string` — the source of column names when a `RETURN`/`WITH`/`Project` item has no explicit alias — collapsed `Binary`/`Unary`/`Case`/`Labels`/`Type`/`Id`/`Slice`/`List`/`Map`/subquery shapes to the literal string `"expr"` via a catch-all `_` arm. Two such items in one clause silently produced two columns sharing a name, so result-by-name lookups in external clients (Python bindings, MCP, anything using `result.columns` as a dict key) would shadow.

The internal planner is mostly insulated: ORDER BY/GROUP BY/DISTINCT resolution goes through `resolved_column_name` rather than the user-visible string, so this isn't a correctness bug in query *execution*. It is, however, a real bug at the **client API boundary**: result-set tooling and dict-style accessors over the column list see collisions for any unaliased complex expression.

## What changes

Every `LogicalExpression` variant now produces a distinct, Cypher-style rendering. Examples:

| Expression | Before | After |
|---|---|---|
| `n.a + n.b` | `"expr"` | `"(n.a + n.b)"` |
| `NOT n.active` | `"expr"` | `"(NOT n.active)"` |
| `id(a)` | `"id(...)"` | `"id(a)"` |
| `count(*)` | `"count(...)"` | `"count(*)"` |
| `labels(n)` | `"labels(...)"` | `"labels(n)"` |
| `text_score(s.body, $q)` | `"text_score(...)"` | `"text_score(s.body, $q)"` |
| `CASE n.tier ... END` | `"expr"` | `"case"` |
| `EXISTS { ... }` | `"expr"` | `"exists"` |

Heavy expressions (Case, subqueries, comprehensions, Reduce) collapse to short generic labels (`"case"`, `"exists"`, `"count"`, `"subquery"`, `"reduce"`, `"list_comprehension"`, `"pattern_comprehension"`, predicate kind). Two unaliased instances of the same kind in one RETURN still collide; the right answer there is to alias them — documented in the function's doc comment.

The `_` catch-all arm is dropped from the three matches (`LogicalExpression`, `BinaryOp`, `UnaryOp`) so future variants force an explicit handler at compile time. Matches the codebase's existing `convert_binary_op` convention ("for forward compatibility" = exhaustive match, not a `_` arm).

A new `binary_op_symbol` helper sits next to `expression_to_string` and maps `BinaryOp` variants to their Cypher symbols (`+`, `<>`, `STARTS WITH`, etc.).

## Breaking change

**This is a user-visible change.** Callers matching column names by literal string against the old `"expr"`/`"name(...)"` outputs need to either update the checks or alias the expressions explicitly in the query.

The version bump implication is for the maintainer to decide — CHANGELOG note added under `[Unreleased]` § Changed.

## Test plan

- [x] `cargo test -p grafeo-engine --no-default-features --features "lpg gql ai parallel" --test expression_and_projection` — 68 tests pass (65 existing + 3 new).
- [x] Three regression tests added:
  - `return_two_unaliased_binary_expressions_have_distinct_column_names` — verified fails pre-fix with `["expr", "expr"]`.
  - `return_two_unaliased_id_calls_have_distinct_column_names` — verified fails pre-fix with `["id(...)", "id(...)"]`.
  - `return_mixed_scalar_intrinsics_have_distinct_column_names` — already passed pre-fix because Cypher emits these as `FunctionCall`; retained as forward-regression guard for the `Labels`/`Type`/`Id` `LogicalExpression` variants.
- [x] Repository-wide grep for consumers of `"expr"`/`"id(...)"`/`"labels(...)"`/`"count(...)"` literal strings — zero internal hits beyond the new tests.

## Notes for the reviewer

- **Independent of #349** (the heap top-K state-pollution fix). Submitted as a separate PR because this one carries a user-visible behavior change in column naming; that one is purely internal to the planner.
- **Merge order doesn't matter.** This PR touches `expression_to_string` and its immediate neighbor in `query/planner/common.rs`; #349 touches `resolve_expression_to_column` and adds `output_column_name`/`resolved_column_name` helpers in different parts of the same file. Whichever lands first, the other rebases cleanly.