### PR TITLE
fix(engine): refuse restore_to_epoch onto an existing path

### DIFF
--- a/crates/grafeo-engine/src/database/backup.rs
+++ b/crates/grafeo-engine/src/database/backup.rs
@@ -507,6 +507,22 @@ pub(super) fn do_restore_to_epoch(
     target_epoch: EpochId,
     output_path: &Path,
 ) -> Result<()> {
+    // Refuse to restore on top of an existing database. The `std::fs::copy`
+    // below overwrites `output_path` unconditionally, and the sidecar handling
+    // further down deletes an existing `<output_path>.wal/` directory. Pointing
+    // a restore at a live database would therefore clobber the `.grafeo` file
+    // and silently destroy its sidecar WAL -- exactly the data an operator may
+    // be trying to recover. Restores must target a fresh path; callers that
+    // intend to replace a database should move or remove it first.
+    let sidecar_dir = format!("{}.wal", output_path.display());
+    if output_path.exists() || Path::new(&sidecar_dir).exists() {
+        return Err(Error::InvalidValue(format!(
+            "restore output path already exists: {} (restore must target a fresh path; \
+             move or remove the existing database and its {sidecar_dir} sidecar first)",
+            output_path.display(),
+        )));
+    }
+
     let manifest = read_manifest(backup_dir)?
         .ok_or_else(|| Error::Internal("no backup manifest found".to_string()))?;
 
@@ -760,5 +776,54 @@ mod tests {
         let (parsed, _): (BackupKind, _) =
             bincode::serde::decode_from_slice(&encoded, config).unwrap();
         assert_eq!(parsed, BackupKind::Full);
+    }
+
+    #[test]
+    fn test_do_restore_to_epoch_refuses_existing_output() {
+        let dir = TempDir::new().unwrap();
+        let backup_dir = dir.path().join("backup");
+        std::fs::create_dir_all(&backup_dir).unwrap();
+
+        // A pre-existing database file at the restore target must be refused
+        // before any copy/overwrite happens (the guard fires ahead of manifest
+        // reading, so no real backup chain is needed for this case).
+        let output_path = dir.path().join("live.grafeo");
+        std::fs::write(&output_path, b"existing database -- must not be clobbered").unwrap();
+
+        let err = do_restore_to_epoch(&backup_dir, EpochId::new(0), &output_path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("already exists"),
+            "expected refuse-if-exists error, got: {msg}"
+        );
+
+        // The existing file must be left untouched by the refused restore.
+        assert_eq!(
+            std::fs::read(&output_path).unwrap(),
+            b"existing database -- must not be clobbered"
+        );
+    }
+
+    #[test]
+    fn test_do_restore_to_epoch_refuses_existing_sidecar() {
+        let dir = TempDir::new().unwrap();
+        let backup_dir = dir.path().join("backup");
+        std::fs::create_dir_all(&backup_dir).unwrap();
+
+        // No `.grafeo` file, but a leftover sidecar WAL at the target is still a
+        // non-fresh path: restoring would delete it.
+        let output_path = dir.path().join("live.grafeo");
+        let sidecar = dir.path().join("live.grafeo.wal");
+        std::fs::create_dir_all(&sidecar).unwrap();
+
+        let err = do_restore_to_epoch(&backup_dir, EpochId::new(0), &output_path).unwrap_err();
+        assert!(
+            err.to_string().contains("already exists"),
+            "expected refuse-if-exists error for leftover sidecar, got: {err}"
+        );
+        assert!(
+            sidecar.exists(),
+            "refused restore must leave the sidecar in place"
+        );
     }
 }


### PR DESCRIPTION
### Problem

`do_restore_to_epoch` copied the full backup to `output_path` with an unconditional `std::fs::copy`, and further down deleted any existing `<output_path>.wal` sidecar directory. Pointing a restore at a live database therefore clobbered the `.grafeo` file and silently destroyed its sidecar WAL — the very data an operator may be trying to recover.

### Fix

Add a refuse-if-exists guard at the top of `do_restore_to_epoch` that returns `Error::InvalidValue` when `output_path` or its sidecar already exists, before any filesystem mutation. Restores must target a fresh path.

### Tests

Two new unit tests assert the refusal and that the pre-existing artifacts are left untouched. Full `grafeo-engine` backup suite is green:

```
cargo fmt --all -- --check                     -> clean
cargo clippy -p grafeo-engine --all-features   -> clean (no new warnings)
cargo test  -p grafeo-engine --all-features -- backup
  -> 12 passed; 0 failed  (10 pre-existing + 2 new)
```

Single commit, based on `main` @ `4ebae02`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents accidental data loss by refusing to restore onto an existing database path or its `.wal` sidecar in `grafeo-engine`. Restores must now target a fresh path.

- **Bug Fixes**
  - Add early guard in `do_restore_to_epoch` that returns `Error::InvalidValue` if `output_path` or `<output_path>.wal` exists.
  - Add two unit tests to confirm refusal and that existing files/dirs are untouched.

- **Migration**
  - Restore to a new, empty path.
  - To replace a database, stop the service and move or remove the existing `.grafeo` file and `<path>.wal/` directory, then run restore.

<sup>Written for commit 69ef608d8ba5fadf3f08d3bfa3e6c54f947ab4c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/GrafeoDB/grafeo/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

