### PR TITLE
docs(storage): correct sidecar WAL removal timing

### DIFF
--- a/crates/grafeo-storage/src/file/manager.rs
+++ b/crates/grafeo-storage/src/file/manager.rs
@@ -21,8 +21,10 @@ use super::header;
 ///
 /// 1. [`create`](Self::create) or [`open`](Self::open)
 /// 2. Mutations flow through a sidecar WAL (managed externally by the engine)
-/// 3. [`write_snapshot`](Self::write_snapshot) checkpoints memory to the file
-/// 4. After a successful checkpoint, call [`remove_sidecar_wal`](Self::remove_sidecar_wal)
+/// 3. [`write_snapshot`](Self::write_snapshot) checkpoints memory to the file;
+///    periodic checkpoints retain the sidecar WAL
+/// 4. On a clean shutdown, after the final checkpoint, call
+///    [`remove_sidecar_wal`](Self::remove_sidecar_wal) to discard the sidecar
 /// 5. [`close`](Self::close) (or drop) releases the file handle
 pub struct GrafeoFileManager {
     /// Path to the `.grafeo` file.
@@ -363,7 +365,10 @@ impl GrafeoFileManager {
         self.sidecar_wal_path().exists()
     }
 
-    /// Removes the sidecar WAL directory after a successful checkpoint.
+    /// Removes the sidecar WAL directory after the final checkpoint on a clean
+    /// shutdown. Periodic checkpoints retain the sidecar so an unexpected
+    /// restart can still recover in-flight mutations; only an orderly `close()`
+    /// discards it.
     ///
     /// # Errors
     ///

--- a/crates/grafeo-storage/src/file/mod.rs
+++ b/crates/grafeo-storage/src/file/mod.rs
@@ -2,8 +2,9 @@
 //!
 //! This module implements a portable, crash-safe, single-file storage format.
 //! At rest, only the `.grafeo` file exists. During operation a sidecar
-//! WAL directory (`<path>.wal/`) captures in-flight mutations and is
-//! removed after each checkpoint.
+//! WAL directory (`<path>.wal/`) captures in-flight mutations. Checkpoints
+//! fold those mutations into the `.grafeo` file but retain the sidecar; it
+//! is removed only on a clean `close()`.
 //!
 //! ## File layout
 //!


### PR DESCRIPTION
### Problem

The single-file storage docs claimed the sidecar WAL directory is "removed after each checkpoint". It is not: periodic checkpoints fold in-flight mutations into the `.grafeo` file but **retain** the sidecar; `remove_sidecar_wal` is invoked only on a clean `close()`. Retaining the sidecar across checkpoints is exactly what lets an unexpected restart recover in-flight mutations — only an orderly close discards it.

### Fix

Correct three docstrings to match actual behaviour: the `file/mod.rs` module doc, the `GrafeoFileManager` lifecycle steps, and the `remove_sidecar_wal` doc comment (all under `crates/grafeo-storage/src/file/`). Docs-only; no functional change.

Note: `flush.rs` already documents the periodic-checkpoint WAL correctly as "Kept" on current `main`, so it is deliberately left untouched — only the remaining stale docstrings are corrected.

### Tests

```
cargo fmt --all -- --check                                 -> clean
cargo test -p grafeo-storage --all-features file::         -> 54 passed; 0 failed
RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" \
  cargo doc -p grafeo-storage --no-deps --all-features     -> no broken links
```

Single commit, based on `main` @ `4ebae02`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix storage docs to reflect the correct sidecar WAL lifecycle: periodic checkpoints keep the sidecar; only a clean `close()` calls `remove_sidecar_wal`. Updates the `GrafeoFileManager` lifecycle comments and the module docs in `crates/grafeo-storage/src/file/`; no behavior change.

<sup>Written for commit 18e59dfde627129de3f07e540c17c76d996a0d9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/GrafeoDB/grafeo/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

