### PR TITLE
fix(query): widen UNION output schema to the union of all branches

### DIFF
--- a/crates/grafeo-engine/src/query/planner/lpg/join.rs
+++ b/crates/grafeo-engine/src/query/planner/lpg/join.rs
@@ -3,7 +3,7 @@
 use super::{
     ApplyOp, ApplyOperator, DistinctOp, Error, ExceptOp, HashJoinOperator, IntersectOp, JoinOp,
     JoinType, LeapfrogJoinOperator, LogicalExpression, MultiWayJoinOp, Operator, OtherwiseOp,
-    PhysicalJoinType, ProjectExpr, ProjectOperator, Result, UnionOp, common,
+    PhysicalJoinType, ProjectExpr, ProjectOperator, Result, UnionOp, Value, common,
 };
 
 impl super::Planner {
@@ -204,20 +204,73 @@ impl super::Planner {
     }
 
     /// Plans a UNION operator.
+    ///
+    /// Cypher / GQL UNION aligns branches by column POSITION (the output column
+    /// names come from the first branch that reaches each position), so the
+    /// output arity must be the MAXIMUM branch arity. The historical
+    /// branch-0-only seed used the first branch's arity instead, which silently
+    /// TRUNCATED a UNION whose later branch is WIDER: the extra trailing columns
+    /// were dropped with no error, because Cypher projects inside each branch
+    /// below the union, leaving no node above it to fail. Each narrower branch
+    /// is now null-padded to the maximum width so the core `UnionOperator`
+    /// forwards uniform-width chunks and no column is lost.
+    ///
+    /// This is the LPG-side counterpart to the RDF/SPARQL fix in the RDF
+    /// planner, but the reconciliation differs: SPARQL UNION is over solution
+    /// mappings keyed by variable NAME (so the RDF leg unions branch variable
+    /// SETS), whereas Cypher/GQL UNION is POSITIONAL. The legs also fail
+    /// differently -- the RDF leg crashes (X001/V001), this leg silently
+    /// truncates -- so they are verified by different oracles. Cypher-level
+    /// union-compatibility validation (requiring matching column names) is out
+    /// of scope; this fix targets only the drop mechanism.
     pub(super) fn plan_union(&self, union: &UnionOp) -> Result<(Box<dyn Operator>, Vec<String>)> {
-        let mut inputs = Vec::with_capacity(union.inputs.len());
-        let mut columns = Vec::new();
-
-        for (i, input) in union.inputs.iter().enumerate() {
-            let (op, cols) = self.plan_operator(input)?;
-            if i == 0 {
-                columns = cols;
-            }
-            inputs.push(op);
+        let mut planned = Vec::with_capacity(union.inputs.len());
+        for input in &union.inputs {
+            planned.push(self.plan_operator(input)?);
         }
 
-        let schema = self.derive_schema_from_columns(&columns);
-        common::build_union(inputs, columns, schema)
+        // Positional column domain: position i is named by the first branch
+        // that reaches it; the output arity is the maximum branch arity.
+        let mut unified_columns: Vec<String> = Vec::new();
+        for (_, cols) in &planned {
+            for (i, col) in cols.iter().enumerate() {
+                if i == unified_columns.len() {
+                    unified_columns.push(col.clone());
+                }
+            }
+        }
+
+        let unified_schema = self.derive_schema_from_columns(&unified_columns);
+        let width = unified_columns.len();
+
+        // Null-pad each narrower branch's trailing positions so the core
+        // UnionOperator never forwards a short chunk. A full-width branch passes
+        // through unwrapped (positional union keeps its values in place; the
+        // output column names are taken from `unified_columns`).
+        let inputs: Vec<Box<dyn Operator>> = planned
+            .into_iter()
+            .map(|(op, cols)| {
+                if cols.len() == width {
+                    return op;
+                }
+                let projections: Vec<ProjectExpr> = (0..width)
+                    .map(|i| {
+                        if i < cols.len() {
+                            ProjectExpr::Column(i)
+                        } else {
+                            ProjectExpr::Constant(Value::Null)
+                        }
+                    })
+                    .collect();
+                Box::new(ProjectOperator::new(
+                    op,
+                    projections,
+                    unified_schema.clone(),
+                )) as Box<dyn Operator>
+            })
+            .collect();
+
+        common::build_union(inputs, unified_columns, unified_schema)
     }
 
     /// Plans a DISTINCT operator.

--- a/crates/grafeo-engine/src/query/planner/rdf/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/rdf/mod.rs
@@ -1268,6 +1268,22 @@ impl RdfPlanner {
     }
 
     /// Plans a UNION operator.
+    ///
+    /// The output schema is the UNION of every branch's variable set, not the
+    /// first branch alone. Per SPARQL 1.1 (sec 18.2.1, the result variable
+    /// domain is the union of the branches' in-scope variables; sec 18.5, the
+    /// multiset union of the partial solution mappings), a variable bound in
+    /// only some branches is present-with-UNBOUND in the others, never dropped.
+    ///
+    /// Seeding the schema from branch 0 alone (the historical behavior) dropped
+    /// later-branch-only variables, which surfaced three ways: GRAFEO-X001
+    /// ("Variable not found") when a projection / ORDER BY / aggregate above the
+    /// UNION referenced such a variable at plan time; GRAFEO-V001 ("Column not
+    /// found") at run time when a narrower branch chunk was indexed against the
+    /// wider first-branch width; and, most dangerously, silent corruption for
+    /// SELECT * (a later branch's values surfaced under the first branch's
+    /// variable names, with no error). Each branch is now null-padded to the
+    /// unified width so every emitted chunk shares one physical schema.
     fn plan_union(
         &self,
         union: &crate::query::plan::UnionOp,
@@ -1276,34 +1292,53 @@ impl RdfPlanner {
             return Err(Error::Internal("Empty UNION".to_string()));
         }
 
-        // For INSERT operations, we execute all operators in sequence
-        let mut operators: Vec<Box<dyn Operator>> = Vec::new();
-        let mut columns = Vec::new();
-        let mut types = Vec::new();
+        // Plan every branch, keeping each branch's own (columns, types) so the
+        // unified domain can be computed across all of them.
+        let mut planned: Vec<(Box<dyn Operator>, Vec<String>, Vec<LogicalType>)> =
+            Vec::with_capacity(union.inputs.len());
+        for input in &union.inputs {
+            planned.push(self.plan_operator(input)?);
+        }
 
-        for (i, input) in union.inputs.iter().enumerate() {
-            let (op, cols, tys) = self.plan_operator(input)?;
-            operators.push(op);
-            if i == 0 {
-                columns = cols;
-                types = tys;
+        // Single-branch UNION: the unified domain equals branch 0, so return it
+        // verbatim with no reconciliation (fast path).
+        if planned.len() == 1 {
+            let (op, cols, tys) = planned.into_iter().next().expect("single-element vector");
+            return Ok((op, cols, tys));
+        }
+
+        // Unified, first-seen-ordered column domain with a parallel type vector:
+        // each column's type comes from the first branch that binds it, falling
+        // back to LogicalType::Any when two branches bind it with different
+        // types (the conservative widening precedent of plan_project). This
+        // mirrors the widen + first-seen-dedup idiom of common::build_left_join.
+        let mut unified_columns: Vec<String> = Vec::new();
+        let mut unified_types: Vec<LogicalType> = Vec::new();
+        for (_, cols, tys) in &planned {
+            for (col, ty) in cols.iter().zip(tys.iter()) {
+                if let Some(existing) = unified_columns.iter().position(|c| c == col) {
+                    if unified_types[existing] != *ty {
+                        unified_types[existing] = LogicalType::Any;
+                    }
+                } else {
+                    unified_columns.push(col.clone());
+                    unified_types.push(ty.clone());
+                }
             }
         }
 
-        if operators.len() == 1 {
-            return Ok((
-                operators
-                    .into_iter()
-                    .next()
-                    .expect("single-element iterator"),
-                columns,
-                types,
-            ));
-        }
+        // Null-pad each branch to the unified width. The padding must be a
+        // genuine per-chunk-width copy (not merely a wider declared schema):
+        // DISTINCT and ORDER BY copy at each chunk's own column count against a
+        // fixed-width builder, so a narrow chunk under a wide declared schema
+        // would commit short / misaligned rows.
+        let operators: Vec<Box<dyn Operator>> = planned
+            .into_iter()
+            .map(|(op, cols, _)| pad_union_branch(op, &cols, &unified_columns, &unified_types))
+            .collect();
 
-        // Create a chain operator that executes all operators in sequence
-        let operator = Box::new(RdfUnionOperator::new(operators));
-        Ok((operator, columns, types))
+        let operator = Box::new(RdfUnionOperator::new(operators, unified_columns.len()));
+        Ok((operator, unified_columns, unified_types))
     }
 
     /// Plans an INSERT TRIPLE operator.
@@ -2817,18 +2852,25 @@ impl Operator for RdfModifyOperator {
 // RDF Union Operator
 // ============================================================================
 
-/// Operator that executes multiple operators in sequence.
-/// Used for UNION of INSERT operations.
+/// Sequences the already-planned branches of a SPARQL UNION, emitting each
+/// branch's `DataChunk`s in turn (a multiset union with no de-duplication; see
+/// SPARQL 1.1 sec 18.5). `plan_union` widens every branch to the unified column
+/// domain upstream, so this operator forwards chunks verbatim and only asserts
+/// that each one matches the uniform width.
 struct RdfUnionOperator {
     operators: Vec<Box<dyn Operator>>,
     current_idx: usize,
+    /// Unified output width (the number of columns in the union variable
+    /// domain). Every branch is null-padded to this width by `plan_union`.
+    expected_width: usize,
 }
 
 impl RdfUnionOperator {
-    fn new(operators: Vec<Box<dyn Operator>>) -> Self {
+    fn new(operators: Vec<Box<dyn Operator>>, expected_width: usize) -> Self {
         Self {
             operators,
             current_idx: 0,
+            expected_width,
         }
     }
 }
@@ -2839,7 +2881,19 @@ impl Operator for RdfUnionOperator {
         while self.current_idx < self.operators.len() {
             let op = &mut self.operators[self.current_idx];
             match op.next()? {
-                Some(chunk) => return Ok(Some(chunk)),
+                Some(chunk) => {
+                    debug_assert_eq!(
+                        chunk.column_count(),
+                        self.expected_width,
+                        "RdfUnion branch {} emitted a {}-column chunk but the unified \
+                         UNION schema is {} columns wide; branches must be null-padded \
+                         to a uniform width for DISTINCT / ORDER BY correctness",
+                        self.current_idx,
+                        chunk.column_count(),
+                        self.expected_width,
+                    );
+                    return Ok(Some(chunk));
+                }
                 None => self.current_idx += 1,
             }
         }
@@ -5101,6 +5155,47 @@ fn strip_internal_columns(
     (stripped, output_columns)
 }
 
+/// Null-pads a single UNION branch onto the unified column domain.
+///
+/// Maps each unified column to the branch's local column when the branch binds
+/// it, or to a `Value::Null` constant when it does not, and reorders to the
+/// unified order. The wrap reuses `RdfProjectOperator`, so the branch emits a
+/// `DataChunk` genuinely padded to the unified width (a per-chunk-width copy,
+/// not a merely-declared schema) — what DISTINCT / ORDER BY require downstream.
+///
+/// A branch whose columns already equal the unified domain in order is returned
+/// unwrapped (this also covers branch 0 when no later branch adds a variable).
+fn pad_union_branch(
+    branch: Box<dyn Operator>,
+    branch_columns: &[String],
+    unified_columns: &[String],
+    unified_types: &[LogicalType],
+) -> Box<dyn Operator> {
+    if branch_columns == unified_columns {
+        return branch;
+    }
+
+    let local_index: HashMap<&str, usize> = branch_columns
+        .iter()
+        .enumerate()
+        .map(|(i, name)| (name.as_str(), i))
+        .collect();
+
+    let projections: Vec<RdfProjectExpr> = unified_columns
+        .iter()
+        .map(|name| match local_index.get(name.as_str()) {
+            Some(&idx) => RdfProjectExpr::Column(idx),
+            None => RdfProjectExpr::Constant(Value::Null),
+        })
+        .collect();
+
+    Box::new(RdfProjectOperator::new(
+        branch,
+        projections,
+        unified_types.to_vec(),
+    ))
+}
+
 /// Converts an RDF Term to a string for IRI/blank node representation.
 fn term_to_string(term: &Term) -> String {
     match term {
@@ -6510,6 +6605,93 @@ mod tests {
         assert_eq!(rows, 2);
     }
 
+    /// White-box guard for the UNION output-arity fix: when a later branch
+    /// binds a variable absent from branch 0, `plan_union` must advertise the
+    /// UNION of the branch variable sets and every emitted chunk must be
+    /// null-padded to that unified width (not the branch-0 width). This is the
+    /// planner-level counterpart to the gtest oracles; a regression here is the
+    /// branch-0-only seed returning, which surfaces downstream as GRAFEO-X001 /
+    /// GRAFEO-V001 / silent SELECT-star corruption.
+    #[test]
+    fn test_plan_union_heterogeneous_pads_to_union_domain() {
+        let store = Arc::new(RdfStore::new());
+        // Branch 0 (?s <p> ?a) binds {s, a}; branch 1 (?s <q> ?b) binds {s, b}.
+        store.insert(Triple::new(
+            Term::iri("http://example.org/x"),
+            Term::iri("http://example.org/p"),
+            Term::literal("PVAL"),
+        ));
+        store.insert(Triple::new(
+            Term::iri("http://example.org/y"),
+            Term::iri("http://example.org/q"),
+            Term::literal("QVAL"),
+        ));
+        let planner = RdfPlanner::new(Arc::clone(&store));
+        let scan1 = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://example.org/p".to_string()),
+            object: TripleComponent::Variable("a".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let scan2 = LogicalOperator::TripleScan(TripleScanOp {
+            subject: TripleComponent::Variable("s".to_string()),
+            predicate: TripleComponent::Iri("http://example.org/q".to_string()),
+            object: TripleComponent::Variable("b".to_string()),
+            graph: None,
+            input: None,
+            dataset: None,
+        });
+        let union = LogicalOperator::Union(crate::query::plan::UnionOp {
+            inputs: vec![scan1, scan2],
+        });
+        let physical = planner.plan(&LogicalPlan::new(union)).unwrap();
+
+        // The advertised schema is the UNION of the branch variable sets.
+        assert_eq!(physical.columns.len(), 3, "expected the union of {{s,a,b}}");
+        for v in ["s", "a", "b"] {
+            assert!(
+                physical.columns.iter().any(|c| c == v),
+                "unified UNION schema is missing variable '{v}': {:?}",
+                physical.columns
+            );
+        }
+        let a_idx = physical.columns.iter().position(|c| c == "a").unwrap();
+        let b_idx = physical.columns.iter().position(|c| c == "b").unwrap();
+
+        let mut op = physical.operator;
+        let mut rows = 0;
+        let mut saw_a_only = false;
+        let mut saw_b_only = false;
+        while let Ok(Some(chunk)) = op.next() {
+            // Every branch chunk is genuinely padded to the unified width.
+            assert_eq!(
+                chunk.column_count(),
+                3,
+                "branch chunk was not null-padded to the unified width"
+            );
+            for row in chunk.selected_indices() {
+                let a = chunk.column(a_idx).unwrap().get_value(row);
+                let b = chunk.column(b_idx).unwrap().get_value(row);
+                let a_null = matches!(a, None | Some(Value::Null));
+                let b_null = matches!(b, None | Some(Value::Null));
+                // Disjoint branches: exactly one of {a, b} is bound per row, and
+                // the absent branch's variable is UNBOUND (Null), never dropped.
+                assert!(
+                    a_null ^ b_null,
+                    "each row binds exactly one branch variable; got a={a:?}, b={b:?}"
+                );
+                saw_a_only |= b_null;
+                saw_b_only |= a_null;
+                rows += 1;
+            }
+        }
+        assert_eq!(rows, 2, "expected one row from each branch");
+        assert!(saw_a_only, "branch 0 row (a bound, b UNBOUND) missing");
+        assert!(saw_b_only, "branch 1 row (b bound, a UNBOUND) missing");
+    }
+
     #[test]
     fn test_plan_construct() {
         let store = Arc::new(RdfStore::new());
@@ -7191,7 +7373,7 @@ mod tests {
 
     #[test]
     fn test_into_any_rdf_union_operator() {
-        let op: Box<dyn Operator> = Box::new(RdfUnionOperator::new(vec![]));
+        let op: Box<dyn Operator> = Box::new(RdfUnionOperator::new(vec![], 0));
         let any = op.into_any();
         assert!(any.downcast::<RdfUnionOperator>().is_ok());
     }

--- a/tests/spec/lpg/cypher/reading_clauses.gtest
+++ b/tests/spec/lpg/cypher/reading_clauses.gtest
@@ -241,6 +241,34 @@ tests:
     expect:
       count: 2
 
+  # Positive-correctness oracle for the UNION output-arity fix (LPG leg).
+  # Cypher / GQL UNION aligns columns by POSITION, with the output arity equal
+  # to the WIDEST branch. When the second branch is wider, its trailing column
+  # must be preserved (null-padded into the narrower first branch), NOT silently
+  # dropped. Cypher projects inside each branch (below the union), so the pre-fix
+  # branch-0-only arity dropped the extra column with no error -- silent
+  # truncation, distinct from the SPARQL leg's crash.
+  - name: union_wider_second_branch_no_truncation
+    setup:
+      - "CREATE (:Person {name: 'Alix', age: 30})"
+    query: "MATCH (p:Person) RETURN p.name AS name UNION ALL MATCH (q:Person) RETURN q.name AS name, q.age AS age"
+    expect:
+      columns: [name, age]
+      rows:
+        - [Alix, null]
+        - [Alix, 30]
+
+  - name: union_wider_first_branch_pads_second
+    setup:
+      - "CREATE (:Person {name: 'Alix', age: 30})"
+      - "CREATE (:City {name: 'Amsterdam'})"
+    query: "MATCH (p:Person) RETURN p.name AS name, p.age AS age UNION ALL MATCH (c:City) RETURN c.name AS name"
+    expect:
+      columns: [name, age]
+      rows:
+        - [Alix, 30]
+        - [Amsterdam, null]
+
   # ---------------------------------------------------------------------------
   # CALL procedure
   # ---------------------------------------------------------------------------

--- a/tests/spec/lpg/gql/14.2_set_operations.gtest
+++ b/tests/spec/lpg/gql/14.2_set_operations.gtest
@@ -39,6 +39,24 @@ tests:
         - [Alix]
         - [Amsterdam]
 
+  # Positional alignment: GQL UNION combines branches by column POSITION and
+  # names each output column from the FIRST branch. union_distinct_deduplicates
+  # cannot distinguish this -- both of its branches name the column identically,
+  # so positional and by-name alignment look the same. Here the two branches
+  # alias the same position to DIFFERENT names ('name' vs 'city'); positional
+  # alignment yields a single column carrying both values under the first
+  # branch's name, whereas a by-name implementation would split or reject them.
+  - name: union_all_aligns_by_position_with_first_branch_name
+    setup:
+      - "INSERT (:Person {name: 'Alix'})"
+      - "INSERT (:City {city: 'Amsterdam'})"
+    query: MATCH (n:Person) RETURN n.name AS name UNION ALL MATCH (c:City) RETURN c.city AS city
+    expect:
+      columns: [name]
+      rows:
+        - [Alix]
+        - [Amsterdam]
+
   - name: except_set_difference
     setup:
       - "INSERT (:N {v: 1})"

--- a/tests/spec/rdf/sparql/union_minus.gtest
+++ b/tests/spec/rdf/sparql/union_minus.gtest
@@ -87,6 +87,207 @@ tests:
         - [Alix]
 
   # ---------------------------------------------------------------------------
+  # Heterogeneous-arity UNION (output-arity fix)
+  #
+  # Per SPARQL 1.1 sec 18.2.1 the result variable domain is the UNION of the
+  # branches' in-scope variables; a variable bound in only some branches is
+  # present-with-UNBOUND (null) elsewhere, never dropped. These cases cover the
+  # three manifestations of the prior branch-0-only schema: GRAFEO-X001 at plan
+  # time (explicit SELECT of a later-branch-only variable), GRAFEO-V001 at run
+  # time (a narrower branch indexed against a wider first branch), and the
+  # silent SELECT-star corruption (a later branch's values surfacing under the
+  # first branch's variable names). The existing UNION cases above all share
+  # branch-0 width, so this is the heterogeneous coverage that was missing.
+  # ---------------------------------------------------------------------------
+
+  - name: union_heterogeneous_vars_explicit
+    # GRAFEO-X001 repro: ?y lives only in the second branch. Before the fix the
+    # projection above the UNION raised "Variable not found"; now ?y is UNBOUND
+    # in the first branch.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/a> <http://ex.org/q> <http://ex.org/z> .
+        }
+    query: |
+      SELECT ?x ?y WHERE {
+        { ?s <http://ex.org/p> ?x }
+        UNION
+        { ?s <http://ex.org/q> ?y }
+      }
+    expect:
+      columns: [x, y]
+      rows:
+        - [http://ex.org/b, null]
+        - [null, http://ex.org/z]
+
+  - name: union_heterogeneous_vars_reversed
+    # The branch that defines a variable must not change the outcome: here the
+    # first-listed branch binds ?y and the second binds ?x.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/a> <http://ex.org/q> <http://ex.org/z> .
+        }
+    query: |
+      SELECT ?y ?x WHERE {
+        { ?s <http://ex.org/q> ?y }
+        UNION
+        { ?s <http://ex.org/p> ?x }
+      }
+    expect:
+      columns: [y, x]
+      rows:
+        - [http://ex.org/z, null]
+        - [null, http://ex.org/b]
+
+  - name: union_three_branches_heterogeneous
+    # Each branch contributes a distinct variable; the result domain is the
+    # union of all three, with the two absent variables UNBOUND per row.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/a> <http://ex.org/q> <http://ex.org/z> .
+          <http://ex.org/a> <http://ex.org/r> <http://ex.org/w> .
+        }
+    query: |
+      SELECT ?x ?y ?z WHERE {
+        { ?s <http://ex.org/p> ?x }
+        UNION
+        { ?s <http://ex.org/q> ?y }
+        UNION
+        { ?s <http://ex.org/r> ?z }
+      }
+    expect:
+      columns: [x, y, z]
+      rows:
+        - [http://ex.org/b, null, null]
+        - [null, http://ex.org/z, null]
+        - [null, null, http://ex.org/w]
+
+  - name: union_bind_misaligned_v001
+    # GRAFEO-V001 repro (heterogeneous-variable UNION shape): the first branch is
+    # WIDER (it adds ?o plus a BIND ?dir) and binds ?dir at a different physical
+    # column than the narrower second branch. Before the fix the second branch's
+    # chunk was indexed against the first branch's width, raising "Column not
+    # found"; now each branch is reordered and padded to the unified domain.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/c> <http://ex.org/q> <http://ex.org/d> .
+        }
+    query: |
+      SELECT ?s ?dir WHERE {
+        { ?s <http://ex.org/p> ?o . BIND("out" AS ?dir) }
+        UNION
+        { ?s <http://ex.org/q> ?dir }
+      }
+    expect:
+      columns: [s, dir]
+      rows:
+        - [http://ex.org/a, out]
+        - [http://ex.org/c, http://ex.org/d]
+
+  - name: union_select_star_no_corruption
+    # Guards against silent column mislabeling. A SELECT * over heterogeneous-name
+    # branches must NEVER surface a later branch's values under the first
+    # branch's variable names. Before the fix the Wildcard projection skipped
+    # the by-name guard, the schema was the first branch's [s, x], and the
+    # second branch's object value appeared under ?x with ?y dropped and no
+    # error. The fix advertises the full domain [s, x, y] with null padding.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/a> <http://ex.org/q> <http://ex.org/z> .
+        }
+    query: |
+      SELECT * WHERE {
+        { ?s <http://ex.org/p> ?x }
+        UNION
+        { ?s <http://ex.org/q> ?y }
+      }
+    expect:
+      columns: [s, x, y]
+      rows:
+        - [http://ex.org/a, http://ex.org/b, null]
+        - [http://ex.org/a, null, http://ex.org/z]
+
+  - name: union_same_arity_control
+    # Control: homogeneous-name branches keep their pre-fix behavior exactly.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/a> <http://ex.org/q> <http://ex.org/z> .
+        }
+    query: |
+      SELECT ?x WHERE {
+        { ?s <http://ex.org/p> ?x }
+        UNION
+        { ?s <http://ex.org/q> ?x }
+      }
+    expect:
+      columns: [x]
+      rows:
+        - [http://ex.org/b]
+        - [http://ex.org/z]
+
+  - name: union_distinct_over_null
+    # DISTINCT after a heterogeneous UNION must dedup over UNBOUND (KeyPart::Null)
+    # as well as over concrete values. This depends on every branch chunk being
+    # genuinely null-padded to a uniform width (DISTINCT copies at per-chunk
+    # column count against a fixed-width builder).
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/m> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/n> .
+          <http://ex.org/c> <http://ex.org/q> <http://ex.org/z> .
+          <http://ex.org/d> <http://ex.org/q> <http://ex.org/z> .
+        }
+    query: |
+      SELECT DISTINCT ?y WHERE {
+        { ?s <http://ex.org/p> ?x }
+        UNION
+        { ?s <http://ex.org/q> ?y }
+      }
+    expect:
+      columns: [y]
+      rows:
+        - [null]
+        - [http://ex.org/z]
+
+  - name: union_order_by_nulls_last
+    # ORDER BY over a heterogeneous UNION column places UNBOUND (null) last and
+    # requires the same uniform branch-chunk width as DISTINCT.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/m> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/n> .
+          <http://ex.org/c> <http://ex.org/q> <http://ex.org/z> .
+          <http://ex.org/d> <http://ex.org/q> <http://ex.org/z> .
+        }
+    query: |
+      SELECT DISTINCT ?y WHERE {
+        { ?s <http://ex.org/p> ?x }
+        UNION
+        { ?s <http://ex.org/q> ?y }
+      }
+      ORDER BY ?y
+    expect:
+      ordered: true
+      columns: [y]
+      rows:
+        - [http://ex.org/z]
+        - [null]
+
+  # ---------------------------------------------------------------------------
   # MINUS
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #365

## Problem

`UNION` built its result schema from the **first branch alone**, so a variable (SPARQL) or column (Cypher/GQL) that appears only in a later branch was dropped instead of present-with-unbound. This produced four observable failures (full repros in the linked issue):

- **Silent SELECT-\* corruption** (most severe): a `SELECT *` over heterogeneous-name branches returned a later branch's values under the first branch's variable names, with no error.
- **`GRAFEO-X001`** at plan time: a projection / `ORDER BY` / aggregate above the UNION referencing a later-branch-only variable could not resolve it.
- **`GRAFEO-V001`** at run time: a narrower later branch was indexed against the wider first-branch width.
- **Cypher/GQL silent truncation**: a wider later branch's extra columns were dropped.

Per SPARQL 1.1, the result variable domain is the union of the branches' in-scope variables (§18.2.1) and the result is the multiset union of the partial solution mappings (§18.5): a variable unbound in a branch is unbound there, never removed.

## Root cause

- **RDF/SPARQL** — `crates/grafeo-engine/src/query/planner/rdf/mod.rs`, `plan_union`: the branch loop assigned output columns/types only on the first iteration and returned that schema; `RdfUnionOperator::next` then forwarded each branch's `DataChunk` verbatim. `SELECT *` additionally yields an empty projection list that bypasses the by-name guard, so first-branch names win silently.
- **Cypher/GQL** — `crates/grafeo-engine/src/query/planner/lpg/join.rs`, `plan_union`: the same first-branch-only seed, forwarded through the core `UnionOperator`. Because Cypher projects inside each branch (below the union), there is no node above the union to fail, so a wider later branch is silently truncated.

## Fix

The two legs reconcile differently, because their UNION semantics differ, so the fix lands at each site (one logical change, two operator/planner sites):

- **RDF/SPARQL (by variable name):** `plan_union` now computes the union of every branch's variable set (first-seen order), with each column's type taken from the first branch that binds it (falling back to `Any` on disagreement). Each branch is wrapped in a projection that maps the unified columns to the branch's local column when present, or to a `Value::Null` constant when absent — reusing the existing `RdfProjectOperator`. The padding is a **genuine per-chunk-width copy**, not a merely-wider declared schema, because `DISTINCT` and `ORDER BY` copy at each chunk's own column count against a fixed-width builder. `RdfUnionOperator` carries the unified width and `debug_assert`s that every emitted chunk matches it; the single-branch fast path is preserved; and the stale "UNION of INSERT" docstring is refreshed.
- **Cypher/GQL (by position):** Cypher/GQL UNION aligns columns by position, with the output names taken from the first branch that reaches each position, so `plan_union` widens to the **maximum branch arity** and null-pads the trailing columns of narrower branches via the core `ProjectOperator`. Column-name compatibility validation (rejecting mismatched names) is intentionally out of scope; this targets only the drop mechanism.

The change is planner-local: no executor, operator-trait, logical-operator, or on-disk change.

## Tests

The existing UNION spec cases were all same-arity, so the heterogeneous path was uncovered. Added:

- **SPARQL** (`tests/spec/rdf/sparql/union_minus.gtest`): the X001 and V001 repros; a `SELECT *` anti-corruption guard asserting the widened columns `[s, x, y]` with correct null padding; reversed-branch and three-branch variants; `DISTINCT` over unbound; `ORDER BY` with nulls last; a same-arity control.
- **Cypher** (`tests/spec/lpg/cypher/reading_clauses.gtest`): positive-correctness oracles for the wider-second-branch and wider-first-branch cases (the dropped column is now preserved and null-padded).
- **GQL** (`tests/spec/lpg/gql/14.2_set_operations.gtest`): a positional-alignment oracle asserting `UNION ALL` aligns branches by column position and names each output column from the first branch (distinct from the same-name dedup case, which cannot tell positional alignment apart from by-name alignment).
- **White-box planner** (`rdf/mod.rs`): `plan_union` advertises the union of branch variable sets and emits genuinely null-padded, uniform-width chunks.

No existing spec test encoded the pre-fix behavior, so none required correction. `cargo fmt` and `clippy` are clean; the `grafeo-engine`, `grafeo-core`, and `grafeo-spec-tests` suites pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UNION to include all branch variables/columns and null-pad missing ones, preventing SELECT-* corruption and fixing `GRAFEO-X001`/`GRAFEO-V001` in SPARQL and silent truncation in Cypher/GQL.

- **Bug Fixes**
  - RDF/SPARQL: Planner now unions branch variable names and types (first binding wins; disagreements widen to `Any`). Each branch is projected to the unified schema with nulls for absent vars; `RdfUnionOperator` asserts uniform width. Single-branch fast path kept.
  - Cypher/GQL: UNION aligns by position, widens to the maximum arity, and null-pads trailing columns of narrower branches via `ProjectOperator` with `Value::Null`. Output names come from the first branch.
  - Planner-local change only. Added spec tests for heterogeneous UNIONs (SPARQL SELECT-*, DISTINCT, ORDER BY nulls-last; Cypher/GQL positional alignment) and a white-box planner guard.

<sup>Written for commit ad9405843c22c04b777fc82f69748d52dbfe13c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/GrafeoDB/grafeo/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

