### PR TITLE
fix(query): route named-graph SPARQL DELETE/INSERT WHERE to the target graph (and make MODIFY durable)

### DIFF
--- a/crates/grafeo-engine/src/query/planner/rdf/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/rdf/mod.rs
@@ -1628,6 +1628,8 @@ impl RdfPlanner {
             modify.delete_templates.clone(),
             modify.insert_templates.clone(),
             column_map,
+            #[cfg(feature = "wal")]
+            self.wal.clone(),
             #[cfg(feature = "cdc")]
             self.cdc_log.clone(),
             #[cfg(feature = "cdc")]
@@ -2641,6 +2643,8 @@ struct RdfModifyOperator {
     insert_templates: Vec<TripleTemplate>,
     column_map: HashMap<String, usize>,
     done: bool,
+    #[cfg(feature = "wal")]
+    wal: Option<Arc<RdfWal>>,
     #[cfg(feature = "cdc")]
     cdc_log: Option<Arc<crate::cdc::CdcLog>>,
     #[cfg(feature = "cdc")]
@@ -2648,12 +2652,16 @@ struct RdfModifyOperator {
 }
 
 impl RdfModifyOperator {
+    // The WAL and CDC sinks are independent cfg-gated arguments; with both
+    // enabled this constructor exceeds the default threshold by one.
+    #[allow(clippy::too_many_arguments)]
     fn new(
         store: Arc<RdfStore>,
         input: Box<dyn Operator>,
         delete_templates: Vec<TripleTemplate>,
         insert_templates: Vec<TripleTemplate>,
         column_map: HashMap<String, usize>,
+        #[cfg(feature = "wal")] wal: Option<Arc<RdfWal>>,
         #[cfg(feature = "cdc")] cdc_log: Option<Arc<crate::cdc::CdcLog>>,
         #[cfg(feature = "cdc")] cdc_epoch: grafeo_common::types::EpochId,
     ) -> Self {
@@ -2664,6 +2672,8 @@ impl RdfModifyOperator {
             insert_templates,
             column_map,
             done: false,
+            #[cfg(feature = "wal")]
+            wal,
             #[cfg(feature = "cdc")]
             cdc_log,
             #[cfg(feature = "cdc")]
@@ -2801,6 +2811,16 @@ impl Operator for RdfModifyOperator {
                                 })
                                 .collect();
                             for matched in matching {
+                                #[cfg(feature = "wal")]
+                                log_rdf_wal(
+                                    &self.wal,
+                                    &grafeo_storage::wal::WalRecord::DeleteRdfTriple {
+                                        subject: term_to_wal(matched.subject()),
+                                        predicate: term_to_wal(matched.predicate()),
+                                        object: term_to_wal(matched.object()),
+                                        graph: template.graph.clone(),
+                                    },
+                                );
                                 #[cfg(feature = "cdc")]
                                 record_cdc_triple_delete(
                                     &self.cdc_log,
@@ -2815,6 +2835,16 @@ impl Operator for RdfModifyOperator {
                             continue;
                         }
                     }
+                    #[cfg(feature = "wal")]
+                    log_rdf_wal(
+                        &self.wal,
+                        &grafeo_storage::wal::WalRecord::DeleteRdfTriple {
+                            subject: term_to_wal(triple.subject()),
+                            predicate: term_to_wal(triple.predicate()),
+                            object: term_to_wal(triple.object()),
+                            graph: template.graph.clone(),
+                        },
+                    );
                     #[cfg(feature = "cdc")]
                     record_cdc_triple_delete(
                         &self.cdc_log,
@@ -2841,6 +2871,16 @@ impl Operator for RdfModifyOperator {
 
                 if let (Some(s), Some(p), Some(o)) = (subject, predicate, object) {
                     let triple = Triple::new(s, p, o);
+                    #[cfg(feature = "wal")]
+                    log_rdf_wal(
+                        &self.wal,
+                        &grafeo_storage::wal::WalRecord::InsertRdfTriple {
+                            subject: term_to_wal(triple.subject()),
+                            predicate: term_to_wal(triple.predicate()),
+                            object: term_to_wal(triple.object()),
+                            graph: template.graph.clone(),
+                        },
+                    );
                     #[cfg(feature = "cdc")]
                     record_cdc_triple_insert(
                         &self.cdc_log,
@@ -7242,6 +7282,8 @@ mod tests {
             vec![],
             vec![],
             HashMap::new(),
+            #[cfg(feature = "wal")]
+            None,
             #[cfg(feature = "cdc")]
             None,
             #[cfg(feature = "cdc")]

--- a/crates/grafeo-engine/src/query/planner/rdf/mod.rs
+++ b/crates/grafeo-engine/src/query/planner/rdf/mod.rs
@@ -109,6 +109,33 @@ struct TripleOperands {
     predicate: TripleComponent,
     object: TripleComponent,
     column_map: HashMap<String, usize>,
+    /// Named graph to mutate (`None` = default graph).
+    graph: Option<String>,
+}
+
+/// Resolves the target sub-store for a pattern/template graph mutation,
+/// failing closed on an unresolved variable graph.
+///
+/// `create` selects insert semantics (`graph_or_create`, which materialises the
+/// named graph) versus delete semantics (non-creating `graph`, so a zero-match
+/// named delete never leaves an empty sub-store behind). A graph name
+/// beginning with `?` is an unbound `GRAPH ?var` target that the executor cannot
+/// route to a concrete graph; it is rejected loudly rather than silently
+/// misrouted or degraded to a no-op.
+fn resolve_mutation_graph(
+    store: &Arc<RdfStore>,
+    graph_name: Option<&str>,
+    create: bool,
+) -> std::result::Result<Option<Arc<RdfStore>>, OperatorError> {
+    match graph_name {
+        None => Ok(Some(Arc::clone(store))),
+        Some(name) if name.starts_with('?') => Err(OperatorError::Execution(format!(
+            "SPARQL Update cannot target a variable graph ({name}); \
+             use a concrete graph IRI or a WITH clause"
+        ))),
+        Some(name) if create => Ok(Some(store.graph_or_create(name))),
+        Some(name) => Ok(store.graph(name)),
+    }
 }
 
 /// Converts logical plans with RDF operators to physical operators.
@@ -1338,6 +1365,7 @@ impl RdfPlanner {
                         predicate: insert.predicate.clone(),
                         object: insert.object.clone(),
                         column_map,
+                        graph: insert.graph.clone(),
                     },
                     #[cfg(feature = "wal")]
                     self.wal.clone(),
@@ -1451,6 +1479,7 @@ impl RdfPlanner {
                         predicate: delete.predicate.clone(),
                         object: delete.object.clone(),
                         column_map,
+                        graph: delete.graph.clone(),
                     },
                     #[cfg(feature = "wal")]
                     self.wal.clone(),
@@ -1726,6 +1755,8 @@ struct RdfInsertPatternOperator {
     predicate: TripleComponent,
     object: TripleComponent,
     column_map: HashMap<String, usize>,
+    /// Named graph to insert into (`None` = default graph).
+    graph_name: Option<String>,
     done: bool,
     #[cfg(feature = "wal")]
     wal: Option<Arc<RdfWal>>,
@@ -1751,6 +1782,7 @@ impl RdfInsertPatternOperator {
             predicate: operands.predicate,
             object: operands.object,
             column_map: operands.column_map,
+            graph_name: operands.graph,
             done: false,
             #[cfg(feature = "wal")]
             wal,
@@ -1830,6 +1862,12 @@ impl Operator for RdfInsertPatternOperator {
             return Ok(None);
         }
 
+        // Resolve the named-graph target up front so an unsupported variable
+        // graph fails closed even when the pattern binds no rows. INSERT
+        // materialises the target graph if it does not yet exist.
+        let target = resolve_mutation_graph(&self.store, self.graph_name.as_deref(), true)?
+            .expect("insert target is always present when create=true");
+
         // Collect all triples to insert
         let mut triples_to_insert = Vec::new();
 
@@ -1845,9 +1883,9 @@ impl Operator for RdfInsertPatternOperator {
             }
         }
 
-        // Insert all collected triples
+        // Insert all collected triples into the resolved graph
         for triple in &triples_to_insert {
-            self.store.insert(triple.clone());
+            target.insert(triple.clone());
         }
 
         #[cfg(feature = "wal")]
@@ -1858,7 +1896,7 @@ impl Operator for RdfInsertPatternOperator {
                     subject: term_to_wal(triple.subject()),
                     predicate: term_to_wal(triple.predicate()),
                     object: term_to_wal(triple.object()),
-                    graph: None,
+                    graph: self.graph_name.clone(),
                 },
             );
         }
@@ -1870,7 +1908,7 @@ impl Operator for RdfInsertPatternOperator {
                 triple.subject(),
                 triple.predicate(),
                 triple.object(),
-                None,
+                self.graph_name.as_deref(),
                 self.cdc_epoch,
             );
         }
@@ -2010,6 +2048,8 @@ struct RdfDeletePatternOperator {
     predicate: TripleComponent,
     object: TripleComponent,
     column_map: HashMap<String, usize>,
+    /// Named graph to delete from (`None` = default graph).
+    graph_name: Option<String>,
     done: bool,
     #[cfg(feature = "wal")]
     wal: Option<Arc<RdfWal>>,
@@ -2035,6 +2075,7 @@ impl RdfDeletePatternOperator {
             predicate: operands.predicate,
             object: operands.object,
             column_map: operands.column_map,
+            graph_name: operands.graph,
             done: false,
             #[cfg(feature = "wal")]
             wal,
@@ -2114,6 +2155,11 @@ impl Operator for RdfDeletePatternOperator {
             return Ok(None);
         }
 
+        // Resolve the named-graph target up front: a variable graph fails closed,
+        // and a missing named graph is a clean no-op that does not materialise an
+        // empty sub-store (non-creating).
+        let target = resolve_mutation_graph(&self.store, self.graph_name.as_deref(), false)?;
+
         // Collect all triples to delete
         let mut triples_to_delete = Vec::new();
 
@@ -2129,34 +2175,37 @@ impl Operator for RdfDeletePatternOperator {
             }
         }
 
-        // Delete all collected triples
-        for triple in &triples_to_delete {
-            self.store.remove(triple);
-        }
+        // Delete all collected triples from the resolved graph. A missing named
+        // graph leaves nothing to remove (and was not created above).
+        if let Some(target) = target {
+            for triple in &triples_to_delete {
+                target.remove(triple);
+            }
 
-        #[cfg(feature = "wal")]
-        for triple in &triples_to_delete {
-            log_rdf_wal(
-                &self.wal,
-                &grafeo_storage::wal::WalRecord::DeleteRdfTriple {
-                    subject: term_to_wal(triple.subject()),
-                    predicate: term_to_wal(triple.predicate()),
-                    object: term_to_wal(triple.object()),
-                    graph: None,
-                },
-            );
-        }
+            #[cfg(feature = "wal")]
+            for triple in &triples_to_delete {
+                log_rdf_wal(
+                    &self.wal,
+                    &grafeo_storage::wal::WalRecord::DeleteRdfTriple {
+                        subject: term_to_wal(triple.subject()),
+                        predicate: term_to_wal(triple.predicate()),
+                        object: term_to_wal(triple.object()),
+                        graph: self.graph_name.clone(),
+                    },
+                );
+            }
 
-        #[cfg(feature = "cdc")]
-        for triple in &triples_to_delete {
-            record_cdc_triple_delete(
-                &self.cdc_log,
-                triple.subject(),
-                triple.predicate(),
-                triple.object(),
-                None,
-                self.cdc_epoch,
-            );
+            #[cfg(feature = "cdc")]
+            for triple in &triples_to_delete {
+                record_cdc_triple_delete(
+                    &self.cdc_log,
+                    triple.subject(),
+                    triple.predicate(),
+                    triple.object(),
+                    self.graph_name.as_deref(),
+                    self.cdc_epoch,
+                );
+            }
         }
 
         self.done = true;
@@ -2710,6 +2759,14 @@ impl Operator for RdfModifyOperator {
         // matches the bound string. This handles the type mismatch without
         // changing the column type system.
         for template in &self.delete_templates {
+            // Resolve the delete target up front (non-creating). A variable
+            // graph fails closed even when no rows bind; a missing named graph
+            // leaves nothing to delete.
+            let Some(target) =
+                resolve_mutation_graph(&self.store, template.graph.as_deref(), false)?
+            else {
+                continue;
+            };
             for (chunk, row) in &bindings {
                 let subject = self.resolve_component(&template.subject, chunk, *row);
                 let predicate = self.resolve_component(&template.predicate, chunk, *row);
@@ -2717,7 +2774,7 @@ impl Operator for RdfModifyOperator {
 
                 if let (Some(s), Some(p), Some(o)) = (subject, predicate, object) {
                     let triple = Triple::new(s.clone(), p.clone(), o.clone());
-                    if !self.store.remove(&triple) {
+                    if !target.remove(&triple) {
                         // Exact match failed: the object may be a plain string
                         // whose stored form is a typed literal (e.g. "1" vs
                         // xsd:integer "1"). Query by subject+predicate and
@@ -2728,8 +2785,7 @@ impl Operator for RdfModifyOperator {
                                 predicate: Some(p.clone()),
                                 object: None,
                             };
-                            let matching: Vec<_> = self
-                                .store
+                            let matching: Vec<_> = target
                                 .find(&pattern)
                                 .into_iter()
                                 .filter(|t| {
@@ -2751,10 +2807,10 @@ impl Operator for RdfModifyOperator {
                                     matched.subject(),
                                     matched.predicate(),
                                     matched.object(),
-                                    None,
+                                    template.graph.as_deref(),
                                     self.cdc_epoch,
                                 );
-                                self.store.remove(&matched);
+                                target.remove(&matched);
                             }
                             continue;
                         }
@@ -2765,7 +2821,7 @@ impl Operator for RdfModifyOperator {
                         triple.subject(),
                         triple.predicate(),
                         triple.object(),
-                        None,
+                        template.graph.as_deref(),
                         self.cdc_epoch,
                     );
                 }
@@ -2774,6 +2830,10 @@ impl Operator for RdfModifyOperator {
 
         // Step 3: Apply INSERT templates using the SAME bindings
         for template in &self.insert_templates {
+            // Resolve the insert target up front; a variable graph fails closed.
+            // INSERT materialises the target graph if it does not yet exist.
+            let target = resolve_mutation_graph(&self.store, template.graph.as_deref(), true)?
+                .expect("insert target is always present when create=true");
             for (chunk, row) in &bindings {
                 let subject = self.resolve_component(&template.subject, chunk, *row);
                 let predicate = self.resolve_component(&template.predicate, chunk, *row);
@@ -2787,10 +2847,10 @@ impl Operator for RdfModifyOperator {
                         triple.subject(),
                         triple.predicate(),
                         triple.object(),
-                        None,
+                        template.graph.as_deref(),
                         self.cdc_epoch,
                     );
-                    self.store.insert(triple);
+                    target.insert(triple);
                 }
             }
         }
@@ -7024,6 +7084,7 @@ mod tests {
             predicate: TripleComponent::Iri("http://example.org/p".to_string()),
             object: TripleComponent::Literal(Value::String("o".into())),
             column_map: HashMap::new(),
+            graph: None,
         };
         let op: Box<dyn Operator> = Box::new(RdfInsertPatternOperator::new(
             store,
@@ -7073,6 +7134,7 @@ mod tests {
             predicate: TripleComponent::Iri("http://example.org/p".to_string()),
             object: TripleComponent::Literal(Value::String("o".into())),
             column_map: HashMap::new(),
+            graph: None,
         };
         let op: Box<dyn Operator> = Box::new(RdfDeletePatternOperator::new(
             store,

--- a/crates/grafeo-engine/src/query/translators/sparql.rs
+++ b/crates/grafeo-engine/src/query/translators/sparql.rs
@@ -331,9 +331,15 @@ impl SparqlTranslator {
                 with_graph,
                 delete_template,
                 insert_template,
-                using_clauses: _,
+                using_clauses,
                 where_clause,
-            } => self.translate_modify(with_graph, delete_template, insert_template, where_clause),
+            } => self.translate_modify(
+                with_graph,
+                delete_template,
+                insert_template,
+                using_clauses,
+                where_clause,
+            ),
             ast::UpdateOperation::Load {
                 silent,
                 source,
@@ -457,16 +463,20 @@ impl SparqlTranslator {
 
         // Build delete operators with the match plan as input
         let mut ops = Vec::new();
-        for triple in &triples {
+        for (triple, graph) in &triples {
             let subject = self.translate_triple_term(&triple.subject)?;
             let predicate = self.translate_property_path(&triple.predicate)?;
             let object = self.translate_triple_term(&triple.object)?;
+            // A GRAPH-wrapped DELETE WHERE deletes from the named graph; a
+            // variable graph (`GRAPH ?g`) resolves to a "?"-prefixed name that
+            // the executor rejects loudly (fail-closed).
+            let graph = graph.as_ref().map(|g| self.resolve_variable_or_iri(g));
 
             ops.push(LogicalOperator::DeleteTriple(DeleteTripleOp {
                 subject,
                 predicate,
                 object,
-                graph: None, // Default graph
+                graph,
                 input: Some(Box::new(match_plan.clone())),
             }));
         }
@@ -484,13 +494,34 @@ impl SparqlTranslator {
         }
     }
 
-    fn extract_triples_from_pattern(pattern: &ast::GraphPattern) -> Vec<ast::TriplePattern> {
+    /// Extracts the triple templates from a DELETE WHERE pattern, tagging each
+    /// with its enclosing named graph (if any) so the delete routes to the
+    /// correct sub-store. Descends into GRAPH blocks via the `NamedGraph` arm;
+    /// dropping that arm is what made a GRAPH-wrapped DELETE WHERE a silent
+    /// no-op (the template came back empty).
+    fn extract_triples_from_pattern(
+        pattern: &ast::GraphPattern,
+    ) -> Vec<(ast::TriplePattern, Option<ast::VariableOrIri>)> {
+        Self::extract_triples_with_graph(pattern, None)
+    }
+
+    fn extract_triples_with_graph(
+        pattern: &ast::GraphPattern,
+        graph: Option<&ast::VariableOrIri>,
+    ) -> Vec<(ast::TriplePattern, Option<ast::VariableOrIri>)> {
         match pattern {
-            ast::GraphPattern::Basic(triples) => triples.clone(),
+            ast::GraphPattern::Basic(triples) => triples
+                .iter()
+                .map(|t| (t.clone(), graph.cloned()))
+                .collect(),
             ast::GraphPattern::Group(patterns) => patterns
                 .iter()
-                .flat_map(Self::extract_triples_from_pattern)
+                .flat_map(|p| Self::extract_triples_with_graph(p, graph))
                 .collect(),
+            ast::GraphPattern::NamedGraph {
+                graph: inner_graph,
+                pattern: inner_pattern,
+            } => Self::extract_triples_with_graph(inner_pattern, Some(inner_graph)),
             _ => Vec::new(),
         }
     }
@@ -500,12 +531,40 @@ impl SparqlTranslator {
         with_graph: &Option<ast::Iri>,
         delete_template: &Option<Vec<ast::QuadPattern>>,
         insert_template: &Option<Vec<ast::QuadPattern>>,
+        using_clauses: &[ast::UsingClause],
         where_clause: &ast::GraphPattern,
     ) -> Result<LogicalPlan> {
+        // USING / USING NAMED is parsed but not yet honoured by the executor.
+        // Fail closed rather than silently dropping the clause and mis-scoping
+        // the WHERE evaluation against the wrong dataset.
+        if !using_clauses.is_empty() {
+            return Err(Error::Query(QueryError::new(
+                QueryErrorKind::Semantic,
+                "SPARQL Update USING / USING NAMED is not yet supported",
+            )));
+        }
+
+        let default_graph = with_graph.as_ref().map(|g| self.resolve_iri(g));
+
+        // The WITH clause redefines the WHERE clause's default graph as <g>
+        // (SPARQL 1.1 Update, DELETE/INSERT): an unqualified WHERE pattern must
+        // bind rows from the named graph, not the empty default graph. Redirect
+        // the dataset before building the WHERE plan (mirroring translate_select)
+        // so a WITH-scoped Modify does not silently no-op for lack of bindings.
+        // A GRAPH-wrapped WHERE still binds via the graph context stack and is
+        // unaffected.
+        if let Some(ref graph) = default_graph {
+            self.dataset = Some(DatasetRestriction {
+                default_graphs: vec![graph.clone()],
+                named_graphs: Vec::new(),
+            });
+        }
+
         // Translate the WHERE clause - this will be evaluated once and shared
         let where_plan = self.translate_graph_pattern(where_clause)?;
 
-        let default_graph = with_graph.as_ref().map(|g| self.resolve_iri(g));
+        // Clear the dataset redirect after translating the WHERE clause
+        self.dataset = None;
 
         // Build DELETE templates
         let mut delete_templates = Vec::new();

--- a/crates/grafeo-engine/src/session/rdf.rs
+++ b/crates/grafeo-engine/src/session/rdf.rs
@@ -195,7 +195,18 @@ impl Session {
         result
     }
 
-    /// Executes a SPARQL query.
+    /// Executes a SPARQL query or update against this session.
+    ///
+    /// # Atomicity (transaction handle)
+    ///
+    /// A single SPARQL Update statement is applied atomically. A *sequence* of
+    /// updates is atomic only when run inside one explicit transaction on this
+    /// same session handle: call `begin_transaction` before the sequence and
+    /// `commit` after it. Statements executed without an open transaction
+    /// auto-commit individually, so a failure partway through a multi-statement
+    /// sequence leaves the earlier statements applied. Updates issued through a
+    /// different handle than the one holding the open transaction are not
+    /// enlisted in that transaction.
     ///
     /// # Errors
     ///

--- a/crates/grafeo-engine/tests/named_graph_modify.rs
+++ b/crates/grafeo-engine/tests/named_graph_modify.rs
@@ -1,0 +1,191 @@
+//! Integration tests for named-graph SPARQL DELETE/INSERT WHERE (MODIFY) routing.
+//!
+//! Companion to the declarative oracles in
+//! `tests/spec/rdf/sparql/update_advanced.gtest`. These cover behaviours the
+//! `.gtest` harness cannot express: fail-closed loud errors for unsupported
+//! variants (USING, variable graph targets), and the white-box invariant that a
+//! zero-match named delete does not create an empty named sub-store.
+//!
+//! ```bash
+//! cargo test -p grafeo-engine --features full --test named_graph_modify
+//! ```
+
+#![allow(missing_docs)]
+
+#[cfg(all(feature = "sparql", feature = "triple-store"))]
+mod tests {
+    use grafeo_engine::{Config, GrafeoDB, GraphModel};
+
+    fn rdf_db() -> GrafeoDB {
+        GrafeoDB::with_config(Config::in_memory().with_graph_model(GraphModel::Rdf)).unwrap()
+    }
+
+    // ==================== mis-write / routing (store-level) ====================
+
+    /// The headline corruption: a GRAPH-wrapped INSERT-via-Modify must write to
+    /// the named graph and must NOT leak into the default graph.
+    #[test]
+    fn named_insert_via_modify_writes_named_not_default() {
+        let db = rdf_db();
+        let session = db.session();
+        session
+            .execute_sparql(r#"INSERT DATA { <http://ex.org/trigger> <http://ex.org/p> "go" . }"#)
+            .unwrap();
+        session
+            .execute_sparql(
+                r#"INSERT { GRAPH <http://ex.org/g> { <http://ex.org/s> <http://ex.org/p> "v" } }
+                   WHERE  { <http://ex.org/trigger> <http://ex.org/p> ?x }"#,
+            )
+            .unwrap();
+
+        // The named graph received the triple ...
+        let named = session
+            .execute_sparql(
+                r#"SELECT ?s WHERE { GRAPH <http://ex.org/g> { ?s <http://ex.org/p> "v" } }"#,
+            )
+            .unwrap();
+        assert_eq!(
+            named.row_count(),
+            1,
+            "named INSERT-via-Modify must land in the named graph"
+        );
+
+        // ... and the default graph did NOT (no silent mis-write).
+        let default = session
+            .execute_sparql(r#"SELECT ?s WHERE { ?s <http://ex.org/p> "v" }"#)
+            .unwrap();
+        assert_eq!(
+            default.row_count(),
+            0,
+            "named INSERT-via-Modify must not leak into the default graph"
+        );
+    }
+
+    // ==================== non-creating delete target ====================
+
+    /// A DELETE WHERE targeting a graph that does not exist must be a clean
+    /// no-op that does not materialise an empty named sub-store.
+    #[test]
+    fn named_delete_where_does_not_create_empty_substore() {
+        let db = rdf_db();
+        let session = db.session();
+        session
+            .execute_sparql(
+                r#"DELETE WHERE {
+                       GRAPH <http://ex.org/missing> { <http://ex.org/a> <http://ex.org/p> ?o }
+                   }"#,
+            )
+            .unwrap();
+        let rdf = db.rdf_store();
+        assert!(
+            rdf.graph("http://ex.org/missing").is_none(),
+            "a zero-match named DELETE WHERE must not create an empty named sub-store"
+        );
+    }
+
+    /// A WITH-scoped Modify whose target graph does not exist must not create it
+    /// on the delete path.
+    #[test]
+    fn named_modify_delete_does_not_create_empty_substore() {
+        let db = rdf_db();
+        let session = db.session();
+        session
+            .execute_sparql(r#"INSERT DATA { <http://ex.org/trigger> <http://ex.org/p> "go" . }"#)
+            .unwrap();
+        session
+            .execute_sparql(
+                r#"WITH <http://ex.org/missing>
+                   DELETE { <http://ex.org/a> <http://ex.org/p> ?o }
+                   WHERE  { <http://ex.org/a> <http://ex.org/p> ?o }"#,
+            )
+            .unwrap();
+        let rdf = db.rdf_store();
+        assert!(
+            rdf.graph("http://ex.org/missing").is_none(),
+            "a WITH-scoped delete against a missing graph must not create it"
+        );
+    }
+
+    // ==================== M5: fail-closed loud errors ====================
+
+    /// USING / USING NAMED is parsed but cannot be honoured; it must error
+    /// loudly rather than silently drop the clause and mis-scope the update.
+    #[test]
+    fn modify_using_clause_errors_loudly() {
+        let db = rdf_db();
+        let session = db.session();
+        session
+            .execute_sparql(r#"INSERT DATA { <http://ex.org/a> <http://ex.org/p> "1" . }"#)
+            .unwrap();
+        let result = session.execute_sparql(
+            r#"DELETE { <http://ex.org/a> <http://ex.org/p> ?o }
+               USING <http://ex.org/g>
+               WHERE  { <http://ex.org/a> <http://ex.org/p> ?o }"#,
+        );
+        assert!(
+            result.is_err(),
+            "USING in a SPARQL Modify must error loudly, not silently no-op"
+        );
+    }
+
+    /// A variable graph target (`GRAPH ?g`) in a DELETE/INSERT template cannot
+    /// be routed to a concrete graph; fail closed rather than misroute.
+    #[test]
+    fn modify_variable_graph_template_errors_loudly() {
+        let db = rdf_db();
+        let session = db.session();
+        session
+            .execute_sparql(
+                r#"INSERT DATA {
+                       GRAPH <http://ex.org/g> { <http://ex.org/a> <http://ex.org/p> "1" . }
+                   }"#,
+            )
+            .unwrap();
+        let result = session.execute_sparql(
+            r#"DELETE { GRAPH ?g { <http://ex.org/a> <http://ex.org/p> ?o } }
+               WHERE  { GRAPH ?g { <http://ex.org/a> <http://ex.org/p> ?o } }"#,
+        );
+        assert!(
+            result.is_err(),
+            "a variable graph target must error loudly (fail-closed)"
+        );
+    }
+
+    /// The variable-graph guard must fire even when the WHERE binds zero rows,
+    /// so an unsupported template can never degrade to a silent no-op.
+    #[test]
+    fn modify_variable_graph_template_errors_even_with_zero_bindings() {
+        let db = rdf_db();
+        let session = db.session();
+        let result = session.execute_sparql(
+            r#"DELETE { GRAPH ?g { <http://ex.org/a> <http://ex.org/p> ?o } }
+               WHERE  { GRAPH ?g { <http://ex.org/a> <http://ex.org/p> ?o } }"#,
+        );
+        assert!(
+            result.is_err(),
+            "variable-graph guard must fire even with zero WHERE bindings (fail-closed)"
+        );
+    }
+
+    /// The same fail-closed guard for the pure `DELETE WHERE { GRAPH ?g { .. } }`
+    /// form, which flows through the translator extraction + pattern executor.
+    #[test]
+    fn delete_where_variable_graph_errors_loudly() {
+        let db = rdf_db();
+        let session = db.session();
+        session
+            .execute_sparql(
+                r#"INSERT DATA {
+                       GRAPH <http://ex.org/g> { <http://ex.org/a> <http://ex.org/p> "1" . }
+                   }"#,
+            )
+            .unwrap();
+        let result = session.execute_sparql(
+            r#"DELETE WHERE { GRAPH ?g { <http://ex.org/a> <http://ex.org/p> ?o } }"#,
+        );
+        assert!(
+            result.is_err(),
+            "DELETE WHERE with a variable graph must error loudly (fail-closed)"
+        );
+    }
+}

--- a/crates/grafeo-engine/tests/named_graph_modify_durability.rs
+++ b/crates/grafeo-engine/tests/named_graph_modify_durability.rs
@@ -1,0 +1,124 @@
+//! Durability tests for SPARQL DELETE/INSERT WHERE (MODIFY).
+//!
+//! `RdfModifyOperator` previously emitted no WAL record at all, so a
+//! DELETE/INSERT-WHERE MODIFY was not durable even on the default graph and was
+//! lost on `wal-directory` replay. These tests open a DB with
+//! `StorageFormat::WalDirectory`, run a MODIFY, close, reopen, and assert the
+//! mutation survived -- for both a named graph and the default graph.
+//!
+//! ```bash
+//! cargo test -p grafeo-engine --features full --test named_graph_modify_durability
+//! ```
+
+#![allow(missing_docs)]
+
+#[cfg(all(feature = "wal", feature = "sparql", feature = "triple-store"))]
+mod durability {
+    use grafeo_engine::config::StorageFormat;
+    use grafeo_engine::{Config, GrafeoDB, GraphModel};
+    use std::path::Path;
+
+    fn open(path: &Path) -> GrafeoDB {
+        GrafeoDB::with_config(
+            Config::persistent(path)
+                .with_graph_model(GraphModel::Rdf)
+                .with_storage_format(StorageFormat::WalDirectory),
+        )
+        .expect("open wal-directory rdf db")
+    }
+
+    /// A named-graph MODIFY (delete old value, insert new) must survive a
+    /// close/reopen WAL replay, with the resolved graph carried in the record.
+    #[test]
+    fn named_graph_modify_survives_reopen() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("db");
+
+        {
+            let db = open(&path);
+            let session = db.session();
+            session
+                .execute_sparql(
+                    r#"INSERT DATA {
+                           GRAPH <http://ex.org/g> {
+                               <http://ex.org/alix> <http://ex.org/status> "active" .
+                           }
+                       }"#,
+                )
+                .expect("seed named graph");
+            session
+                .execute_sparql(
+                    r#"WITH <http://ex.org/g>
+                       DELETE { <http://ex.org/alix> <http://ex.org/status> ?s }
+                       INSERT { <http://ex.org/alix> <http://ex.org/status> "archived" }
+                       WHERE  { <http://ex.org/alix> <http://ex.org/status> ?s }"#,
+                )
+                .expect("named MODIFY");
+            db.close().expect("close");
+        }
+
+        let db = open(&path);
+        let session = db.session();
+        let result = session
+            .execute_sparql(
+                r#"SELECT ?s WHERE {
+                       GRAPH <http://ex.org/g> { <http://ex.org/alix> <http://ex.org/status> ?s }
+                   }"#,
+            )
+            .expect("query after reopen");
+        assert_eq!(
+            result.row_count(),
+            1,
+            "named MODIFY result was lost on reopen (RdfModifyOperator emitted no WAL)"
+        );
+        assert_eq!(
+            result.rows()[0][0].to_string().trim_matches('"'),
+            "archived",
+            "named MODIFY new value was not durable across reopen"
+        );
+    }
+
+    /// The same hole existed on the default graph: a default-graph MODIFY must
+    /// also survive close/reopen.
+    #[test]
+    fn default_graph_modify_survives_reopen() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("db");
+
+        {
+            let db = open(&path);
+            let session = db.session();
+            session
+                .execute_sparql(
+                    r#"INSERT DATA { <http://ex.org/item> <http://ex.org/version> "1" . }"#,
+                )
+                .expect("seed default graph");
+            session
+                .execute_sparql(
+                    r#"DELETE { <http://ex.org/item> <http://ex.org/version> ?v }
+                       INSERT { <http://ex.org/item> <http://ex.org/version> "2" }
+                       WHERE  { <http://ex.org/item> <http://ex.org/version> ?v }"#,
+                )
+                .expect("default MODIFY");
+            db.close().expect("close");
+        }
+
+        let db = open(&path);
+        let session = db.session();
+        let result = session
+            .execute_sparql(
+                r#"SELECT ?v WHERE { <http://ex.org/item> <http://ex.org/version> ?v }"#,
+            )
+            .expect("query after reopen");
+        assert_eq!(
+            result.row_count(),
+            1,
+            "default-graph MODIFY result was lost on reopen"
+        );
+        assert_eq!(
+            result.rows()[0][0].to_string().trim_matches('"'),
+            "2",
+            "default-graph MODIFY new value was not durable across reopen"
+        );
+    }
+}

--- a/tests/spec/rdf/sparql/update_advanced.gtest
+++ b/tests/spec/rdf/sparql/update_advanced.gtest
@@ -203,6 +203,159 @@ tests:
         - [http://ex.org/gus, editor]
 
   # ---------------------------------------------------------------------------
+  # Named-graph DELETE/INSERT WHERE (MODIFY) -- routing correctness
+  #
+  # Regression oracles for named-graph SPARQL Update. Before the fix the
+  # pattern/Modify executors ignored the template graph: a named DELETE WHERE
+  # was a silent no-op, and INSERT-via-Modify silently mis-wrote into the
+  # default graph. These exercise GRAPH-wrapped templates, the WITH read-side
+  # dataset redirect, and default/named isolation.
+  # ---------------------------------------------------------------------------
+
+  - name: named_delete_where_removes_from_named_graph
+    # DELETE WHERE inside a GRAPH block must delete from the named graph.
+    # Pre-fix: silent no-op (both triples survive).
+    setup:
+      - |
+        INSERT DATA {
+          GRAPH <http://ex.org/g> {
+            <http://ex.org/a> <http://ex.org/p> "1" .
+            <http://ex.org/b> <http://ex.org/p> "2" .
+          }
+        }
+      - |
+        DELETE WHERE {
+          GRAPH <http://ex.org/g> { <http://ex.org/a> <http://ex.org/p> "1" }
+        }
+    query: |
+      SELECT ?s WHERE { GRAPH <http://ex.org/g> { ?s <http://ex.org/p> ?o } }
+    expect:
+      rows:
+        - [http://ex.org/b]
+
+  - name: named_delete_where_preserves_default_graph
+    # Isolation guard: a named DELETE WHERE must not touch the default graph.
+    setup:
+      - |
+        INSERT DATA { <http://ex.org/a> <http://ex.org/p> "1" . }
+      - |
+        INSERT DATA {
+          GRAPH <http://ex.org/g> { <http://ex.org/a> <http://ex.org/p> "1" . }
+        }
+      - |
+        DELETE WHERE {
+          GRAPH <http://ex.org/g> { <http://ex.org/a> <http://ex.org/p> "1" }
+        }
+    query: |
+      SELECT ?s WHERE { ?s <http://ex.org/p> ?o }
+    expect:
+      rows:
+        - [http://ex.org/a]
+
+  - name: named_modify_insert_lands_in_named_graph
+    # INSERT-via-Modify with a GRAPH-wrapped template must write to the named
+    # graph. Pre-fix: silently mis-written into the default graph.
+    setup:
+      - |
+        INSERT DATA { <http://ex.org/trigger> <http://ex.org/p> "go" . }
+      - |
+        INSERT { GRAPH <http://ex.org/g> { <http://ex.org/s> <http://ex.org/p> "v" } }
+        WHERE  { <http://ex.org/trigger> <http://ex.org/p> ?x }
+    query: |
+      SELECT ?s WHERE { GRAPH <http://ex.org/g> { ?s <http://ex.org/p> "v" } }
+    expect:
+      rows:
+        - [http://ex.org/s]
+
+  - name: named_modify_insert_does_not_leak_to_default
+    # The mis-write oracle: the named INSERT-via-Modify must leave the default
+    # graph with zero matching triples. Pre-fix: the default graph gets it.
+    setup:
+      - |
+        INSERT DATA { <http://ex.org/trigger> <http://ex.org/p> "go" . }
+      - |
+        INSERT { GRAPH <http://ex.org/g> { <http://ex.org/s> <http://ex.org/p> "v" } }
+        WHERE  { <http://ex.org/trigger> <http://ex.org/p> ?x }
+    query: |
+      SELECT ?s WHERE { ?s <http://ex.org/p> "v" }
+    expect:
+      empty: true
+
+  - name: named_modify_graph_wrapped_delete_and_insert
+    # GRAPH-wrapped DELETE+INSERT Modify: rename within a named graph.
+    # Pre-fix: delete no-op (old value stays) AND insert mis-write (new value
+    # lands in the default graph).
+    setup:
+      - |
+        INSERT DATA {
+          GRAPH <http://ex.org/g> { <http://ex.org/alix> <http://ex.org/city> "Amsterdam" . }
+        }
+      - |
+        DELETE { GRAPH <http://ex.org/g> { <http://ex.org/alix> <http://ex.org/city> ?old } }
+        INSERT { GRAPH <http://ex.org/g> { <http://ex.org/alix> <http://ex.org/city> "Berlin" } }
+        WHERE  { GRAPH <http://ex.org/g> { <http://ex.org/alix> <http://ex.org/city> ?old } }
+    query: |
+      SELECT ?city WHERE {
+        GRAPH <http://ex.org/g> { <http://ex.org/alix> <http://ex.org/city> ?city }
+      }
+    expect:
+      rows:
+        - [Berlin]
+
+  - name: named_modify_with_clause_binds_named_graph
+    # WITH <g> redirects the unqualified WHERE to the named graph (read-side),
+    # so the match binds and the rename applies inside <g>.
+    # Pre-fix: WHERE binds 0 rows (scans the default graph) -> total no-op.
+    setup:
+      - |
+        INSERT DATA {
+          GRAPH <http://ex.org/g> { <http://ex.org/alix> <http://ex.org/status> "active" . }
+        }
+      - |
+        WITH <http://ex.org/g>
+        DELETE { <http://ex.org/alix> <http://ex.org/status> ?s }
+        INSERT { <http://ex.org/alix> <http://ex.org/status> "archived" }
+        WHERE  { <http://ex.org/alix> <http://ex.org/status> ?s }
+    query: |
+      SELECT ?s WHERE {
+        GRAPH <http://ex.org/g> { <http://ex.org/alix> <http://ex.org/status> ?s }
+      }
+    expect:
+      rows:
+        - [archived]
+
+  - name: named_modify_with_clause_does_not_leak_to_default
+    # The WITH-scoped rename must not write the new value into the default graph.
+    setup:
+      - |
+        INSERT DATA {
+          GRAPH <http://ex.org/g> { <http://ex.org/alix> <http://ex.org/status> "active" . }
+        }
+      - |
+        WITH <http://ex.org/g>
+        DELETE { <http://ex.org/alix> <http://ex.org/status> ?s }
+        INSERT { <http://ex.org/alix> <http://ex.org/status> "archived" }
+        WHERE  { <http://ex.org/alix> <http://ex.org/status> ?s }
+    query: |
+      SELECT ?s WHERE { <http://ex.org/alix> <http://ex.org/status> ?s }
+    expect:
+      empty: true
+
+  - name: named_drop_graph_still_works
+    # Fingerprint guard: DROP GRAPH continues to remove the whole named graph.
+    setup:
+      - |
+        INSERT DATA {
+          GRAPH <http://ex.org/g> { <http://ex.org/a> <http://ex.org/p> "1" . }
+        }
+      - |
+        DROP GRAPH <http://ex.org/g>
+    query: |
+      SELECT ?s WHERE { GRAPH <http://ex.org/g> { ?s ?p ?o } }
+    expect:
+      empty: true
+
+  # ---------------------------------------------------------------------------
   # RDF set semantics
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #367.

## What was wrong

Named-graph SPARQL Update worked for the concrete-term forms (`INSERT DATA`,
`DELETE DATA`) and `DROP GRAPH`, but the **pattern / MODIFY** path ignored the
target graph entirely. The result was a set of silent failures (no error, no
warning):

- a `GRAPH`-wrapped `INSERT ... WHERE` **mis-wrote into the default graph**
  (data corruption);
- a `GRAPH`-wrapped `DELETE WHERE` was a **silent no-op**;
- a `WITH <g>` MODIFY with an unqualified WHERE bound **zero rows** and no-oped;
- a `DELETE/INSERT ... WHERE` MODIFY emitted **no WAL record**, so it was lost
  on `wal-directory` replay (even on the default graph).

See the linked issue for runnable repros.

## Root cause (paths/lines at `main`, 4ebae02f)

The concrete-term operators already resolve the per-graph sub-store via the
existing `RdfStore::graph` / `graph_or_create` API; the pattern/MODIFY family
did not. Specifically:

- **Translator dropped the GRAPH block.**
  `SparqlTranslator::extract_triples_from_pattern`
  (`crates/grafeo-engine/src/query/translators/sparql.rs:487`) matched only
  `Basic` / `Group` and returned `Vec::new()` for `NamedGraph`, so a
  GRAPH-wrapped `DELETE WHERE` produced an empty template; `DeleteTripleOp.graph`
  was hard-coded `None` (`sparql.rs:469`).
- **Pattern executors used the bare default store.**
  `RdfInsertPatternOperator` (`rdf/mod.rs:1850`) and `RdfDeletePatternOperator`
  (`rdf/mod.rs:2134`) called `store.insert` / `store.remove` on the default
  store and logged `graph: None` to WAL/CDC
  (`rdf/mod.rs:1861/1873`, `2145/2157`).
- **MODIFY executor ignored `template.graph`.**
  `RdfModifyOperator::next` (`rdf/mod.rs:2688`) deleted via `store.remove`
  (`:2720`) and inserted via `store.insert` (`:2793`) on the default store, and
  the struct had no WAL field at all.
- **Read side never redirected for `WITH`.**
  `SparqlTranslator::translate_modify` (`sparql.rs:498`) built the WHERE plan
  with `self.dataset = None`, so an unqualified WHERE under `WITH <g>` scanned
  the default graph (contrast `translate_select`, which sets `self.dataset`).
- **`USING` was dropped at dispatch** (`sparql.rs:334`, `using_clauses: _`).

## The fix

Two logical commits in one PR.

### Commit 1 — routing correctness

- `extract_triples_from_pattern` descends into `GRAPH` blocks and tags each
  extracted triple with its enclosing graph; `translate_delete_where` sets
  `DeleteTripleOp.graph` accordingly.
- `RdfInsertPatternOperator`, `RdfDeletePatternOperator` and `RdfModifyOperator`
  resolve the per-template named sub-store and insert/remove there, with the
  resolved graph carried into the CDC events (and the pattern operators' WAL
  records). The delete path uses the **non-creating** `graph` lookup so a
  zero-match named delete never materialises an empty sub-store.
- `translate_modify` redirects the WHERE clause's default graph to the `WITH`
  graph before planning it, mirroring `translate_select`, so an unqualified
  WITH-scoped WHERE binds in the named graph. A GRAPH-wrapped WHERE still binds
  through the existing graph-context stack and is unaffected.
- Fail closed on variants that cannot be routed: `USING` / `USING NAMED` and a
  variable graph target (`GRAPH ?g`) now return an explicit error instead of
  silently dropping the clause or mis-targeting.
- Documents the transaction-handle atomicity contract on
  `Session::execute_sparql`.

### Commit 2 — MODIFY durability

`RdfModifyOperator` now emits `InsertRdfTriple` / `DeleteRdfTriple` WAL records
for the triples it inserts and removes, carrying the resolved per-template
graph. WAL replay already routes by the record's graph field, so this is a
writer-side-only change. The operator receives the session WAL handle through
`plan_modify`, the same way the pattern operators already do.

## Tests

- `tests/spec/rdf/sparql/update_advanced.gtest`: named-graph MODIFY oracles —
  the mis-write (named gets the triple, default stays empty), the fingerprint
  trio (named `DELETE WHERE` deletes, default still works, `DROP GRAPH` still
  works), the GRAPH-wrapped MODIFY rename, and the `WITH` read-side binding.
- `crates/grafeo-engine/tests/named_graph_modify.rs`: the store-level
  mis-write check, the non-creating-on-zero-match-delete invariant, and the
  fail-closed `USING` / variable-graph guards (including the zero-binding case).
- `crates/grafeo-engine/tests/named_graph_modify_durability.rs`: close/reopen
  WAL-replay durability for a named-graph and a default-graph MODIFY.

All four touched crates pass (`grafeo-engine`, `grafeo-core`,
`grafeo-adapters`, `grafeo-spec-tests`); `cargo fmt` and
`cargo clippy --all-targets --all-features -- -D warnings` are clean.

## Notes / scope

- No store-API change: the per-graph sub-store API already exists; this reuses
  it on the pattern/MODIFY path.
- LPG/Cypher/Gremlin mutation is a separate store and is untouched.
- The pattern/MODIFY operators remain non-transactional (unchanged,
  pre-existing). Honest caveat: happy to split this into more commits/PRs if
  preferred.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes named-graph SPARQL DELETE/INSERT WHERE (MODIFY) to the correct graph and makes MODIFY durable via WAL. Fixes silent no-ops, wrong-graph writes, and data loss on WAL replay.

- **Bug Fixes**
  - GRAPH-wrapped deletes/inserts now target the named graph; the default graph is untouched.
  - WITH <g> now scopes the WHERE plan to that graph; unqualified patterns bind in <g>.
  - Pattern and MODIFY executors resolve the per-template graph; deletes use non-creating lookup; CDC/WAL include the graph.
  - Unsupported variants fail closed with clear errors: `USING`/`USING NAMED` and `GRAPH ?g`.
  - MODIFY emits WAL records for inserts/deletes (with graph), so changes persist across close/reopen.

- **Migration**
  - Replace `USING`/`USING NAMED` in MODIFY with `WITH <g>` or explicit `GRAPH <g>`.
  - Avoid `GRAPH ?g` in DELETE/INSERT templates; use a concrete graph IRI.

<sup>Written for commit 417d6295f7447b8b8c693751d5a44413670371cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/GrafeoDB/grafeo/pull/368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

