### PR TITLE
Fix SPARQL `path+` (OneOrMore) transitive closure: project each depth branch to its endpoints

### DIFF
--- a/crates/grafeo-engine/src/query/translators/sparql.rs
+++ b/crates/grafeo-engine/src/query/translators/sparql.rs
@@ -1904,8 +1904,11 @@ impl SparqlTranslator {
 
     /// Translates a `OneOrMore` property path (`path+`) using bounded expansion.
     ///
-    /// Expands to a `Union` of sequences from depth 1 to `MAX_DEPTH`, wrapped
-    /// in `Distinct` to deduplicate rows that appear at multiple depths.
+    /// Expands to a `Union` of fixed-depth sequences from depth 1 to
+    /// `MAX_DEPTH`, each projected to its endpoint columns so every branch
+    /// shares a schema, wrapped in `Distinct` to deduplicate the transitive
+    /// closure across depths. Unlike `ZeroOrMore`, no reflexive 0-hop branch is
+    /// added: `path+` excludes the zero-length path (SPARQL 1.1 sec 9.1).
     fn translate_one_or_more_path(
         &mut self,
         triple: &ast::TriplePattern,
@@ -1922,7 +1925,13 @@ impl SparqlTranslator {
         for depth in 1..=MAX_DEPTH {
             let branch =
                 self.translate_fixed_depth_path(inner_path, &subject, &object, &graph, depth)?;
-            branches.push(branch);
+            // Project every depth branch to its endpoint columns before the
+            // Union, exactly as `ZeroOrMore` and `ZeroOrOne` do. Depth-N
+            // branches carry intermediate-hop columns of differing widths;
+            // without this projection the heterogeneous branches reach `Union`
+            // and `Distinct` unnormalized and the visible object column ends up
+            // holding the first intermediate hop instead of the true endpoint.
+            branches.push(self.project_path_endpoints(&subject, &object, branch));
         }
 
         let union = LogicalOperator::Union(UnionOp { inputs: branches });
@@ -2839,7 +2848,7 @@ mod tests {
         }
         let branch_count = count_union_branches(&plan.root)
             .expect("Expected Union inside Distinct for ZeroOrMore path");
-        // ZeroOrMore has 2 reflexive branches + MAX_DEPTH (10) depth branches = 12
+        // ZeroOrMore has 2 reflexive branches + MAX_DEPTH (50) depth branches = 52
         assert!(
             branch_count > 10,
             "ZeroOrMore should have reflexive branches plus depth branches, got {}",

--- a/tests/spec/rdf/sparql/property_paths.gtest
+++ b/tests/spec/rdf/sparql/property_paths.gtest
@@ -218,7 +218,10 @@ tests:
   # ---------------------------------------------------------------------------
 
   - name: one_or_more_path_chain
-    # <p>+ follows transitive closure, excluding the start node
+    # <p>+ follows transitive closure, excluding the start node.
+    # Asserts the actual reached nodes (not just a row count): a bare `count: 3`
+    # passes even when + leaks the first intermediate hop into every endpoint
+    # slot, so the closure must be checked by value.
     setup:
       - |
         INSERT DATA {
@@ -231,7 +234,10 @@ tests:
         <http://ex.org/alix> <http://ex.org/next>+ ?node
       }
     expect:
-      count: 3
+      rows:
+        - [http://ex.org/gus]
+        - [http://ex.org/vincent]
+        - [http://ex.org/jules]
 
   - name: one_or_more_path_single_hop
     # Exactly one hop in the data
@@ -404,7 +410,10 @@ tests:
         - [http://ex.org/amsterdam]
 
   - name: sequence_with_one_or_more
-    # Combine sequence and + for transitive chain then final step
+    # Combine sequence and + for transitive chain then final step.
+    # Asserts the actual names: the transitive step must reach vincent (2 hops),
+    # not just gus (1 hop), so the value-level check catches a + that fails to
+    # transit. A bare `count: 2` passes even when both rows collapse to "Gus".
     setup:
       - |
         INSERT DATA {
@@ -418,7 +427,9 @@ tests:
         <http://ex.org/alix> <http://ex.org/knows>+/<http://ex.org/name> ?name
       }
     expect:
-      count: 2
+      rows:
+        - [Gus]
+        - [Vincent]
 
   - name: zero_or_more_rdf_collection_traversal
     # Traverse an RDF collection using rdf:rest*/rdf:first
@@ -456,3 +467,249 @@ tests:
     expect:
       rows:
         - [Alix]
+
+  # ---------------------------------------------------------------------------
+  # 9.5b  One-or-More (+) transitive-closure result-level oracles
+  #
+  #       Graph G (predicate p):  a -> b -> c -> d -> e  and  c -> x
+  #
+  #       These oracles assert the FULL distinct closure by value (a sorted
+  #       multiset), so they fail both when + misses transitive pairs and when
+  #       it leaks duplicate rows. Shape-only and bare-count tests do not catch
+  #       the OneOrMore endpoint-projection defect: a count over the buggy
+  #       output matches the correct cardinality on G while every value is the
+  #       leaked first intermediate hop. The companion SELECT DISTINCT cases
+  #       state the distinct row count explicitly.
+  # ---------------------------------------------------------------------------
+
+  - name: one_or_more_open_ended_full_closure
+    # O1: open-ended ?s :p+ ?o -> the full distinct transitive closure of G.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/c> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/d> .
+          <http://ex.org/d> <http://ex.org/p> <http://ex.org/e> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/x> .
+        }
+    query: |
+      SELECT ?s ?o WHERE { ?s <http://ex.org/p>+ ?o }
+    expect:
+      rows:
+        - [http://ex.org/a, http://ex.org/b]
+        - [http://ex.org/a, http://ex.org/c]
+        - [http://ex.org/a, http://ex.org/d]
+        - [http://ex.org/a, http://ex.org/e]
+        - [http://ex.org/a, http://ex.org/x]
+        - [http://ex.org/b, http://ex.org/c]
+        - [http://ex.org/b, http://ex.org/d]
+        - [http://ex.org/b, http://ex.org/e]
+        - [http://ex.org/b, http://ex.org/x]
+        - [http://ex.org/c, http://ex.org/d]
+        - [http://ex.org/c, http://ex.org/e]
+        - [http://ex.org/c, http://ex.org/x]
+        - [http://ex.org/d, http://ex.org/e]
+
+  - name: one_or_more_open_ended_distinct_count
+    # O1 (distinct-count form): SELECT DISTINCT over the closure is 13 rows.
+    # Pre-fix the leaked rows collapse to the 5 direct edges under DISTINCT.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/c> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/d> .
+          <http://ex.org/d> <http://ex.org/p> <http://ex.org/e> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/x> .
+        }
+    query: |
+      SELECT DISTINCT ?s ?o WHERE { ?s <http://ex.org/p>+ ?o }
+    expect:
+      count: 13
+
+  - name: one_or_more_bound_subject_closure
+    # O2: bound-subject :a :p+ ?o -> {b,c,d,e,x}, each once.
+    # Pre-fix returns the direct neighbor b replicated across depth branches.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/c> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/d> .
+          <http://ex.org/d> <http://ex.org/p> <http://ex.org/e> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/x> .
+        }
+    query: |
+      SELECT ?o WHERE { <http://ex.org/a> <http://ex.org/p>+ ?o }
+    expect:
+      rows:
+        - [http://ex.org/b]
+        - [http://ex.org/c]
+        - [http://ex.org/d]
+        - [http://ex.org/e]
+        - [http://ex.org/x]
+
+  - name: zero_or_more_bound_subject_closure_regression
+    # O3: control on the SAME graph. :a :p* ?o must stay correct (reflexive a
+    # plus the closure) = {a,b,c,d,e,x}. Regression guard for the * operator,
+    # which this fix does not touch.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/c> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/d> .
+          <http://ex.org/d> <http://ex.org/p> <http://ex.org/e> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/x> .
+        }
+    query: |
+      SELECT ?o WHERE { <http://ex.org/a> <http://ex.org/p>* ?o }
+    expect:
+      rows:
+        - [http://ex.org/a]
+        - [http://ex.org/b]
+        - [http://ex.org/c]
+        - [http://ex.org/d]
+        - [http://ex.org/e]
+        - [http://ex.org/x]
+
+  - name: one_or_more_ask_three_hops
+    # O4: ASK over a fully-bound + path (3 hops a->b->c->d) -> TRUE. Existence
+    # works before and after this fix (project_path_endpoints is a no-op when both
+    # endpoints are bound); regression guard that the fix does not break it.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/c> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/d> .
+          <http://ex.org/d> <http://ex.org/p> <http://ex.org/e> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/x> .
+        }
+    query: |
+      ASK { <http://ex.org/a> <http://ex.org/p>+ <http://ex.org/d> }
+    expect:
+      count: 1
+
+  - name: one_or_more_cycle_terminates_and_dedups
+    # O5: cycle a <-> b. ?s :p+ ?o -> {(a,a),(a,b),(b,a),(b,b)}, each once.
+    # Termination is by the bounded depth-50 expansion (no visited-set), so a
+    # cycle does not hang; pre-fix this emits 100 duplicate-leaked rows.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/a> .
+        }
+    query: |
+      SELECT ?s ?o WHERE { ?s <http://ex.org/p>+ ?o }
+    expect:
+      rows:
+        - [http://ex.org/a, http://ex.org/a]
+        - [http://ex.org/a, http://ex.org/b]
+        - [http://ex.org/b, http://ex.org/a]
+        - [http://ex.org/b, http://ex.org/b]
+
+  - name: one_or_more_cycle_distinct_count
+    # O5 (distinct-count form): the cycle closure has exactly 4 distinct pairs.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/a> .
+        }
+    query: |
+      SELECT DISTINCT ?s ?o WHERE { ?s <http://ex.org/p>+ ?o }
+    expect:
+      count: 4
+
+  - name: one_or_more_inverse_nesting
+    # O6: ^(:p+) reverse closure. Nodes that reach e via p+ are {a,b,c,d}.
+    # The Inverse arm recurses into the + translation, so this fix covers it too.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/c> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/d> .
+          <http://ex.org/d> <http://ex.org/p> <http://ex.org/e> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/x> .
+        }
+    query: |
+      SELECT ?o WHERE { <http://ex.org/e> ^(<http://ex.org/p>+) ?o }
+    expect:
+      rows:
+        - [http://ex.org/a]
+        - [http://ex.org/b]
+        - [http://ex.org/c]
+        - [http://ex.org/d]
+
+  - name: one_or_more_sequence_leg_nesting
+    # O6: (:p+)/:q sequence leg. Closure of p from a = {b,c,d}; only d has a q
+    # edge to z, so the result is {z}. The Sequence arm recurses, so this fix covers it.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/c> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/d> .
+          <http://ex.org/d> <http://ex.org/q> <http://ex.org/z> .
+        }
+    query: |
+      SELECT ?o WHERE { <http://ex.org/a> <http://ex.org/p>+/<http://ex.org/q> ?o }
+    expect:
+      rows:
+        - [http://ex.org/z]
+
+  - name: zero_or_one_bound_subject_regression
+    # O7: ? operator unchanged. :a :p? ?o -> {a (0-hop), b (1-hop)}.
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/c> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/d> .
+          <http://ex.org/d> <http://ex.org/p> <http://ex.org/e> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/x> .
+        }
+    query: |
+      SELECT ?o WHERE { <http://ex.org/a> <http://ex.org/p>? ?o }
+    expect:
+      rows:
+        - [http://ex.org/a]
+        - [http://ex.org/b]
+
+  - name: sequence_two_hops_regression
+    # O7: / operator unchanged. :a :p/:p ?o -> {c} (exactly two hops a->b->c).
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/c> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/d> .
+          <http://ex.org/d> <http://ex.org/p> <http://ex.org/e> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/x> .
+        }
+    query: |
+      SELECT ?o WHERE { <http://ex.org/a> <http://ex.org/p>/<http://ex.org/p> ?o }
+    expect:
+      rows:
+        - [http://ex.org/c]
+
+  - name: inverse_single_hop_regression
+    # O7: ^ operator unchanged. :b ^:p ?o -> {a} (a is the only inbound).
+    setup:
+      - |
+        INSERT DATA {
+          <http://ex.org/a> <http://ex.org/p> <http://ex.org/b> .
+          <http://ex.org/b> <http://ex.org/p> <http://ex.org/c> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/d> .
+          <http://ex.org/d> <http://ex.org/p> <http://ex.org/e> .
+          <http://ex.org/c> <http://ex.org/p> <http://ex.org/x> .
+        }
+    query: |
+      SELECT ?o WHERE { <http://ex.org/b> ^<http://ex.org/p> ?o }
+    expect:
+      rows:
+        - [http://ex.org/a]


### PR DESCRIPTION
Fixes #369.

## What

SPARQL `path+` (`OneOrMore`) did not return a transitive closure for variable
endpoints — it returned only the direct neighbours, with the true multi-hop
endpoint replaced by the first intermediate hop, plus duplicate rows that
`DISTINCT` failed to collapse. The five sibling operators (`/ | ^ * ?`) were
already correct.

This was a single missing endpoint projection in the `OneOrMore` translation.

## Root cause

`crates/grafeo-engine/src/query/translators/sparql.rs`

`translate_one_or_more_path` pushed each fixed-depth branch **raw** into the
`Union`, whereas `translate_zero_or_more_path` and `translate_zero_or_one_path`
wrap every depth branch in `project_path_endpoints` first. The projection strips
the per-hop intermediate columns so all union branches share the endpoint
schema.

Without it, a depth-N branch is wider than the depth-1 branch (one extra column
per intermediate hop). The union output schema is seeded from branch 0 (the
narrow depth-1 branch), and `Distinct` keys on each chunk's own width while
copying into the narrow branch-0-sized builder — so the visible object column
ends up holding the **first intermediate hop** instead of the true endpoint, and
endpoints reached at different depths keep distinct (wider) keys and are never
de-duplicated.

## The fix

One call site — wrap each depth branch exactly as the sibling operators do:

```diff
 for depth in 1..=MAX_DEPTH {
     let branch =
         self.translate_fixed_depth_path(inner_path, &subject, &object, &graph, depth)?;
-    branches.push(branch);
+    branches.push(self.project_path_endpoints(&subject, &object, branch));
 }
```

No reflexive 0-hop branch is added: `path+` excludes the zero-length path
(SPARQL 1.1 §9.1). `project_path_endpoints` is the existing, unchanged helper;
this only adds a third caller and touches no shared state, so the five working
operators are textually unaffected.

## Tests (result-level oracles)

The existing `tests/spec/rdf/sparql/property_paths.gtest` `+` cases asserted only
a row **count** (or single-hop data), which passed even with the bug present —
on the chain graph the buggy output has the right cardinality but every value is
the leaked intermediate hop. This PR:

- **Strengthens** the two count-only `+` cases (`one_or_more_path_chain`,
  `sequence_with_one_or_more`) to assert the actual reached values.
- **Adds** a result-level closure oracle set over `a->b->c->d->e` + `c->x`
  (predicate `p`) that asserts the full distinct closure as a sorted multiset,
  so it fails on both missing transitive pairs and duplicate leakage:
  - open-ended `?s :p+ ?o` (full 13-pair closure; `SELECT DISTINCT` count = 13),
  - bound-subject `:a :p+ ?o` = `{b,c,d,e,x}`,
  - a `:p*` control on the same graph (regression guard for `*`),
  - `ASK` over a 3-hop fully-bound `+` path,
  - a cycle `a <-> b` (4 distinct pairs; proves termination + de-duplication),
  - nested `^(:p+)` and `(:p+)/:q`,
  - `?`, `/`, `^` regression guards over the same graph.

Pre-fix these new/strengthened oracles fail with the leaked output (e.g. the
cycle yields 100 rows; `SELECT DISTINCT` open-ended yields 5 instead of 13);
post-fix all pass. The rest of `property_paths.gtest` and the SPARQL suites stay
green, demonstrating `/ | ^ * ?` are unchanged.

Run them with:

```
cargo test -p grafeo-spec-tests --features rdf rdf_sparql_property_paths
```

## Scope / honesty

- **Bounded depth, not unbounded ALP.** Like `path*`, `path+` expands to a
  bounded `MAX_DEPTH = 50` hops plus `Distinct` (no visited-set), so this is not
  the unbounded ALP of SPARQL 1.1 §18.4; closures over 50 hops truncate. Shared
  with `path*`, orthogonal to this fix — this PR does not claim spec-complete
  ALP conformance.
- **Related, not fixed here.** A fully-bound `SELECT ?s WHERE { :a :p+ :b }`
  (projecting a variable absent from the pattern) errors with `GRAFEO-X001:
  Internal error: Variable 's' not found in input columns`. This is identical
  for `:p*` and `:p?` (shared with the working operators), so it is a separate
  normalization item left for a follow-up. `ASK` and `SELECT *` over
  fully-bound paths already work.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SPARQL `path+` so it returns the true transitive closure for variable endpoints and removes duplicate leakage. Each fixed-depth branch is now projected to its endpoints before union, matching the behavior of `*` and `?`.

- **Bug Fixes**
  - Project each `OneOrMore` depth branch with `project_path_endpoints` before `Union`/`Distinct`; no 0‑hop branch (per spec).
  - Strengthened two `+` tests to assert values, and added closure oracles (open-ended, bound-subject, cycle, nested `^(:p+)` and `(:p+)/:q`) plus regression guards for `*`, `?`, `/`, `^`.
  - Kept bounded expansion at `MAX_DEPTH = 50` and updated a stale test comment; other path operators unchanged.

<sup>Written for commit f77bae7a42250ce3ebdcacf75c0040a33f454999. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/GrafeoDB/grafeo/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

