### PR TITLE
Fail closed on duplicate result columns; render function arguments in column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Grafeo, for future reference (and enjoyment).
 
+## [Unreleased]
+
+### Fixed
+
+- **Silent data loss from duplicate output-column names**: a query whose projection produced two columns with the same name built a `QueryResult` whose schema could not represent itself, and name-addressed consumers then dropped data silently — the PyO3 `to_list()` dict via last-write-wins, and bindings that key rows into duplicate-key-rejecting structures via whole-row loss. The most common trigger needed no duplicate intent: distinct bare calls like `id(s)`, `id(t)`, `id(r)` all collapsed to the header `id(...)`. `QueryResult`'s column-bearing constructors (`new`/`with_types`/`from_rows`) and the streaming open path now enforce a fail-closed uniqueness invariant — a structured semantic error that names the duplicate — so the guarantee holds on both the eager and the streaming result paths and across every language leg.
+
+### Changed
+
+- **Un-aliased function-call columns now render their arguments**: openCypher 9 names an un-aliased `RETURN` item by its expression text, but `expression_to_string` rendered every `FunctionCall` as `name(...)` (discarding arguments) and several expression kinds as the constant `expr`, so distinct bare expressions collapsed to one name. They now render faithfully — `id(s)`, `id(t)`, `id(r)`, `a.age + 1`, `-a.age` — so the common case needs no alias. This is a column-naming contract change for previously-collapsed headers; aggregate headers are produced by a separate path and are unchanged. The `QueryResult` column-bearing constructors now return `Result` (they validate column-name uniqueness).
+- **SPARQL rejects duplicate projection aliases at parse time** (SPARQL 1.1 §18.2.4.4): `SELECT (?s AS ?x) (?o AS ?x)`, and an alias shadowing another projected variable, are now syntax errors. The degenerate `SELECT ?s ?s` is caught by the engine's result-column uniqueness invariant. Full visible-scope validation against `WHERE`-bound variables remains future work.
+
 ## [0.5.42] - 2026-05-04
 
 End-to-end tiered storage: section data (LPG, RDF Ring, vector topology) can spill to mmap-backed disk under memory pressure or explicit configuration, with per-section tier overrides, introspection, and reload. Plus per-block columnar zone maps for selective range scans, paged HNSW topology, packed RDF Ring on disk, a WAL overlay for mutating mmap'd compact stores and a streaming top-K operator that fuses `ORDER BY ... LIMIT` into a single bounded-heap pass.

--- a/crates/bindings/common/src/entity.rs
+++ b/crates/bindings/common/src/entity.rs
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn extracts_nodes_and_edges() {
-        let mut result = QueryResult::new(vec!["n".into(), "e".into()]);
+        let mut result = QueryResult::new(vec!["n".into(), "e".into()]).unwrap();
         result.push_row(vec![
             node_map(1, &["Person"], &[("name", Value::String("Alix".into()))]),
             edge_map(10, "KNOWS", 1, 2, &[("since", Value::Int64(2020))]),
@@ -207,7 +207,7 @@ mod tests {
 
     #[test]
     fn deduplicates_by_id() {
-        let mut result = QueryResult::new(vec!["n".into()]);
+        let mut result = QueryResult::new(vec!["n".into()]).unwrap();
         result.push_row(vec![node_map(1, &["Person"], &[])]);
         result.push_row(vec![node_map(1, &["Person"], &[])]);
 
@@ -217,7 +217,7 @@ mod tests {
 
     #[test]
     fn handles_empty_result() {
-        let result = QueryResult::new(vec![]);
+        let result = QueryResult::new(vec![]).unwrap();
         let (nodes, edges) = extract_entities(&result);
         assert!(nodes.is_empty());
         assert!(edges.is_empty());

--- a/crates/grafeo-adapters/src/query/sparql/parser.rs
+++ b/crates/grafeo-adapters/src/query/sparql/parser.rs
@@ -576,6 +576,35 @@ impl<'a> Parser<'a> {
             return Err(self.error("expected '*' or variable list in SELECT"));
         }
 
+        // Within-projection duplicate-alias guard (SPARQL 1.1 sec 18.2.4.4: the
+        // target variable of `(expr AS ?v)` must be a fresh variable). This cheap
+        // check over the projection rejects `(?s AS ?x) (?o AS ?x)` and an alias
+        // that shadows another projected name, at parse time. Full visible-scope
+        // validation (against the WHERE-bound variables, which are parsed after
+        // the projection) is a disclosed follow-up; bare duplicate variables
+        // (`SELECT ?s ?s`) are left to the engine's leg-agnostic result-column
+        // uniqueness invariant.
+        {
+            let mut seen: Vec<(&str, bool)> = Vec::with_capacity(variables.len());
+            for var in &variables {
+                let (name, is_alias): (&str, bool) = match (&var.alias, &var.expression) {
+                    (Some(alias), _) => (alias.as_str(), true),
+                    (None, Expression::Variable(name)) => (name.as_str(), false),
+                    (None, _) => continue,
+                };
+                let collides = seen.iter().any(|&(prev_name, prev_is_alias)| {
+                    prev_name == name && (prev_is_alias || is_alias)
+                });
+                if collides {
+                    return Err(self.error(&format!(
+                        "duplicate projection variable '?{name}' in SELECT: the target of AS \
+                         must be a fresh variable (SPARQL 1.1 sec 18.2.4.4)"
+                    )));
+                }
+                seen.push((name, is_alias));
+            }
+        }
+
         Ok(Projection::Variables(variables))
     }
 
@@ -2646,6 +2675,51 @@ mod tests {
     fn test_parse_invalid_keyword_fails() {
         let result = parse("SELECTX ?x WHERE { ?x ?y ?z }");
         assert!(result.is_err(), "Invalid keyword should fail");
+    }
+
+    // --- within-projection duplicate-alias rejection (SPARQL 18.2.4.4) ---
+
+    #[test]
+    fn test_projection_duplicate_alias_fails() {
+        // `(expr AS ?v)` must bind a fresh variable; reusing ?x is a syntax error.
+        let result = parse("SELECT (?s AS ?x) (?o AS ?x) WHERE { ?s ?p ?o }");
+        assert!(result.is_err(), "Duplicate projection alias should fail");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .to_lowercase()
+                .contains("duplicate projection variable"),
+            "error should flag the duplicate projection variable"
+        );
+    }
+
+    #[test]
+    fn test_projection_alias_shadowing_bare_var_fails() {
+        // An alias that shadows an already-projected variable is also rejected.
+        let result = parse("SELECT ?x (?o AS ?x) WHERE { ?x ?p ?o }");
+        assert!(
+            result.is_err(),
+            "Alias shadowing a bare variable should fail"
+        );
+    }
+
+    #[test]
+    fn test_projection_distinct_aliases_ok() {
+        let result = parse("SELECT (?s AS ?a) (?o AS ?b) WHERE { ?s ?p ?o }");
+        assert!(result.is_ok(), "Distinct aliases must still parse");
+    }
+
+    #[test]
+    fn test_projection_bare_duplicate_variable_parses() {
+        // `SELECT ?s ?s` is NOT rejected at parse time — that degenerate case is
+        // caught fail-closed by the engine's leg-agnostic result-column
+        // uniqueness invariant, not by this cheap within-projection alias check.
+        let result = parse("SELECT ?s ?s WHERE { ?s ?p ?o }");
+        assert!(
+            result.is_ok(),
+            "Bare duplicate variables parse; rejection is deferred to the engine"
+        );
     }
 
     // ==================== Recursion depth limit tests ====================

--- a/crates/grafeo-engine/src/database/mod.rs
+++ b/crates/grafeo-engine/src/database/mod.rs
@@ -2941,6 +2941,41 @@ pub struct QueryResult {
 }
 
 impl QueryResult {
+    /// Validates that a result schema carries no repeated column name.
+    ///
+    /// A [`QueryResult`] addresses its rows positionally, but every FFI binding
+    /// consumes them *by column name* (the PyO3 dict, the Node and C JSON
+    /// objects, or any binding that keys rows into a structure forbidding
+    /// duplicate keys). A repeated name there loses data silently —
+    /// last-write-wins in some bindings, a dropped whole row in others. Rather
+    /// than emit a result that cannot represent its own schema, the engine fails
+    /// closed here with a structured error that names the duplicate. This is the
+    /// leg-agnostic backstop: every column-bearing constructor and the streaming
+    /// open path route their schema through this check, so the invariant holds on
+    /// both the eager and the streaming result paths.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryErrorKind::Semantic`] if any column name appears more than
+    /// once in `columns`.
+    pub(crate) fn validate_unique_columns(columns: &[String]) -> Result<()> {
+        // Column lists are tiny; a simple scan avoids an allocation and reports
+        // the first duplicate deterministically (in column order).
+        for (idx, name) in columns.iter().enumerate() {
+            if columns[..idx].contains(name) {
+                return Err(Error::Query(QueryError::new(
+                    QueryErrorKind::Semantic,
+                    format!(
+                        "duplicate column name '{name}' in query result: a result cannot carry \
+                         two columns with the same name because name-addressed consumers would \
+                         silently drop one; give the projections distinct aliases (e.g. `AS {name}_2`)"
+                    ),
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Creates a fully empty query result (no columns, no rows).
     #[must_use]
     pub fn empty() -> Self {
@@ -2970,10 +3005,15 @@ impl QueryResult {
     }
 
     /// Creates a new empty query result.
-    #[must_use]
-    pub fn new(columns: Vec<String>) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `columns` contains a repeated column name (see
+    /// [`validate_unique_columns`](Self::validate_unique_columns)).
+    pub fn new(columns: Vec<String>) -> Result<Self> {
+        Self::validate_unique_columns(&columns)?;
         let len = columns.len();
-        Self {
+        Ok(Self {
             columns,
             column_types: vec![grafeo_common::types::LogicalType::Any; len],
             rows: Vec::new(),
@@ -2981,16 +3021,21 @@ impl QueryResult {
             rows_scanned: None,
             status_message: None,
             gql_status: grafeo_common::utils::GqlStatus::SUCCESS,
-        }
+        })
     }
 
     /// Creates a new empty query result with column types.
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `columns` contains a repeated column name (see
+    /// [`validate_unique_columns`](Self::validate_unique_columns)).
     pub fn with_types(
         columns: Vec<String>,
         column_types: Vec<grafeo_common::types::LogicalType>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        Self::validate_unique_columns(&columns)?;
+        Ok(Self {
             columns,
             column_types,
             rows: Vec::new(),
@@ -2998,14 +3043,22 @@ impl QueryResult {
             rows_scanned: None,
             status_message: None,
             gql_status: grafeo_common::utils::GqlStatus::SUCCESS,
-        }
+        })
     }
 
     /// Creates a query result with pre-populated rows.
-    #[must_use]
-    pub fn from_rows(columns: Vec<String>, rows: Vec<Vec<grafeo_common::types::Value>>) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `columns` contains a repeated column name (see
+    /// [`validate_unique_columns`](Self::validate_unique_columns)).
+    pub fn from_rows(
+        columns: Vec<String>,
+        rows: Vec<Vec<grafeo_common::types::Value>>,
+    ) -> Result<Self> {
+        Self::validate_unique_columns(&columns)?;
         let len = columns.len();
-        Self {
+        Ok(Self {
             columns,
             column_types: vec![grafeo_common::types::LogicalType::Any; len],
             rows,
@@ -3013,7 +3066,7 @@ impl QueryResult {
             rows_scanned: None,
             status_message: None,
             gql_status: grafeo_common::utils::GqlStatus::SUCCESS,
-        }
+        })
     }
 
     /// Appends a row to this result.
@@ -3724,7 +3777,7 @@ mod tests {
 
     #[test]
     fn test_query_result_new_with_columns() {
-        let result = QueryResult::new(vec!["name".into(), "age".into()]);
+        let result = QueryResult::new(vec!["name".into(), "age".into()]).unwrap();
         assert_eq!(result.column_count(), 2);
         assert_eq!(result.row_count(), 0);
         assert!(result.is_empty());
@@ -3744,15 +3797,53 @@ mod tests {
         let result = QueryResult::with_types(
             vec!["name".into(), "age".into()],
             vec![LogicalType::String, LogicalType::Int64],
-        );
+        )
+        .unwrap();
         assert_eq!(result.column_count(), 2);
         assert_eq!(result.column_types[0], LogicalType::String);
         assert_eq!(result.column_types[1], LogicalType::Int64);
     }
 
     #[test]
+    fn test_query_result_rejects_duplicate_columns() {
+        // The fail-closed result-column uniqueness invariant. A result must
+        // never carry two columns with the same name (name-addressed FFI
+        // consumers would silently drop one), so the column-bearing constructors
+        // fail closed with a structured error that names the duplicate.
+        let dup_new = QueryResult::new(vec!["x".into(), "x".into()]);
+        assert!(dup_new.is_err());
+        assert!(
+            dup_new
+                .unwrap_err()
+                .to_string()
+                .to_lowercase()
+                .contains("duplicate column"),
+            "error should name the duplicate column"
+        );
+
+        use grafeo_common::types::LogicalType;
+        assert!(
+            QueryResult::with_types(
+                vec!["a".into(), "a".into()],
+                vec![LogicalType::Any, LogicalType::Any],
+            )
+            .is_err()
+        );
+        assert!(QueryResult::from_rows(vec!["c".into(), "c".into()], vec![]).is_err());
+
+        // Distinct column names still construct successfully.
+        assert!(QueryResult::new(vec!["a".into(), "b".into()]).is_ok());
+        assert!(QueryResult::from_rows(vec!["a".into(), "b".into()], vec![]).is_ok());
+        // The zero/one-column cases are trivially unique.
+        assert!(QueryResult::new(vec![]).is_ok());
+        assert!(QueryResult::new(vec!["only".into()]).is_ok());
+    }
+
+    #[test]
     fn test_query_result_with_metrics() {
-        let result = QueryResult::new(vec!["x".into()]).with_metrics(42.5, 100);
+        let result = QueryResult::new(vec!["x".into()])
+            .unwrap()
+            .with_metrics(42.5, 100);
         assert_eq!(result.execution_time_ms(), Some(42.5));
         assert_eq!(result.rows_scanned(), Some(100));
     }
@@ -3760,7 +3851,7 @@ mod tests {
     #[test]
     fn test_query_result_scalar_success() {
         use grafeo_common::types::Value;
-        let mut result = QueryResult::new(vec!["count".into()]);
+        let mut result = QueryResult::new(vec!["count".into()]).unwrap();
         result.rows.push(vec![Value::Int64(42)]);
 
         let val: i64 = result.scalar().unwrap();
@@ -3771,25 +3862,25 @@ mod tests {
     fn test_query_result_scalar_wrong_shape() {
         use grafeo_common::types::Value;
         // Multiple rows
-        let mut result = QueryResult::new(vec!["x".into()]);
+        let mut result = QueryResult::new(vec!["x".into()]).unwrap();
         result.rows.push(vec![Value::Int64(1)]);
         result.rows.push(vec![Value::Int64(2)]);
         assert!(result.scalar::<i64>().is_err());
 
         // Multiple columns
-        let mut result2 = QueryResult::new(vec!["a".into(), "b".into()]);
+        let mut result2 = QueryResult::new(vec!["a".into(), "b".into()]).unwrap();
         result2.rows.push(vec![Value::Int64(1), Value::Int64(2)]);
         assert!(result2.scalar::<i64>().is_err());
 
         // Empty
-        let result3 = QueryResult::new(vec!["x".into()]);
+        let result3 = QueryResult::new(vec!["x".into()]).unwrap();
         assert!(result3.scalar::<i64>().is_err());
     }
 
     #[test]
     fn test_query_result_iter() {
         use grafeo_common::types::Value;
-        let mut result = QueryResult::new(vec!["x".into()]);
+        let mut result = QueryResult::new(vec!["x".into()]).unwrap();
         result.rows.push(vec![Value::Int64(1)]);
         result.rows.push(vec![Value::Int64(2)]);
 
@@ -3800,7 +3891,7 @@ mod tests {
     #[test]
     fn test_query_result_display() {
         use grafeo_common::types::Value;
-        let mut result = QueryResult::new(vec!["name".into()]);
+        let mut result = QueryResult::new(vec!["name".into()]).unwrap();
         result.rows.push(vec![Value::from("Alix")]);
         let display = result.to_string();
         assert!(display.contains("name"));

--- a/crates/grafeo-engine/src/database/query.rs
+++ b/crates/grafeo-engine/src/database/query.rs
@@ -68,7 +68,7 @@ impl super::GrafeoDB {
         // defensive no-op today).
         *self.current_graph.write() = session.current_graph();
         *self.current_schema.write() = session.current_schema();
-        Ok(OwnedResultStream::new(source, columns, deadline))
+        OwnedResultStream::new(source, columns, deadline)
     }
 
     /// Executes a GQL query with visibility at the specified epoch.

--- a/crates/grafeo-engine/src/query/executor/mod.rs
+++ b/crates/grafeo-engine/src/query/executor/mod.rs
@@ -104,7 +104,7 @@ impl Executor {
     /// Returns an error if operator execution fails or the query timeout is exceeded.
     pub fn execute(&self, operator: &mut dyn Operator) -> Result<QueryResult> {
         let _span = grafeo_debug_span!("grafeo::query::execute");
-        let mut result = QueryResult::with_types(self.columns.clone(), self.column_types.clone());
+        let mut result = QueryResult::with_types(self.columns.clone(), self.column_types.clone())?;
         let mut types_captured = !result.column_types.iter().all(|t| *t == LogicalType::Any);
 
         loop {
@@ -166,7 +166,7 @@ impl Executor {
             .expect("sink should be ChunkCollector");
         let chunks = collector.into_chunks();
 
-        let mut result = QueryResult::with_types(self.columns.clone(), self.column_types.clone());
+        let mut result = QueryResult::with_types(self.columns.clone(), self.column_types.clone())?;
         let mut types_captured = !result.column_types.iter().all(|t| *t == LogicalType::Any);
 
         for chunk in &chunks {
@@ -190,7 +190,7 @@ impl Executor {
         operator: &mut dyn Operator,
         limit: usize,
     ) -> Result<QueryResult> {
-        let mut result = QueryResult::with_types(self.columns.clone(), self.column_types.clone());
+        let mut result = QueryResult::with_types(self.columns.clone(), self.column_types.clone())?;
         let mut collected = 0;
         let mut types_captured = !result.column_types.iter().all(|t| *t == LogicalType::Any);
 
@@ -338,7 +338,7 @@ impl Executor {
         let mut wrapped = CardinalityTrackingWrapper::new(operator, "root", shared_ctx.clone());
 
         // Execute with tracking
-        let mut result = QueryResult::with_types(self.columns.clone(), self.column_types.clone());
+        let mut result = QueryResult::with_types(self.columns.clone(), self.column_types.clone())?;
         let mut types_captured = !result.column_types.iter().all(|t| *t == LogicalType::Any);
         let mut total_rows: u64 = 0;
         let check_interval = config.min_rows;

--- a/crates/grafeo-engine/src/query/executor/stream.rs
+++ b/crates/grafeo-engine/src/query/executor/stream.rs
@@ -64,21 +64,34 @@ pub struct ResultStream<'session> {
 }
 
 impl<'s> ResultStream<'s> {
+    /// Opens a streaming result, failing closed if the schema is not unique.
+    ///
+    /// The streaming FFI surfaces (PyO3 `PyResultStream`, C `grafeo_stream_open`)
+    /// build each row keyed by column name, so a duplicate name would silently
+    /// drop data per row. Validating once here — at stream-open, before the first
+    /// row — keeps the result-column uniqueness invariant on the streaming path
+    /// as well as the eager path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryErrorKind::Semantic`](grafeo_common::utils::error::QueryErrorKind)
+    /// if `columns` contains a repeated column name.
     pub(crate) fn new(
         operator: Box<dyn Operator>,
         columns: Vec<String>,
         deadline: Option<Instant>,
         guard: StreamGuard<'s>,
-    ) -> Self {
+    ) -> Result<Self> {
+        QueryResult::validate_unique_columns(&columns)?;
         let len = columns.len();
-        Self {
+        Ok(Self {
             operator,
             columns,
             column_types: vec![LogicalType::Any; len],
             deadline,
             exhausted: false,
             _guard: guard,
-        }
+        })
     }
 
     /// Column names in the order they appear in each row.
@@ -138,7 +151,7 @@ impl<'s> ResultStream<'s> {
     ///
     /// Propagates operator errors and deadline timeouts.
     pub fn collect(mut self) -> Result<QueryResult> {
-        let mut result = QueryResult::with_types(self.columns.clone(), self.column_types.clone());
+        let mut result = QueryResult::with_types(self.columns.clone(), self.column_types.clone())?;
         while let Some(chunk) = self.next_chunk()? {
             append_chunk(&chunk, &mut result);
         }
@@ -228,19 +241,27 @@ impl std::fmt::Debug for OwnedResultStream {
 }
 
 impl OwnedResultStream {
+    /// Opens an owned streaming result, failing closed if the schema is not
+    /// unique (see [`ResultStream::new`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryErrorKind::Semantic`](grafeo_common::utils::error::QueryErrorKind)
+    /// if `columns` contains a repeated column name.
     pub(crate) fn new(
         operator: Box<dyn Operator>,
         columns: Vec<String>,
         deadline: Option<Instant>,
-    ) -> Self {
+    ) -> Result<Self> {
+        QueryResult::validate_unique_columns(&columns)?;
         let len = columns.len();
-        Self {
+        Ok(Self {
             operator,
             columns,
             column_types: vec![LogicalType::Any; len],
             deadline,
             exhausted: false,
-        }
+        })
     }
 
     /// Column names in the order they appear in each row.
@@ -294,7 +315,7 @@ impl OwnedResultStream {
     ///
     /// Propagates operator errors and deadline timeouts.
     pub fn collect(mut self) -> Result<QueryResult> {
-        let mut result = QueryResult::with_types(self.columns.clone(), self.column_types.clone());
+        let mut result = QueryResult::with_types(self.columns.clone(), self.column_types.clone())?;
         while let Some(chunk) = self.next_chunk()? {
             append_chunk(&chunk, &mut result);
         }

--- a/crates/grafeo-engine/src/query/planner/common.rs
+++ b/crates/grafeo-engine/src/query/planner/common.rs
@@ -5,7 +5,7 @@
 //! Each function takes already-planned input operators and column lists,
 //! plus a schema derivation function to handle LPG vs RDF type differences.
 
-use crate::query::plan::LogicalExpression;
+use crate::query::plan::{BinaryOp, LogicalExpression, UnaryOp};
 use grafeo_common::types::LogicalType;
 use grafeo_common::utils::error::{Error, Result};
 use grafeo_core::execution::operators::{
@@ -408,6 +408,19 @@ pub(crate) fn resolve_expression_to_column(
 }
 
 /// Converts a logical expression to a human-readable string for column naming.
+///
+/// The rendering follows the surface syntax of the expression so that two
+/// distinct un-aliased projections receive two distinct column names — e.g.
+/// `id(s)` and `id(t)` rather than a collapsed `id(...)`. openCypher 9 names an
+/// un-aliased RETURN item by its expression text, so rendering a function call's
+/// arguments (rather than discarding them) keeps that contract and stops
+/// distinct expressions from sharing a name. Any residual collisions from the
+/// variants that still fall through to the generic name are caught fail-closed
+/// by the result-column uniqueness invariant
+/// (`QueryResult::validate_unique_columns`).
+///
+/// Aggregate function headers are produced by a separate code path
+/// (`planner/lpg/aggregate.rs`) and are intentionally not rendered here.
 pub(crate) fn expression_to_string(expr: &LogicalExpression) -> String {
     match expr {
         LogicalExpression::Variable(name) => name.clone(),
@@ -415,7 +428,22 @@ pub(crate) fn expression_to_string(expr: &LogicalExpression) -> String {
             format!("{variable}.{property}")
         }
         LogicalExpression::Literal(value) => format!("{value:?}"),
-        LogicalExpression::FunctionCall { name, .. } => format!("{name}(...)"),
+        LogicalExpression::FunctionCall {
+            name,
+            args,
+            distinct,
+        } => {
+            let rendered_args = args
+                .iter()
+                .map(expression_to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            if *distinct {
+                format!("{name}(DISTINCT {rendered_args})")
+            } else {
+                format!("{name}({rendered_args})")
+            }
+        }
         LogicalExpression::IndexAccess { base, index } => {
             format!(
                 "{}[{}]",
@@ -423,7 +451,67 @@ pub(crate) fn expression_to_string(expr: &LogicalExpression) -> String {
                 expression_to_string(index)
             )
         }
+        LogicalExpression::Binary { left, op, right } => {
+            format!(
+                "{} {} {}",
+                expression_to_string(left),
+                binary_op_symbol(*op),
+                expression_to_string(right)
+            )
+        }
+        LogicalExpression::Unary { op, operand } => {
+            let inner = expression_to_string(operand);
+            match op {
+                UnaryOp::Not => format!("NOT {inner}"),
+                UnaryOp::Neg => format!("-{inner}"),
+                UnaryOp::IsNull => format!("{inner} IS NULL"),
+                UnaryOp::IsNotNull => format!("{inner} IS NOT NULL"),
+            }
+        }
+        LogicalExpression::List(items) => {
+            format!(
+                "[{}]",
+                items
+                    .iter()
+                    .map(expression_to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        }
+        LogicalExpression::Parameter(name) => format!("${name}"),
+        LogicalExpression::Labels(variable) => format!("labels({variable})"),
+        LogicalExpression::Type(variable) => format!("type({variable})"),
+        LogicalExpression::Id(variable) => format!("id({variable})"),
         _ => "expr".to_string(),
+    }
+}
+
+/// Renders a binary operator as its openCypher/GQL surface symbol for column
+/// naming (see [`expression_to_string`]).
+fn binary_op_symbol(op: BinaryOp) -> &'static str {
+    match op {
+        BinaryOp::Eq => "=",
+        BinaryOp::Ne => "<>",
+        BinaryOp::Lt => "<",
+        BinaryOp::Le => "<=",
+        BinaryOp::Gt => ">",
+        BinaryOp::Ge => ">=",
+        BinaryOp::And => "AND",
+        BinaryOp::Or => "OR",
+        BinaryOp::Xor => "XOR",
+        BinaryOp::Add => "+",
+        BinaryOp::Sub => "-",
+        BinaryOp::Mul => "*",
+        BinaryOp::Div => "/",
+        BinaryOp::Mod => "%",
+        BinaryOp::Concat => "||",
+        BinaryOp::StartsWith => "STARTS WITH",
+        BinaryOp::EndsWith => "ENDS WITH",
+        BinaryOp::Contains => "CONTAINS",
+        BinaryOp::In => "IN",
+        BinaryOp::Like => "LIKE",
+        BinaryOp::Regex => "=~",
+        BinaryOp::Pow => "^",
     }
 }
 

--- a/crates/grafeo-engine/src/session/mod.rs
+++ b/crates/grafeo-engine/src/session/mod.rs
@@ -2867,7 +2867,7 @@ impl Session {
 
         let (source, columns, deadline) = self.build_streaming_plan(query)?;
         let guard = StreamGuard::new(&self.active_streams);
-        Ok(ResultStream::new(source, columns, deadline, guard))
+        ResultStream::new(source, columns, deadline, guard)
     }
 
     /// Builds a pull-based physical pipeline for streaming, returning the

--- a/crates/grafeo-engine/tests/duplicate_column_disambiguation.rs
+++ b/crates/grafeo-engine/tests/duplicate_column_disambiguation.rs
@@ -1,0 +1,275 @@
+//! Oracle suite: duplicate output-column disambiguation.
+//!
+//! A `QueryResult` stores its rows positionally and losslessly, but it is
+//! consumed *by column name* across the FFI bindings (the PyO3 dict, the Node/C
+//! JSON object, or any binding that keys rows into a structure forbidding
+//! duplicate keys). When two output columns share a name those bindings lose
+//! data silently — last-write-wins in some, a dropped whole row in others.
+//!
+//! Two engine moves close this:
+//!   * a fail-closed result-column uniqueness invariant that is leg-agnostic
+//!     and holds on BOTH the eager and the streaming paths: a result with a
+//!     repeated column name is never built; a structured error is raised
+//!     instead.
+//!   * openCypher-faithful argument rendering in `expression_to_string`, so
+//!     distinct bare expressions (`id(s)`, `id(t)`, `id(r)`) receive distinct
+//!     names and the common case needs no alias.
+//!
+//! Within-projection duplicate-alias rejection in the SPARQL parser is
+//! exercised here end-to-end and unit-tested in `grafeo-adapters`.
+//!
+//! Run: `cargo test -p grafeo-engine --features full --test duplicate_column_disambiguation`
+
+use grafeo_common::types::Value;
+use grafeo_engine::GrafeoDB;
+
+/// Two `Person` nodes (ids 0 and 1) joined by a single `KNOWS` edge (id 0):
+/// `(s {name:"s", age:30}) -[r:KNOWS]-> (t {name:"t", age:25})`.
+fn one_edge() -> GrafeoDB {
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+    let s = session
+        .create_node_with_props(
+            &["Person"],
+            [
+                ("name", Value::String("s".into())),
+                ("age", Value::Int64(30)),
+            ],
+        )
+        .unwrap();
+    let t = session
+        .create_node_with_props(
+            &["Person"],
+            [
+                ("name", Value::String("t".into())),
+                ("age", Value::Int64(25)),
+            ],
+        )
+        .unwrap();
+    session.create_edge(s, t, "KNOWS");
+    db
+}
+
+// ===========================================================================
+// Duplicate bare id() calls get three DISTINCT, correctly-valued columns.
+//   PRE-FIX: all three columns named "id(...)" (arguments discarded).
+// ===========================================================================
+#[test]
+fn r2a_duplicate_bare_id_gets_distinct_faithful_names() {
+    let db = one_edge();
+    let r = db
+        .session()
+        .execute("MATCH (s)-[r]->(t) RETURN id(s), id(t), id(r)")
+        .expect("R2a query should succeed with distinct names");
+    assert_eq!(
+        r.columns,
+        vec!["id(s)", "id(t)", "id(r)"],
+        "M2 must render function arguments so distinct bare expressions get distinct names"
+    );
+    assert_eq!(r.row_count(), 1);
+    let row = &r.rows()[0];
+    assert_eq!(row[0], Value::Int64(0), "id(s)");
+    assert_eq!(row[1], Value::Int64(1), "id(t)");
+    assert_eq!(row[2], Value::Int64(0), "id(r)");
+}
+
+// ===========================================================================
+// Duplicate property accessor (a.name, a.name) fails closed.
+//   PRE-FIX: accepted, columns ["a.name", "a.name"], one key survives at FFI.
+// ===========================================================================
+#[test]
+fn r2b_duplicate_property_fails_closed() {
+    let db = one_edge();
+    match db
+        .session()
+        .execute("MATCH (a:Person) RETURN a.name, a.name")
+    {
+        Ok(r) => panic!(
+            "R2b expected a fail-closed error, got columns {:?} (silent collapse at FFI)",
+            r.columns
+        ),
+        Err(e) => assert!(
+            e.to_string().to_lowercase().contains("duplicate column"),
+            "R2b error should name the duplicate column, got: {e}"
+        ),
+    }
+}
+
+// ===========================================================================
+// Explicit duplicate alias (AS x, AS x) fails closed.
+//   PRE-FIX: WRONGLY ACCEPTED, columns ["x", "x"]; surviving value = id(t)=1.
+// ===========================================================================
+#[test]
+fn r2c_explicit_duplicate_alias_fails_closed() {
+    let db = one_edge();
+    match db
+        .session()
+        .execute("MATCH (s)-[r]->(t) RETURN id(s) AS x, id(t) AS x")
+    {
+        Ok(r) => panic!(
+            "R2c expected a fail-closed error for the duplicate alias, got columns {:?}",
+            r.columns
+        ),
+        Err(e) => assert!(
+            e.to_string().to_lowercase().contains("duplicate column"),
+            "R2c error should name the duplicate column, got: {e}"
+        ),
+    }
+}
+
+// ===========================================================================
+// Distinct-alias control: distinct aliases still succeed (must not regress).
+// ===========================================================================
+#[test]
+fn r2d_distinct_alias_control_unchanged() {
+    let db = one_edge();
+    let r = db
+        .session()
+        .execute("MATCH (s)-[r]->(t) RETURN id(s) AS sid, id(t) AS tid")
+        .expect("R2d distinct-alias query must succeed unchanged");
+    assert_eq!(r.columns, vec!["sid", "tid"]);
+    assert_eq!(r.row_count(), 1);
+    let row = &r.rows()[0];
+    assert_eq!(row[0], Value::Int64(0), "sid");
+    assert_eq!(row[1], Value::Int64(1), "tid");
+}
+
+// ===========================================================================
+// Distinct fallthrough expressions get distinct names, or else fail closed.
+//   PRE-FIX: both render to the constant "expr" and collide.
+// ===========================================================================
+#[test]
+fn rb5_distinct_fallthrough_expressions_do_not_collide() {
+    let db = one_edge();
+    let r = db
+        .session()
+        .execute("MATCH (a:Person) RETURN a.age + 1, -a.age")
+        .expect("distinct fallthrough expressions should not collide after M2");
+    assert_eq!(r.columns.len(), 2);
+    assert_ne!(
+        r.columns[0], r.columns[1],
+        "two distinct expressions must not share a column name"
+    );
+    assert_ne!(r.columns[0], "expr");
+    assert_ne!(r.columns[1], "expr");
+    // The unary negation renders faithfully (no embedded literal).
+    assert_eq!(r.columns[1], "-a.age");
+}
+
+// ===========================================================================
+// Aggregate-exclusion control — argument rendering must NOT touch aggregate
+// headers (they use a separate naming path). An un-aliased count stays unchanged.
+// ===========================================================================
+#[test]
+fn aggregate_header_unchanged_by_m2() {
+    let db = one_edge();
+    let r = db
+        .session()
+        .execute("MATCH (a:Person) RETURN count(a)")
+        .expect("aggregate query should succeed");
+    assert_eq!(r.columns.len(), 1);
+    // If argument rendering had leaked into aggregates the header would render
+    // the argument as "count(a)"; the separate aggregate path keeps the
+    // collapsed form.
+    assert_ne!(r.columns[0], "count(a)", "aggregates are out of M2 scope");
+    assert!(r.columns[0].contains("count"));
+}
+
+// ===========================================================================
+// SPARQL: `SELECT ?s ?s` fails closed via the leg-agnostic uniqueness invariant;
+//   the non-conformant `(?s AS ?x)(?o AS ?x)` is rejected at parse time; the
+//   conformant `SELECT ?s` variable header is unchanged.
+//   PRE-FIX: both degenerate forms collapse to ["s","s"] / ["x","x"].
+// ===========================================================================
+#[cfg(feature = "sparql")]
+fn rdf_db_one_triple() -> GrafeoDB {
+    use grafeo_engine::config::{Config, GraphModel};
+    let db = GrafeoDB::with_config(Config::in_memory().with_graph_model(GraphModel::Rdf)).unwrap();
+    db.session()
+        .execute_sparql("INSERT DATA { <urn:s> <urn:p> <urn:o> }")
+        .unwrap();
+    db
+}
+
+#[cfg(feature = "sparql")]
+#[test]
+fn r2e_sparql_duplicate_variable_fails_closed() {
+    let db = rdf_db_one_triple();
+    match db
+        .session()
+        .execute_sparql("SELECT ?s ?s WHERE { ?s ?p ?o }")
+    {
+        Ok(r) => panic!(
+            "R2e expected fail-closed error for `SELECT ?s ?s`, got columns {:?}",
+            r.columns
+        ),
+        Err(e) => assert!(
+            e.to_string().to_lowercase().contains("duplicate column"),
+            "R2e (M1) error should name the duplicate column, got: {e}"
+        ),
+    }
+}
+
+#[cfg(feature = "sparql")]
+#[test]
+fn r2e_sparql_duplicate_alias_rejected_at_parse() {
+    let db = rdf_db_one_triple();
+    match db
+        .session()
+        .execute_sparql("SELECT (?s AS ?x) (?o AS ?x) WHERE { ?s ?p ?o }")
+    {
+        Ok(r) => panic!(
+            "R2e expected parse rejection for duplicate alias, got columns {:?}",
+            r.columns
+        ),
+        Err(e) => {
+            let msg = e.to_string().to_lowercase();
+            assert!(
+                msg.contains("duplicate") && msg.contains("alias") || msg.contains("fresh"),
+                "R2e (D2) parse error should flag the duplicate alias, got: {e}"
+            );
+        }
+    }
+}
+
+#[cfg(feature = "sparql")]
+#[test]
+fn r2e_sparql_conformant_variable_header_unchanged() {
+    let db = rdf_db_one_triple();
+    let r = db
+        .session()
+        .execute_sparql("SELECT ?s WHERE { ?s ?p ?o }")
+        .expect("conformant SPARQL SELECT must succeed");
+    assert_eq!(
+        r.columns,
+        vec!["s"],
+        "conformant variable headers are untouched"
+    );
+    assert_eq!(r.row_count(), 1);
+}
+
+// ===========================================================================
+// Streaming-path guard: the same duplicate-name query through the lazy/streaming
+//   path fails closed at stream-open, before any row; a distinct-name projection
+//   still opens. PRE-FIX: the stream opens and the collapse happens per-row in
+//   the binding.
+// ===========================================================================
+#[test]
+fn r2f_streaming_guard_rejects_duplicate_columns_at_open() {
+    let db = one_edge();
+    match db.execute_streaming("MATCH (a:Person) RETURN a.name, a.name") {
+        Ok(_) => {
+            panic!("R2f expected the streaming guard to reject duplicate columns at stream-open")
+        }
+        Err(e) => assert!(
+            e.to_string().to_lowercase().contains("duplicate column"),
+            "R2f streaming error should name the duplicate column, got: {e}"
+        ),
+    }
+    // A distinct-name projection must still open on the streaming path.
+    assert!(
+        db.execute_streaming("MATCH (s)-[r]->(t) RETURN id(s), id(t), id(r)")
+            .is_ok(),
+        "distinct streaming projection must open"
+    );
+}


### PR DESCRIPTION
Closes #371

## Problem

A query whose projection produces two columns with the same name builds a `QueryResult` whose schema cannot represent itself, and name-addressed consumers then drop data **silently**. The engine stores rows positionally and losslessly, so the loss is realized only at the binding surface — the PyO3 `to_list()` dict via last-write-wins, and (worse) bindings that key rows into duplicate-key-rejecting structures via whole-row loss. The same collapse happens per-row on the lazy/streaming path.

The most common trigger needs no duplicate intent: `RETURN id(s), id(t), id(r)` names all three columns `id(...)` because the column-naming helper discarded a function call's arguments — so a reasonable query silently returns one value three times while `columns` still reports three entries.

## Root cause

1. **Lossy naming** — `expression_to_string` (`crates/grafeo-engine/src/query/planner/common.rs`): the `FunctionCall` arm rendered `format!("{name}(...)")`, discarding arguments; several other expression kinds rendered the constant `"expr"`. So `id(s)`/`id(t)`/`id(r)` (and `a.age + 1`/`-a.age`) collapsed to one name.
2. **No uniqueness invariant** — `QueryResult` (`crates/grafeo-engine/src/database/mod.rs`) stored `columns`/`rows` as parallel positional vectors and never checked column-name uniqueness, so a self-inconsistent schema was constructed and handed to the bindings. Explicit duplicates (`RETURN a.name, a.name`, `AS x … AS x`, SPARQL `SELECT ?s ?s`, and the non-conformant `SELECT (?s AS ?x) (?o AS ?x)`) were all accepted.

## Fix

Three engine moves, one logical change:

- **M1 — fail-closed uniqueness invariant (both result paths).** A private `QueryResult::validate_unique_columns` returns a structured `Semantic` error that names the duplicate. The eager constructors `QueryResult::{new, with_types, from_rows}` and the streaming opens `ResultStream::new` / `OwnedResultStream::new` (`crates/grafeo-engine/src/query/executor/stream.rs`) route their schema through it, so the invariant holds on **both** the eager and the streaming paths and across every language leg that funnels through `QueryResult`. The column-bearing constructors now return `Result` (API change).
- **M2 — openCypher-faithful naming.** `expression_to_string` now renders a `FunctionCall`'s arguments (`id(s)`, `id(t)`, `id(r)`) and a handful of previously-`"expr"` variants (`Binary`, `Unary`, `List`, `Parameter`, `Labels`, `Type`, `Id`), so distinct bare expressions get distinct names and the common case needs no alias. Aggregate headers are produced by a separate path and are unchanged; residual fallthrough collisions are caught fail-closed by M1.
- **SPARQL parser** (`crates/grafeo-adapters/src/query/sparql/parser.rs`): a cheap within-projection duplicate-alias check rejects `(expr AS ?x) (expr AS ?x)` (and an alias shadowing another projected variable) at parse time, per SPARQL 1.1 §18.2.4.4. Full visible-scope validation against `WHERE`-bound variables is left as a follow-up; the bare `SELECT ?s ?s` case is caught by the engine invariant.

## Standards

- openCypher 9 names an un-aliased `RETURN` item by its expression text (`id(s)`, not `id(...)`).
- Neo4j fails closed on duplicate column **names** ("Multiple result columns with the same name are not supported"). (Cited for the error contract only; Neo4j #4331 is a separate fail-*open* regression, not a model.)
- SPARQL 1.1: a solution mapping is a partial function (§18.1.8); the target of `(expr AS ?v)` must be a fresh variable (§18.2.4.4).

## Tests

New oracle suite `crates/grafeo-engine/tests/duplicate_column_disambiguation.rs` (each oracle was confirmed to fail on the base commit and pass here):

| Oracle | Before | After |
| --- | --- | --- |
| `RETURN id(s), id(t), id(r)` | `["id(...)","id(...)","id(...)"]`, two values lost | `["id(s)","id(t)","id(r)"]`, values `0,1,0` |
| `RETURN a.name, a.name` | accepted, collapses | structured error |
| `RETURN id(s) AS x, id(t) AS x` | wrongly accepted | structured error |
| `RETURN id(s) AS sid, id(t) AS tid` | ok | ok (control, unchanged) |
| `RETURN a.age + 1, -a.age` | both `"expr"`, collide | distinct names |
| `RETURN count(a)` | `count(...)` | `count(...)` (aggregate path unchanged) |
| SPARQL `SELECT ?s ?s` | `["s","s"]` | error (engine invariant) |
| SPARQL `SELECT (?s AS ?x) (?o AS ?x)` | wrongly accepted | parse error (§18.2.4.4) |
| SPARQL `SELECT ?s` | `["s"]` | `["s"]` (conformant header unchanged) |
| streaming `RETURN a.name, a.name` | opens, per-row collapse | fails closed at open |

Plus unit tests for the invariant (`grafeo-engine`) and the parser check (`grafeo-adapters`).

## Compatibility

- `QueryResult::{new, with_types, from_rows}` now return `Result` — a breaking change for direct callers of these constructors. (In-tree callers all already operate in `Result` contexts.)
- Un-aliased scalar function-call / fallthrough column **headers change** for previously-collapsed cases (`id(...)` → `id(s)`; `expr` → faithful text). No in-tree test asserted the old collapsed headers; aggregate headers are unchanged. A CHANGELOG entry documents both.

## Validation

`cargo fmt`, `cargo clippy --all-targets --features full -- -D warnings`, and the full `grafeo-engine` + `grafeo-adapters` suites (`--features full`) are green; the all-leg suites (Cypher / SPARQL / Gremlin / GQL / SQL-PGQ) show no header regressions.

_The breaking `QueryResult::{new, with_types, from_rows}` -> `Result` change is flagged in **Compatibility** above. Happy to gate it behind an adapter, split it into its own commit/PR, or adjust the approach if maintainers prefer._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate result column names and render function-call arguments in column headers to prevent silent data loss. Applies to both eager and streaming results, and aligns headers with openCypher and SPARQL expectations.

- **Bug Fixes**
  - Enforce a uniqueness invariant for result columns; `QueryResult::{new, with_types, from_rows}` and streaming opens now validate and return a structured semantic error on duplicates.
  - Generate distinct, faithful column names: `expression_to_string` renders function arguments and common operators (`id(s)`, `id(t)`, `-a.age`, etc.); aggregate headers are unchanged.
  - SPARQL parser rejects duplicate projection aliases per §18.2.4.4; bare `SELECT ?s ?s` is blocked by the engine invariant.

- **Migration**
  - Update call sites to handle `Result` from `QueryResult::{new, with_types, from_rows}` and stream open paths (use `?` or explicit error handling).
  - Expect updated headers for previously collapsed un-aliased expressions (e.g., `id(...)` → `id(s)`); add aliases if you depended on old names.

<sup>Written for commit e4705b2697c265fddebaf28412b4a533dc7187a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/GrafeoDB/grafeo/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

