### PR TITLE
fix(vector): preserve HNSW connectivity when replacing vectors

### DIFF
--- a/crates/grafeo-core/src/index/vector/hnsw.rs
+++ b/crates/grafeo-core/src/index/vector/hnsw.rs
@@ -428,6 +428,13 @@ impl HnswIndex {
             vector.len()
         );
 
+        // `set_node_property` uses insert for both first writes and updates.
+        // Replacing the topology entry directly would leave reciprocal links
+        // pointing at a node whose own neighbor lists were reset. Remove the
+        // previous entry and reconnect its former neighbors before indexing the
+        // replacement vector.
+        self.remove_for_replacement(id, accessor);
+
         let level = self.random_level();
 
         // Create the new node (topology only)
@@ -573,6 +580,98 @@ impl HnswIndex {
         if level > current_max_level {
             *entry_point = Some(id);
             *max_level = level;
+        }
+    }
+
+    /// Remove an existing node before replacing its vector, preserving paths
+    /// between the node's former neighbors.
+    fn remove_for_replacement(&self, id: NodeId, accessor: &impl VectorAccessor) {
+        let mut nodes = self.nodes.write();
+        let mut entry_point = self.entry_point.write();
+        let nodes_map = nodes.as_heap_mut();
+
+        let Some(removed) = nodes_map.remove(&id) else {
+            return;
+        };
+
+        for node in nodes_map.values_mut() {
+            for neighbors in &mut node.neighbors {
+                neighbors.retain(|&neighbor| neighbor != id);
+            }
+        }
+
+        // Removing a bridge and immediately reinserting it can otherwise leave
+        // its former neighborhoods disconnected. Connect those neighborhoods
+        // at each shared level, then prune them back to the configured degree.
+        for (level, former_neighbors) in removed.neighbors.iter().enumerate() {
+            let existing: Vec<NodeId> = former_neighbors
+                .iter()
+                .copied()
+                .filter(|neighbor| {
+                    nodes_map
+                        .get(neighbor)
+                        .is_some_and(|node| node.neighbors.len() > level)
+                })
+                .collect();
+
+            for &left in &existing {
+                if let Some(node) = nodes_map.get_mut(&left) {
+                    for &right in &existing {
+                        if left != right && !node.neighbors[level].contains(&right) {
+                            node.neighbors[level].push(right);
+                        }
+                    }
+                }
+            }
+
+            let max_neighbors = if level == 0 {
+                self.config.m_max
+            } else {
+                self.config.m
+            };
+            let mut prune_data: Vec<(NodeId, Vec<(NodeId, f32)>)> = Vec::new();
+            for &neighbor_id in &existing {
+                let Some(node) = nodes_map.get(&neighbor_id) else {
+                    continue;
+                };
+                if node.neighbors[level].len() <= max_neighbors {
+                    continue;
+                }
+                let Some(base_vector) = accessor.get_vector(neighbor_id) else {
+                    continue;
+                };
+                let distances: Vec<(NodeId, f32)> = node.neighbors[level]
+                    .iter()
+                    .map(|&candidate| {
+                        let distance = accessor.get_vector(candidate).map_or(f32::MAX, |vector| {
+                            self.vector_distance(&base_vector, &vector)
+                        });
+                        (candidate, distance)
+                    })
+                    .collect();
+                prune_data.push((neighbor_id, distances));
+            }
+
+            for (neighbor_id, distances) in prune_data {
+                if let Some(node) = nodes_map.get_mut(&neighbor_id) {
+                    Self::prune_neighbors_with_distances(
+                        &mut node.neighbors[level],
+                        &distances,
+                        max_neighbors,
+                    );
+                }
+            }
+        }
+
+        if *entry_point == Some(id) {
+            *entry_point = removed
+                .neighbors
+                .iter()
+                .rev()
+                .flatten()
+                .find(|neighbor| nodes_map.contains_key(neighbor))
+                .copied()
+                .or_else(|| nodes_map.keys().next().copied());
         }
     }
 

--- a/crates/grafeo-engine/tests/vector_incremental.rs
+++ b/crates/grafeo-engine/tests/vector_incremental.rs
@@ -42,6 +42,82 @@ fn test_incremental_insert_via_set_property() {
 }
 
 #[test]
+fn test_repeated_vector_update_preserves_hnsw_reachability() {
+    const ITERATIONS: usize = 60;
+    const NODE_COUNT: usize = 6;
+
+    for iteration in 0..ITERATIONS {
+        let db = GrafeoDB::new_in_memory();
+        let mut nodes = Vec::with_capacity(NODE_COUNT);
+
+        for offset in 0..NODE_COUNT {
+            let node = db.create_node(&["Doc"]);
+            db.set_node_property(node, "emb", vec3(0.5 + offset as f32 * 0.01, 0.0, 0.0));
+            nodes.push(node);
+        }
+
+        db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
+            .expect("create index");
+
+        let target = nodes[NODE_COUNT / 2];
+        for _ in 0..5 {
+            db.set_node_property(target, "emb", vec3(0.53, 0.0, 0.0));
+        }
+
+        let results = db
+            .vector_search("Doc", "emb", &[0.5, 0.0, 0.0], NODE_COUNT, None, None)
+            .expect("search");
+
+        assert_eq!(
+            results.len(),
+            NODE_COUNT,
+            "same-ID vector replay must not disconnect HNSW nodes (iteration {iteration})"
+        );
+    }
+}
+
+#[test]
+fn test_vector_replacement_moves_node_without_losing_neighbors() {
+    let db = GrafeoDB::new_in_memory();
+
+    let left = db.create_node(&["Doc"]);
+    db.set_node_property(left, "emb", vec3(1.0, 0.0, 0.0));
+    let moving = db.create_node(&["Doc"]);
+    db.set_node_property(moving, "emb", vec3(0.9, 0.1, 0.0));
+    let right = db.create_node(&["Doc"]);
+    db.set_node_property(right, "emb", vec3(0.0, 1.0, 0.0));
+
+    db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
+        .expect("create index");
+
+    db.set_node_property(moving, "emb", vec3(0.0, 0.99, 0.01));
+
+    let results = db
+        .vector_search("Doc", "emb", &[0.0, 1.0, 0.0], 3, None, None)
+        .expect("search");
+    let ids: Vec<u64> = results.iter().map(|(id, _)| id.as_u64()).collect();
+
+    assert_eq!(
+        results.len(),
+        3,
+        "replacement must keep all nodes reachable"
+    );
+    assert_eq!(
+        ids.first(),
+        Some(&right.as_u64()),
+        "the unchanged nearest node should remain first"
+    );
+    assert!(
+        ids.contains(&moving.as_u64()),
+        "the replaced vector must remain indexed"
+    );
+    assert!(
+        ids.contains(&left.as_u64()),
+        "unrelated nodes must remain indexed"
+    );
+}
+
+#[test]
 fn test_incremental_batch_create_after_index() {
     let db = GrafeoDB::new_in_memory();
 


### PR DESCRIPTION
## Summary

- treat insertion of an existing `NodeId` as vector replacement
- remove the old topology entry and stale reciprocal links
- reconnect the replaced node's former neighborhoods before reinsertion
- add regression coverage for repeated identical updates and moved vectors

Fixes #374.

## Problem

`GrafeoDB::set_node_property()` auto-syncs vector indexes by calling `insert()` even when the node is already indexed. `HnswIndex::insert()` previously overwrote that node's topology entry with fresh empty neighbor lists while other nodes retained reciprocal links to the old entry. Depending on the randomized HNSW level, this could make unrelated nodes unreachable.

A simple `remove()` followed by `insert()` prevents stale links but can still disconnect the removed node's former neighborhoods when it was a bridge. This patch reconnects those former neighbors at each shared layer, prunes them to the configured degree, and then performs normal insertion for the replacement vector.

## Verification

```text
cargo fmt --all --check
cargo test -p grafeo-engine --test vector_incremental --features vector-index
cargo test -p grafeo-core index::vector::hnsw::tests::test_hnsw_remove --features vector-index
```

The vector incremental suite passes 10/10 tests, including 60 fresh-database repeated-update iterations and a changed-vector replacement case.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves HNSW connectivity when updating vectors via `set_node_property()`, preventing stale links and unreachable nodes. Adds neighbor reconnection and pruning during replacement, plus regression tests to ensure full reachability.

- **Bug Fixes**
  - Treat inserting an existing `NodeId` as a replacement: remove the old topology and drop stale reciprocal links.
  - Reconnect the removed node’s former neighbors at each shared level, then prune to configured `m`/`m_max`; reinsert the new vector and update the entry point if needed.
  - Add tests for repeated identical updates and for moved vectors to verify all nodes remain reachable.

<sup>Written for commit 23102d7cc5ebe3ec2747afbf794db4b680f66798. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/GrafeoDB/grafeo/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

