### PR TITLE
docs(README): add grafeo-loro to ecosystem table

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ grafeo info ./mydb --format table # Human-readable table (default)
 |---------|-------------|
 | [**grafeo-server**](https://github.com/GrafeoDB/grafeo-server) | HTTP server & web UI: REST API, transactions, single binary (~40MB Docker image) |
 | [**grafeo-web**](https://github.com/GrafeoDB/grafeo-web) | Browser-based Grafeo via WebAssembly with IndexedDB persistence |
+| [**grafeo-loro**](https://github.com/OndeHQ/grafeo-loro) | Local-first graph database with invisible consensus: Loro CRDT sync + Grafeo execution in one process, offline-first with mathematically impossible conflicts |
 | [**gwp**](https://github.com/GrafeoDB/gql-wire-protocol) | GQL Wire Protocol: gRPC wire protocol for GQL (ISO/IEC 39075) with client bindings in 5 languages |
 | [**boltr**](https://github.com/GrafeoDB/boltr) | Bolt Wire Protocol: pure Rust Bolt v5.x implementation for Neo4j driver compatibility |
 | [**grafeo-langchain**](https://github.com/GrafeoDB/grafeo-langchain) | LangChain integration: graph store, vector store, Graph RAG retrieval |


### PR DESCRIPTION
## What

Adds [grafeo-loro](https://github.com/OndeHQ/grafeo-loro) to the Ecosystem table in `README.md`.

## Why

`grafeo-loro` integrates [Loro](https://loro.dev/) CRDT sync with the Grafeo execution engine in a single process, providing a local-first graph database with offline-first collaboration and conflict-free replication. It is a runtime/storage integration in the same vein as `grafeo-server` and `grafeo-web`, and belongs in the ecosystem listing.

## Where

One new row inserted into the Ecosystem table, positioned right after `grafeo-web` (both are runtime/storage integrations running Grafeo in different environments):

```md
| [**grafeo-loro**](https://github.com/OndeHQ/grafeo-loro) | Local-first graph database with invisible consensus: Loro CRDT sync + Grafeo execution in one process, offline-first with mathematically impossible conflicts |
```

## Project context

- **Repo:** https://github.com/OndeHQ/grafeo-loro
- **Crates.io:** https://crates.io/crates/grafeo-loro (v0.1.0 just published — pending a verified-email config on the crates.io account, will be live shortly)
- **License:** MIT OR Apache-2.0
- **Status:** v0.1.0 released (tagged at `v0.1.0`, GitHub release published)

## Checklist

- [x] Row added to Ecosystem table
- [x] Description matches the style of existing entries (terse, capability-focused)
- [x] Link points to the canonical repo
- [x] No other files touched

---

Happy to adjust the description wording or row placement if maintainers prefer a different grouping.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `grafeo-loro` to the Ecosystem table in `README.md`, describing it as a local-first graph database that combines Loro CRDT sync with the Grafeo execution engine. The row is placed after `grafeo-web` to group runtime/storage integrations.

<sup>Written for commit 9277350273f5b92ced79f7c15ba1382272a5ee63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/GrafeoDB/grafeo/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

