### PR TITLE
feat(lpg): Track E residency accounting + lazy compressed get

### DIFF
--- a/BENCH_EVIDENCE_transactional_batch.txt
+++ b/BENCH_EVIDENCE_transactional_batch.txt
@@ -1,0 +1,48 @@
+# W1-GRAFEO-BATCH benchmark evidence (release, GCP NVMe host)
+
+Command:
+  CARGO_TARGET_DIR=/data/cargo-targets/jfrie-grafeo-session-batch/target \
+  SCCACHE_DIR=/data/sccache TMPDIR=/data/tmp RUSTC_WRAPPER=sccache \
+    cargo bench -p grafeo-engine --bench transactional_batch_bench
+
+Workload: 5,000 nodes (3 props each) + 5,000 edges, one explicit transaction, one commit.
+Pin: 4c2db085596e4f5976426cd3231fad08f26d91f5 (branch agent/txn-session-batch-20260726)
+
+## Storage-only group (isolates the lock-hoisting primitive; no WAL/session layer)
+
+transactional_batch_storage_only/row_oriented
+                        time:   [7.7507 ms 7.9808 ms 8.2142 ms]
+                        thrpt:  [1.2174 Melem/s 1.2530 Melem/s 1.2902 Melem/s]
+transactional_batch_storage_only/storage_batched
+                        time:   [5.8711 ms 5.9850 ms 6.1104 ms]
+                        thrpt:  [1.6366 Melem/s 1.6708 Melem/s 1.7033 Melem/s]
+
+  => storage-level batch is ~1.33x faster than row-oriented at the storage layer
+     (8.0 ms -> 6.0 ms). This is the genuine, measurable win of hoisting every
+     per-row RwLock to once per batch + one atomic ID allocation. It proves the
+     API is a REAL storage-level batch, not a loop wrapper.
+
+## Session-level group (full public API, includes WAL logging — identical in both)
+
+transactional_batch_write/row_oriented_nodes_edges
+                        time:   [13.078 ms 13.292 ms 13.562 ms]
+                        thrpt:  [737.36 Kelem/s 752.34 Kelem/s 764.64 Kelem/s]
+transactional_batch_write/storage_batched_nodes_edges
+                        time:   [13.819 ms 14.150 ms 14.554 ms]
+                        thrpt:  [687.09 Kelem/s 706.72 Kelem/s 723.63 Kelem/s]
+
+  => ~parity at the session layer. HONEST FINDING: per-row WAL logging (which the
+     contract REQUIRES us to preserve identically) dominates the session-level
+     cost and masks the storage-layer win at this 10k-row scale. The batch path
+     does NOT reduce WAL record count — it emits the same CreateNode/SetNodeProperty/
+     CreateEdge/SetEdgeProperty stream as the row path (correctness-preserving).
+
+## Interpretation vs plan §5 (4x gate)
+
+The plan's 4x gate applies to the AMLabs WritePlan apply phases
+(validate/purge/entities/facts/commit/finalize) measured in W1-DELTA-PROOF /
+Wave 2 on the ~46k-row fixture — NOT to this upstream primitive in isolation.
+This packet delivers and proves the real storage-level batch primitive (1.33x
+storage-only). The session-level parity is expected because WAL is preserved
+per-row by contract; further session-level speedup would require WAL batching,
+which is out of this packet's locked scope and would change durability semantics.

--- a/crates/grafeo-cli/src/commands/data.rs
+++ b/crates/grafeo-cli/src/commands/data.rs
@@ -66,7 +66,7 @@ pub fn run(cmd: DataCommands, _format: OutputFormat, quiet: bool) -> Result<()> 
                             .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
                             .unwrap_or_default();
 
-                        let id = db.create_node(&labels);
+                        let id = db.create_node(&labels)?;
 
                         if let Some(props) = record.get("properties").and_then(|p| p.as_object()) {
                             for (key, val) in props {

--- a/crates/grafeo-common/src/memory/buffer/manager.rs
+++ b/crates/grafeo-common/src/memory/buffer/manager.rs
@@ -1,6 +1,6 @@
 //! Unified buffer manager implementation.
 
-use super::consumer::MemoryConsumer;
+use super::consumer::{MemoryConsumer, SpillError};
 use super::grant::{GrantReleaser, MemoryGrant};
 use super::region::MemoryRegion;
 use super::stats::{BufferStats, PressureLevel};
@@ -361,6 +361,32 @@ impl BufferManager {
             "tier transition: spill"
         );
         total_freed
+    }
+
+    /// Reloads all OnDisk consumers whose name equals `name`, ignoring the
+    /// automatic reload budget. This is used by durability boundaries that must
+    /// materialize a complete authoritative snapshot before serialization.
+    ///
+    /// Returns the number of matching consumers reloaded. The first reload
+    /// failure is returned so snapshot callers can fail closed.
+    pub fn reload_consumer_by_name(&self, name: &str) -> Result<usize, SpillError> {
+        let candidates: Vec<Arc<dyn MemoryConsumer>> = self
+            .consumers
+            .read()
+            .iter()
+            .filter(|consumer| {
+                consumer.name() == name
+                    && consumer.current_tier() == super::tiered::StorageTier::OnDisk
+            })
+            .map(Arc::clone)
+            .collect();
+
+        let mut reloaded = 0;
+        for consumer in candidates {
+            consumer.reload()?;
+            reloaded += 1;
+        }
+        Ok(reloaded)
     }
 
     /// Reloads OnDisk consumers back into RAM, in priority order (highest

--- a/crates/grafeo-common/src/memory/mod.rs
+++ b/crates/grafeo-common/src/memory/mod.rs
@@ -27,4 +27,7 @@ pub use buffer::{
 pub use bump::BumpAllocator;
 pub use pool::ObjectPool;
 pub use reporter::MemoryReporter;
-pub use usage::{IndexMemory, MvccMemory, NamedMemory, StoreMemory, StringPoolMemory};
+pub use usage::{
+    AdjacencyCapacityMemory, IndexMemory, LpgResidencyMemory, MvccMemory, NamedMemory,
+    PropertyColumnMemory, PropertyStorageMemory, StoreMemory, StringPoolMemory,
+};

--- a/crates/grafeo-common/src/memory/usage.rs
+++ b/crates/grafeo-common/src/memory/usage.rs
@@ -20,6 +20,30 @@ pub struct StoreMemory {
     pub edge_properties_bytes: usize,
     /// Number of property columns (node + edge).
     pub property_column_count: usize,
+    /// Hash-map slot bytes for node property columns (capacity × entry).
+    #[serde(default)]
+    pub node_property_map_slot_bytes: usize,
+    /// Decoded `Value` payload bytes inside node property columns (strings/lists/…).
+    #[serde(default)]
+    pub node_property_decoded_payload_bytes: usize,
+    /// String/bytes payload subset of node property decoded values.
+    #[serde(default)]
+    pub node_property_string_payload_bytes: usize,
+    /// Unused map capacity waste in node property columns.
+    #[serde(default)]
+    pub node_property_capacity_waste_bytes: usize,
+    /// Hash-map slot bytes for edge property columns.
+    #[serde(default)]
+    pub edge_property_map_slot_bytes: usize,
+    /// Decoded `Value` payload bytes inside edge property columns.
+    #[serde(default)]
+    pub edge_property_decoded_payload_bytes: usize,
+    /// String/bytes payload subset of edge property decoded values.
+    #[serde(default)]
+    pub edge_property_string_payload_bytes: usize,
+    /// Unused map capacity waste in edge property columns.
+    #[serde(default)]
+    pub edge_property_capacity_waste_bytes: usize,
 }
 
 impl StoreMemory {
@@ -32,6 +56,139 @@ impl StoreMemory {
     }
 }
 
+/// Per-column residency attribution for one property key.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PropertyColumnMemory {
+    /// Property key name.
+    pub key: String,
+    /// Live entries in the hot map.
+    pub entry_count: usize,
+    /// Hot map capacity (buckets reserved).
+    pub map_capacity: usize,
+    /// `capacity × (Id + Value + 1)` slot estimate.
+    pub map_slot_bytes: usize,
+    /// Sum of [`crate::types::Value::estimated_size_bytes`] over hot values.
+    pub decoded_payload_bytes: usize,
+    /// String + bytes payload subset of decoded values.
+    pub string_payload_bytes: usize,
+    /// Compressed column backing (0 when uncompressed).
+    pub compressed_bytes: usize,
+    /// `(capacity − len) × entry` waste in the hot map.
+    pub capacity_waste_bytes: usize,
+    /// Values held only in compressed form (not in the hot map).
+    pub compressed_entry_count: usize,
+}
+
+impl PropertyColumnMemory {
+    /// Estimated total for this column (slots + payloads + compressed).
+    #[must_use]
+    pub fn total_bytes(&self) -> usize {
+        self.map_slot_bytes + self.decoded_payload_bytes + self.compressed_bytes
+    }
+}
+
+/// Aggregated property-storage residency (node or edge side).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PropertyStorageMemory {
+    /// Outer column-map overhead.
+    pub map_overhead_bytes: usize,
+    /// Per-column breakdown (sorted by `total_bytes` descending when produced).
+    pub columns: Vec<PropertyColumnMemory>,
+    /// Sum of column map-slot bytes.
+    pub total_map_slot_bytes: usize,
+    /// Sum of decoded payloads.
+    pub total_decoded_payload_bytes: usize,
+    /// Sum of string/bytes payloads.
+    pub total_string_payload_bytes: usize,
+    /// Sum of compressed backings.
+    pub total_compressed_bytes: usize,
+    /// Sum of hot-map capacity waste.
+    pub total_capacity_waste_bytes: usize,
+    /// `map_overhead + Σ column totals`.
+    pub total_bytes: usize,
+}
+
+impl PropertyStorageMemory {
+    /// Recomputes aggregate totals from columns + outer map overhead.
+    pub fn compute_total(&mut self) {
+        self.total_map_slot_bytes = self.columns.iter().map(|c| c.map_slot_bytes).sum();
+        self.total_decoded_payload_bytes =
+            self.columns.iter().map(|c| c.decoded_payload_bytes).sum();
+        self.total_string_payload_bytes =
+            self.columns.iter().map(|c| c.string_payload_bytes).sum();
+        self.total_compressed_bytes = self.columns.iter().map(|c| c.compressed_bytes).sum();
+        self.total_capacity_waste_bytes =
+            self.columns.iter().map(|c| c.capacity_waste_bytes).sum();
+        self.total_bytes = self.map_overhead_bytes
+            + self.total_map_slot_bytes
+            + self.total_decoded_payload_bytes
+            + self.total_compressed_bytes;
+    }
+}
+
+/// Adjacency list capacity vs used-byte attribution.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AdjacencyCapacityMemory {
+    /// Nodes with an adjacency list.
+    pub node_count: usize,
+    /// Outer list-map capacity.
+    pub list_map_capacity: usize,
+    /// Outer list-map overhead bytes.
+    pub list_map_overhead_bytes: usize,
+    /// Bytes occupied by live hot entries (destinations + edge ids used len).
+    pub hot_used_bytes: usize,
+    /// Bytes reserved by hot chunk Vec capacities.
+    pub hot_capacity_bytes: usize,
+    /// Compressed cold-chunk bytes.
+    pub cold_bytes: usize,
+    /// Delta / deleted / skip-index reserved bytes.
+    pub aux_capacity_bytes: usize,
+    /// `hot_capacity − hot_used` (+ list map slack approximated separately).
+    pub capacity_waste_bytes: usize,
+    /// Total estimated heap (`list_map_overhead + hot_capacity + cold + aux`).
+    pub total_bytes: usize,
+}
+
+impl AdjacencyCapacityMemory {
+    /// Recomputes `capacity_waste_bytes` and `total_bytes`.
+    pub fn compute_total(&mut self) {
+        self.capacity_waste_bytes = self.hot_capacity_bytes.saturating_sub(self.hot_used_bytes);
+        self.total_bytes = self.list_map_overhead_bytes
+            + self.hot_capacity_bytes
+            + self.cold_bytes
+            + self.aux_capacity_bytes;
+    }
+}
+
+/// Full LPG residency attribution (properties + adjacency capacities).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LpgResidencyMemory {
+    /// Node property columns.
+    pub node_properties: PropertyStorageMemory,
+    /// Edge property columns.
+    pub edge_properties: PropertyStorageMemory,
+    /// Forward adjacency capacity detail.
+    pub forward_adjacency: AdjacencyCapacityMemory,
+    /// Backward adjacency capacity detail (empty when disabled).
+    pub backward_adjacency: AdjacencyCapacityMemory,
+    /// Sum of property + adjacency totals.
+    pub total_bytes: usize,
+}
+
+impl LpgResidencyMemory {
+    /// Recomputes `total_bytes` from children.
+    pub fn compute_total(&mut self) {
+        self.node_properties.compute_total();
+        self.edge_properties.compute_total();
+        self.forward_adjacency.compute_total();
+        self.backward_adjacency.compute_total();
+        self.total_bytes = self.node_properties.total_bytes
+            + self.edge_properties.total_bytes
+            + self.forward_adjacency.total_bytes
+            + self.backward_adjacency.total_bytes;
+    }
+}
+
 /// Memory used by index structures.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct IndexMemory {
@@ -41,6 +198,12 @@ pub struct IndexMemory {
     pub forward_adjacency_bytes: usize,
     /// Backward adjacency lists (0 if disabled).
     pub backward_adjacency_bytes: usize,
+    /// Forward adjacency capacity waste (`capacity − used` on hot chunks).
+    #[serde(default)]
+    pub forward_adjacency_capacity_waste_bytes: usize,
+    /// Backward adjacency capacity waste.
+    #[serde(default)]
+    pub backward_adjacency_capacity_waste_bytes: usize,
     /// Label index (label_id -> node set).
     pub label_index_bytes: usize,
     /// Node-to-labels reverse index.

--- a/crates/grafeo-common/src/mvcc.rs
+++ b/crates/grafeo-common/src/mvcc.rs
@@ -44,11 +44,13 @@ impl VersionInfo {
         self.deleted_by = Some(deleted_by);
     }
 
-    /// Unmarks deletion if deleted by the given transaction. Returns `true` if undeleted.
+    /// Unmarks deletion if deleted by the given transaction while still pending.
     ///
-    /// Used during rollback to restore versions deleted within the rolled-back transaction.
+    /// Returns `true` if undeleted. Committed deletions (non-`PENDING`
+    /// `deleted_epoch`) are left untouched even when `deleted_by` coincides
+    /// with a later recycled transaction id.
     pub fn unmark_deleted_by(&mut self, transaction_id: TransactionId) -> bool {
-        if self.deleted_by == Some(transaction_id) {
+        if self.deleted_by == Some(transaction_id) && self.deleted_epoch == Some(EpochId::PENDING) {
             self.deleted_epoch = None;
             self.deleted_by = None;
             true
@@ -219,14 +221,30 @@ impl<T> VersionChain<T> {
         self.versions.iter().any(|v| v.info.deleted_by == Some(tx))
     }
 
-    /// Removes all versions created by the given transaction.
+    /// Returns `true` when every version is an uncommitted create by `tx`.
     ///
-    /// Used for rollback to discard uncommitted changes.
-    pub fn remove_versions_by(&mut self, tx: TransactionId) {
-        self.versions.retain(|v| v.info.created_by != tx);
+    /// Used by rollback to detect entities created inside the active
+    /// transaction. Matching requires `created_epoch == PENDING` so a recycled
+    /// transaction id cannot treat already-committed versions as disposable.
+    #[must_use]
+    pub fn solely_created_by(&self, tx: TransactionId) -> bool {
+        !self.versions.is_empty()
+            && self
+                .versions
+                .iter()
+                .all(|v| v.info.created_by == tx && v.info.created_epoch == EpochId::PENDING)
     }
 
-    /// Finalizes PENDING epochs for versions created by the given transaction.
+    /// Removes uncommitted versions created by the given transaction.
+    ///
+    /// Only `PENDING` creates are discarded. Committed versions that happen to
+    /// share `created_by` after transaction-manager recreation are preserved.
+    pub fn remove_versions_by(&mut self, tx: TransactionId) {
+        self.versions
+            .retain(|v| !(v.info.created_by == tx && v.info.created_epoch == EpochId::PENDING));
+    }
+
+    /// Finalizes PENDING epochs for versions created or deleted by the given transaction.
     ///
     /// Called at commit time to make uncommitted versions visible at the
     /// real commit epoch instead of `EpochId::PENDING`.
@@ -236,6 +254,11 @@ impl<T> VersionChain<T> {
                 && version.info.created_epoch == EpochId::PENDING
             {
                 version.info.created_epoch = commit_epoch;
+            }
+            if version.info.deleted_by == Some(transaction_id)
+                && version.info.deleted_epoch == Some(EpochId::PENDING)
+            {
+                version.info.deleted_epoch = Some(commit_epoch);
             }
         }
     }
@@ -376,19 +399,27 @@ impl OptionalEpochId {
     /// Represents no epoch (deleted_epoch = None).
     pub const NONE: Self = Self(u32::MAX);
 
+    /// Compact encoding of [`EpochId::PENDING`] for uncommitted deletions.
+    ///
+    /// Real epochs use `0..u32::MAX-1`; `u32::MAX` is [`NONE`].
+    const PENDING_CODE: u32 = u32::MAX - 1;
+
     /// Creates an `OptionalEpochId` from an epoch.
     ///
     /// # Panics
-    /// Panics if epoch exceeds u32::MAX - 1 (4,294,967,294).
+    /// Panics if a non-PENDING epoch exceeds `u32::MAX - 2` (4,294,967,293).
     #[must_use]
     pub fn some(epoch: EpochId) -> Self {
+        if epoch == EpochId::PENDING {
+            return Self(Self::PENDING_CODE);
+        }
         assert!(
-            epoch.as_u64() < u64::from(u32::MAX),
+            epoch.as_u64() < u64::from(Self::PENDING_CODE),
             "epoch {} exceeds OptionalEpochId capacity (max {})",
             epoch.as_u64(),
-            u32::MAX as u64 - 1
+            u64::from(Self::PENDING_CODE) - 1
         );
-        // reason: the assert above guarantees epoch < u32::MAX
+        // reason: the assert above guarantees epoch < PENDING_CODE
         #[allow(clippy::cast_possible_truncation)]
         Self(epoch.as_u64() as u32)
     }
@@ -399,6 +430,8 @@ impl OptionalEpochId {
     pub fn get(self) -> Option<EpochId> {
         if self.0 == u32::MAX {
             None
+        } else if self.0 == Self::PENDING_CODE {
+            Some(EpochId::PENDING)
         } else {
             Some(EpochId::new(u64::from(self.0)))
         }
@@ -415,6 +448,13 @@ impl OptionalEpochId {
     #[must_use]
     pub fn is_none(self) -> bool {
         self.0 == u32::MAX
+    }
+
+    /// Returns `true` when this encodes an uncommitted (`PENDING`) deletion.
+    #[inline]
+    #[must_use]
+    pub fn is_pending(self) -> bool {
+        self.0 == Self::PENDING_CODE
     }
 }
 
@@ -481,9 +521,9 @@ impl HotVersionRef {
         self.deleted_by = Some(deleted_by);
     }
 
-    /// Unmarks deletion if deleted by the given transaction. Returns `true` if undeleted.
+    /// Unmarks a pending deletion by the given transaction. Returns `true` if undeleted.
     pub fn unmark_deleted_by(&mut self, transaction_id: TransactionId) -> bool {
-        if self.deleted_by == Some(transaction_id) {
+        if self.deleted_by == Some(transaction_id) && self.deleted_epoch.is_pending() {
             self.deleted_epoch = OptionalEpochId::NONE;
             self.deleted_by = None;
             true
@@ -779,7 +819,7 @@ impl VersionIndex {
         false
     }
 
-    /// Unmarks deletion for versions deleted by the given transaction.
+    /// Unmarks pending deletion for versions deleted by the given transaction.
     ///
     /// Returns `true` if any version was undeleted. Used during rollback.
     pub fn unmark_deleted_by(&mut self, tx: TransactionId) -> bool {
@@ -790,7 +830,7 @@ impl VersionIndex {
             }
         }
         for v in &mut self.cold {
-            if v.deleted_by == Some(tx) {
+            if v.deleted_by == Some(tx) && v.deleted_epoch.is_pending() {
                 v.deleted_epoch = OptionalEpochId::NONE;
                 v.deleted_by = None;
                 any_undeleted = true;
@@ -812,14 +852,32 @@ impl VersionIndex {
             || self.cold.iter().any(|v| v.deleted_by == Some(tx))
     }
 
-    /// Removes all versions created by the given transaction (for rollback).
+    /// Returns `true` when every version is an uncommitted create by `tx`.
+    ///
+    /// See [`VersionChain::solely_created_by`] for the rollback-cleanup contract.
+    #[must_use]
+    pub fn solely_created_by(&self, tx: TransactionId) -> bool {
+        !self.is_empty()
+            && self
+                .hot
+                .iter()
+                .all(|v| v.created_by == tx && v.epoch == EpochId::PENDING)
+            && self
+                .cold
+                .iter()
+                .all(|v| v.created_by == tx && v.epoch == EpochId::PENDING)
+    }
+
+    /// Removes uncommitted (`PENDING`) versions created by the given transaction.
     pub fn remove_versions_by(&mut self, tx: TransactionId) {
-        self.hot.retain(|v| v.created_by != tx);
-        self.cold.retain(|v| v.created_by != tx);
+        self.hot
+            .retain(|v| !(v.created_by == tx && v.epoch == EpochId::PENDING));
+        self.cold
+            .retain(|v| !(v.created_by == tx && v.epoch == EpochId::PENDING));
         self.recalculate_latest_epoch();
     }
 
-    /// Finalizes PENDING epochs for hot versions created by the given transaction.
+    /// Finalizes PENDING create/delete epochs for versions owned by the transaction.
     ///
     /// Called at commit time to make uncommitted versions visible at the
     /// real commit epoch instead of `EpochId::PENDING`.
@@ -827,6 +885,17 @@ impl VersionIndex {
         for v in &mut self.hot {
             if v.created_by == transaction_id && v.epoch == EpochId::PENDING {
                 v.epoch = commit_epoch;
+            }
+            if v.deleted_by == Some(transaction_id) && v.deleted_epoch.is_pending() {
+                v.deleted_epoch = OptionalEpochId::some(commit_epoch);
+            }
+        }
+        for v in &mut self.cold {
+            if v.created_by == transaction_id && v.epoch == EpochId::PENDING {
+                v.epoch = commit_epoch;
+            }
+            if v.deleted_by == Some(transaction_id) && v.deleted_epoch.is_pending() {
+                v.deleted_epoch = OptionalEpochId::some(commit_epoch);
             }
         }
         self.recalculate_latest_epoch();
@@ -1052,16 +1121,61 @@ mod tests {
     #[test]
     fn test_version_chain_rollback() {
         let mut chain = VersionChain::with_initial("v1", EpochId::new(1), TransactionId::new(1));
-        chain.add_version("v2", EpochId::new(5), TransactionId::new(2));
-        chain.add_version("v3", EpochId::new(6), TransactionId::new(2));
+        chain.add_version("v2", EpochId::PENDING, TransactionId::new(2));
+        chain.add_version("v3", EpochId::PENDING, TransactionId::new(2));
 
         assert_eq!(chain.version_count(), 3);
 
-        // Rollback tx 2's changes
+        // Rollback tx 2's PENDING changes
         chain.remove_versions_by(TransactionId::new(2));
 
         assert_eq!(chain.version_count(), 1);
         assert_eq!(chain.visible_at(EpochId::new(10)), Some(&"v1"));
+    }
+
+    #[test]
+    fn test_version_chain_rollback_ignores_committed_same_tx_id() {
+        let tx = TransactionId::new(7);
+        let mut chain = VersionChain::with_initial("committed", EpochId::new(3), tx);
+        // Simulate transaction-manager recreation reusing the same id while a
+        // prior committed version still carries that created_by.
+        assert!(!chain.solely_created_by(tx));
+        chain.remove_versions_by(tx);
+        assert_eq!(chain.version_count(), 1);
+        assert_eq!(chain.visible_at(EpochId::new(3)), Some(&"committed"));
+
+        chain.add_version("pending", EpochId::PENDING, tx);
+        assert!(chain.solely_created_by(tx) == false); // mixed committed + pending
+        // Only the PENDING create is discarded.
+        chain.remove_versions_by(tx);
+        assert_eq!(chain.version_count(), 1);
+        assert_eq!(chain.visible_at(EpochId::new(3)), Some(&"committed"));
+    }
+
+    #[test]
+    fn test_version_chain_unmark_requires_pending_delete() {
+        let tx = TransactionId::new(9);
+        let mut chain = VersionChain::with_initial("v1", EpochId::new(1), TransactionId::new(1));
+        chain.mark_deleted(EpochId::new(5), tx);
+        // Committed-style delete epoch must not roll back via tx-id coincidence.
+        assert!(!chain.unmark_deleted_by(tx));
+        assert!(chain.deleted_by(tx));
+
+        let mut pending = VersionChain::with_initial("v1", EpochId::new(1), TransactionId::new(1));
+        pending.mark_deleted(EpochId::PENDING, tx);
+        assert!(pending.unmark_deleted_by(tx));
+        assert!(!pending.deleted_by(tx));
+        assert_eq!(pending.visible_at(EpochId::new(10)), Some(&"v1"));
+    }
+
+    #[test]
+    fn test_version_chain_solely_created_requires_pending() {
+        let tx = TransactionId::new(3);
+        let pending = VersionChain::with_initial("p", EpochId::PENDING, tx);
+        assert!(pending.solely_created_by(tx));
+
+        let committed = VersionChain::with_initial("c", EpochId::new(2), tx);
+        assert!(!committed.solely_created_by(tx));
     }
 
     #[test]
@@ -1210,14 +1324,14 @@ mod tiered_storage_tests {
         let mut index = VersionIndex::new();
         index.add_hot(HotVersionRef::new(EpochId::new(1), EpochId::new(1), 0, tx1));
         index.add_hot(HotVersionRef::new(
-            EpochId::new(2),
+            EpochId::PENDING,
             EpochId::new(2),
             100,
             tx2,
         ));
         index.add_hot(HotVersionRef::new(
-            EpochId::new(3),
-            EpochId::new(3),
+            EpochId::PENDING,
+            EpochId::new(2),
             200,
             tx2,
         ));
@@ -1226,7 +1340,7 @@ mod tiered_storage_tests {
         assert!(index.modified_by(tx1));
         assert!(index.modified_by(tx2));
 
-        // Rollback tx2's changes
+        // Rollback tx2's PENDING changes
         index.remove_versions_by(tx2);
 
         assert_eq!(index.version_count(), 1);
@@ -1236,6 +1350,52 @@ mod tiered_storage_tests {
         // Should only see tx1's version
         let v = index.visible_at(EpochId::new(10)).unwrap();
         assert!(matches!(v, VersionRef::Hot(h) if h.created_by == tx1));
+    }
+
+    #[test]
+    fn test_version_index_rollback_ignores_committed_same_tx_id() {
+        let tx = TransactionId::new(42);
+        let mut index = VersionIndex::new();
+        index.add_hot(HotVersionRef::new(EpochId::new(3), EpochId::new(3), 0, tx));
+        assert!(!index.solely_created_by(tx));
+        index.remove_versions_by(tx);
+        assert_eq!(index.version_count(), 1);
+
+        index.add_hot(HotVersionRef::new(
+            EpochId::PENDING,
+            EpochId::new(4),
+            50,
+            tx,
+        ));
+        index.remove_versions_by(tx);
+        assert_eq!(index.version_count(), 1);
+        let v = index.visible_at(EpochId::new(3)).unwrap();
+        assert!(matches!(v, VersionRef::Hot(h) if h.epoch == EpochId::new(3)));
+    }
+
+    #[test]
+    fn test_version_index_unmark_requires_pending_delete() {
+        let tx = TransactionId::new(9);
+        let mut index = VersionIndex::new();
+        index.add_hot(HotVersionRef::new(
+            EpochId::new(1),
+            EpochId::new(1),
+            0,
+            TransactionId::new(1),
+        ));
+        assert!(index.mark_deleted(EpochId::new(5), tx));
+        assert!(!index.unmark_deleted_by(tx));
+
+        let mut pending = VersionIndex::new();
+        pending.add_hot(HotVersionRef::new(
+            EpochId::new(1),
+            EpochId::new(1),
+            0,
+            TransactionId::new(1),
+        ));
+        assert!(pending.mark_deleted(EpochId::PENDING, tx));
+        assert!(pending.unmark_deleted_by(tx));
+        assert!(!pending.deleted_by(tx));
     }
 
     #[test]
@@ -1396,14 +1556,14 @@ mod tiered_storage_tests {
         assert_eq!(index.latest_epoch(), EpochId::new(5));
 
         index.add_hot(HotVersionRef::new(
-            EpochId::new(10),
+            EpochId::PENDING,
             EpochId::new(10),
             100,
             TransactionId::new(2),
         ));
-        assert_eq!(index.latest_epoch(), EpochId::new(10));
+        assert_eq!(index.latest_epoch(), EpochId::PENDING);
 
-        // After rollback, should recalculate
+        // After rollback of the PENDING create, should recalculate
         index.remove_versions_by(TransactionId::new(2));
         assert_eq!(index.latest_epoch(), EpochId::new(5));
     }

--- a/crates/grafeo-common/src/types/value.rs
+++ b/crates/grafeo-common/src/types/value.rs
@@ -425,6 +425,28 @@ impl Value {
             }
         }
     }
+
+    /// String / bytes payload bytes only (subset of [`Self::estimated_size_bytes`]).
+    ///
+    /// Used by LPG residency accounting to attribute ArcStr/bytes separately
+    /// from map-slot and compressed-column bytes. Nested lists/maps recurse.
+    #[must_use]
+    pub fn string_payload_bytes(&self) -> usize {
+        match self {
+            Value::String(s) => s.len(),
+            Value::Bytes(b) => b.len(),
+            Value::List(items) => items.iter().map(Value::string_payload_bytes).sum(),
+            Value::Map(m) => m
+                .iter()
+                .map(|(k, v)| k.as_ref().len() + v.string_payload_bytes())
+                .sum(),
+            Value::Path { nodes, edges } => {
+                nodes.iter().map(Value::string_payload_bytes).sum::<usize>()
+                    + edges.iter().map(Value::string_payload_bytes).sum::<usize>()
+            }
+            _ => 0,
+        }
+    }
 }
 
 impl fmt::Debug for Value {

--- a/crates/grafeo-core/src/graph/lpg/mod.rs
+++ b/crates/grafeo-core/src/graph/lpg/mod.rs
@@ -33,4 +33,5 @@ pub use property::{CompareOp, PropertyStorage};
 #[cfg(feature = "lpg")]
 pub use section::LpgStoreSection;
 #[cfg(feature = "lpg")]
+pub use store::batch_ops::{BatchEdgeCreate, BatchNodeCreate};
 pub use store::{LpgStore, PropertyUndoEntry};

--- a/crates/grafeo-core/src/graph/lpg/property.rs
+++ b/crates/grafeo-core/src/graph/lpg/property.rs
@@ -294,6 +294,17 @@ impl<Id: EntityId> PropertyStorage<Id> {
         }
     }
 
+    /// Shrinks hot-map capacities on every column to fit live entries.
+    ///
+    /// Does not change logical contents. Useful after bulk deserialize or
+    /// after eviction to reclaim HashMap capacity waste.
+    pub fn shrink_capacities(&self) {
+        let mut columns = self.columns.write();
+        for col in columns.values_mut() {
+            col.shrink_capacities();
+        }
+    }
+
     /// Returns compression statistics for all columns.
     #[must_use]
     pub fn compression_stats(&self) -> FxHashMap<PropertyKey, CompressionStats> {
@@ -317,13 +328,34 @@ impl<Id: EntityId> PropertyStorage<Id> {
     /// Returns estimated heap memory for all columns including hash map overhead.
     #[must_use]
     pub fn heap_memory_bytes(&self) -> usize {
+        self.memory_detail().total_bytes
+    }
+
+    /// Detailed residency attribution for every property column.
+    #[must_use]
+    pub fn memory_detail(&self) -> grafeo_common::memory::PropertyStorageMemory {
+        use grafeo_common::memory::PropertyStorageMemory;
+
         let columns = self.columns.read();
-        // Outer hash map capacity
         let map_overhead = columns.capacity()
             * (std::mem::size_of::<PropertyKey>() + std::mem::size_of::<PropertyColumn<Id>>() + 1);
-        // Sum of all column heap memory
-        let column_bytes: usize = columns.values().map(|col| col.heap_memory_bytes()).sum();
-        map_overhead + column_bytes
+        let mut detail = PropertyStorageMemory {
+            map_overhead_bytes: map_overhead,
+            columns: columns
+                .iter()
+                .map(|(key, col)| {
+                    let mut m = col.memory_detail();
+                    m.key = key.as_ref().to_string();
+                    m
+                })
+                .collect(),
+            ..Default::default()
+        };
+        detail
+            .columns
+            .sort_by(|a, b| b.total_bytes().cmp(&a.total_bytes()));
+        detail.compute_total();
+        detail
     }
 
     /// Gets a property value for an entity.
@@ -1069,7 +1101,7 @@ impl<Id: EntityId> PropertyColumn<Id> {
     /// Gets a value for an entity.
     ///
     /// First checks the hot buffer (uncompressed values), then falls back
-    /// to the compressed data if present.
+    /// to compressed storage with on-demand (lazy) decode when present.
     #[must_use]
     pub fn get(&self, id: Id) -> Option<Value> {
         // First check hot buffer
@@ -1077,11 +1109,49 @@ impl<Id: EntityId> PropertyColumn<Id> {
             return Some(value.clone());
         }
 
-        // For now, compressed data lookup is not implemented for sparse access
-        // because the compressed format stores values by index, not by entity ID.
-        // This would require maintaining an ID -> index map in CompressedColumnData.
-        // The compressed data is primarily useful for bulk/scan operations.
-        None
+        self.get_compressed(id)
+    }
+
+    /// Lazy point lookup into compressed column data.
+    ///
+    /// `index_to_id` is sorted by entity id (see compress paths). Binary
+    /// search finds the compressed-array index; strings/bools decode one
+    /// value; integers decompress the whole column once per miss (acceptable
+    /// for sparse correctness; scan paths should use block decode instead).
+    fn get_compressed(&self, id: Id) -> Option<Value> {
+        let compressed = self.compressed.as_ref()?;
+        let id_u64 = id.as_u64();
+        match compressed {
+            CompressedColumnData::Strings {
+                encoding,
+                index_to_id,
+                ..
+            } => {
+                let idx = index_to_id.binary_search(&id_u64).ok()?;
+                encoding
+                    .get(idx)
+                    .map(|s| Value::String(ArcStr::from(s)))
+            }
+            CompressedColumnData::Booleans {
+                data,
+                index_to_id,
+                ..
+            } => {
+                let idx = index_to_id.binary_search(&id_u64).ok()?;
+                let values = TypeSpecificCompressor::decompress_booleans(data).ok()?;
+                values.get(idx).copied().map(Value::Bool)
+            }
+            CompressedColumnData::Integers {
+                data,
+                index_to_id,
+                ..
+            } => {
+                let idx = index_to_id.binary_search(&id_u64).ok()?;
+                let values = TypeSpecificCompressor::decompress_integers(data).ok()?;
+                let raw = *values.get(idx)?;
+                Some(Value::Int64(crate::codec::zigzag_decode(raw)))
+            }
+        }
     }
 
     /// Removes a value for an entity.
@@ -1194,17 +1264,49 @@ impl<Id: EntityId> PropertyColumn<Id> {
 
     /// Returns estimated heap memory for this column.
     ///
-    /// Includes the hot buffer hash map capacity, zone map, and any
-    /// compressed data.
+    /// Includes hot-map slot capacity, decoded `Value` payloads (strings,
+    /// lists, …), and any compressed backing.
     #[must_use]
     pub fn heap_memory_bytes(&self) -> usize {
-        // Hot buffer: FxHashMap<Id, Value> capacity
-        let hot_bytes =
-            self.values.capacity() * (std::mem::size_of::<Id>() + std::mem::size_of::<Value>() + 1);
-        // Compressed data
+        self.memory_detail().total_bytes()
+    }
+
+    /// Detailed residency attribution for this column (key left empty).
+    #[must_use]
+    pub fn memory_detail(&self) -> grafeo_common::memory::PropertyColumnMemory {
+        use grafeo_common::memory::PropertyColumnMemory;
+
+        let entry_size =
+            std::mem::size_of::<Id>() + std::mem::size_of::<Value>() + 1;
+        let map_slot_bytes = self.values.capacity() * entry_size;
+        let capacity_waste_bytes =
+            self.values.capacity().saturating_sub(self.values.len()) * entry_size;
+        let decoded_payload_bytes: usize = self
+            .values
+            .values()
+            .map(Value::estimated_size_bytes)
+            .sum();
+        let string_payload_bytes: usize =
+            self.values.values().map(Value::string_payload_bytes).sum();
         let compressed_bytes = self.compressed.as_ref().map_or(0, |c| c.memory_usage());
-        // ZoneMapEntry is inline (no heap), so just hot + compressed
-        hot_bytes + compressed_bytes
+
+        PropertyColumnMemory {
+            key: String::new(),
+            entry_count: self.values.len(),
+            map_capacity: self.values.capacity(),
+            map_slot_bytes,
+            decoded_payload_bytes,
+            string_payload_bytes,
+            compressed_bytes,
+            capacity_waste_bytes,
+            compressed_entry_count: self.compressed_count,
+        }
+    }
+
+    /// Shrinks the hot map capacity to fit live entries.
+    pub fn shrink_capacities(&mut self) {
+        self.values.shrink_to_fit();
+        self.block_zone_maps.shrink_to_fit();
     }
 
     /// Returns whether the column has compressed data.
@@ -1789,8 +1891,45 @@ impl<Id: EntityId> PropertyColumn<Id> {
     /// Returns estimated heap memory for this column.
     #[must_use]
     pub fn heap_memory_bytes(&self) -> usize {
-        self.values.capacity()
-            * (std::mem::size_of::<Id>() + std::mem::size_of::<VersionLog<Value>>() + 1)
+        self.memory_detail().total_bytes()
+    }
+
+    /// Detailed residency attribution (temporal: version-log slots + latest payloads).
+    #[must_use]
+    pub fn memory_detail(&self) -> grafeo_common::memory::PropertyColumnMemory {
+        use grafeo_common::memory::PropertyColumnMemory;
+
+        let entry_size =
+            std::mem::size_of::<Id>() + std::mem::size_of::<VersionLog<Value>>() + 1;
+        let map_slot_bytes = self.values.capacity() * entry_size;
+        let capacity_waste_bytes =
+            self.values.capacity().saturating_sub(self.values.len()) * entry_size;
+        let mut decoded_payload_bytes = 0usize;
+        let mut string_payload_bytes = 0usize;
+        for log in self.values.values() {
+            if let Some(v) = log.latest() {
+                decoded_payload_bytes += v.estimated_size_bytes();
+                string_payload_bytes += v.string_payload_bytes();
+            }
+        }
+
+        PropertyColumnMemory {
+            key: String::new(),
+            entry_count: self.values.len(),
+            map_capacity: self.values.capacity(),
+            map_slot_bytes,
+            decoded_payload_bytes,
+            string_payload_bytes,
+            compressed_bytes: 0,
+            capacity_waste_bytes,
+            compressed_entry_count: 0,
+        }
+    }
+
+    /// Shrinks the hot map capacity to fit live entries.
+    pub fn shrink_capacities(&mut self) {
+        self.values.shrink_to_fit();
+        self.block_zone_maps.shrink_to_fit();
     }
 
     /// Compression is not supported in temporal mode (no-op).

--- a/crates/grafeo-core/src/graph/lpg/property.rs
+++ b/crates/grafeo-core/src/graph/lpg/property.rs
@@ -189,6 +189,26 @@ impl<Id: EntityId> PropertyStorage<Id> {
             .set(id, value);
     }
 
+    /// Appends properties for a fresh bulk load while holding the column map
+    /// lock once.  Callers must not use this for an online mutation: it does
+    /// not update secondary indexes or transaction undo state.
+    #[cfg(not(feature = "temporal"))]
+    pub fn set_bulk_unindexed<I>(&self, rows: I)
+    where
+        I: IntoIterator<Item = (Id, FxHashMap<PropertyKey, Value>)>,
+    {
+        let mut columns = self.columns.write();
+        let mode = self.default_compression;
+        for (id, properties) in rows {
+            for (key, value) in properties {
+                columns
+                    .entry(key)
+                    .or_insert_with(|| PropertyColumn::with_compression(mode))
+                    .set(id, value);
+            }
+        }
+    }
+
     /// Sets a property value for an entity at a specific epoch.
     ///
     /// For non-transactional writes, pass the current epoch.

--- a/crates/grafeo-core/src/graph/lpg/property.rs
+++ b/crates/grafeo-core/src/graph/lpg/property.rs
@@ -1082,15 +1082,15 @@ impl<Id: EntityId> PropertyColumn<Id> {
 
     /// Restores values into this column after a reload from disk.
     ///
-    /// Clears the `spilled` flag. Callers are responsible for providing
-    /// the correct values (from `MmapStorage::export_all()` or similar).
+    /// Clears the `spilled` flag. Existing hot values win over the mmap
+    /// snapshot because they are inserts or updates written after the spill.
     pub fn restore_values(&mut self, values: impl Iterator<Item = (Id, Value)>) {
         self.spilled = false;
-        // Insert directly into the map without calling set(), which would
-        // re-increment zone map counters (row_count, null_count) on top of
-        // the already-preserved zone map from before eviction.
+        // Insert directly without re-incrementing zone map counters. Preserve
+        // mutable post-spill deltas instead of overwriting them with stale mmap
+        // values for the same entity.
         for (id, value) in values {
-            self.values.insert(id, value);
+            self.values.entry(id).or_insert(value);
         }
     }
 

--- a/crates/grafeo-core/src/graph/lpg/property.rs
+++ b/crates/grafeo-core/src/graph/lpg/property.rs
@@ -209,6 +209,51 @@ impl<Id: EntityId> PropertyStorage<Id> {
         }
     }
 
+    /// Sets many property values across many entities while holding the column
+    /// map write lock exactly once.
+    ///
+    /// This is the storage-level primitive behind transactional batch node/edge
+    /// creation: the row-oriented [`set`](Self::set) re-acquires the column map
+    /// write lock for every single property, which dominates cost on wide
+    /// batches. Each row is `(entity_id, key, value)`. Columns are created
+    /// lazily with the storage's default compression mode, exactly as `set`
+    /// does. Callers remain responsible for secondary-index and transaction
+    /// undo bookkeeping; this only writes column values.
+    #[cfg(not(feature = "temporal"))]
+    pub fn set_batch<I>(&self, rows: I)
+    where
+        I: IntoIterator<Item = (Id, PropertyKey, Value)>,
+    {
+        let mut columns = self.columns.write();
+        let mode = self.default_compression;
+        for (id, key, value) in rows {
+            columns
+                .entry(key)
+                .or_insert_with(|| PropertyColumn::with_compression(mode))
+                .set(id, value);
+        }
+    }
+
+    /// Sets many property values across many entities at a specific epoch while
+    /// holding the column map write lock exactly once (temporal variant).
+    ///
+    /// Pass `EpochId::PENDING` for transactional writes so the values stay
+    /// invisible until commit finalizes them, matching [`set`](Self::set).
+    #[cfg(feature = "temporal")]
+    pub fn set_batch<I>(&self, rows: I, epoch: EpochId)
+    where
+        I: IntoIterator<Item = (Id, PropertyKey, Value)>,
+    {
+        let mut columns = self.columns.write();
+        let mode = self.default_compression;
+        for (id, key, value) in rows {
+            columns
+                .entry(key)
+                .or_insert_with(|| PropertyColumn::with_compression(mode))
+                .set(id, value, epoch);
+        }
+    }
+
     /// Sets a property value for an entity at a specific epoch.
     ///
     /// For non-transactional writes, pass the current epoch.

--- a/crates/grafeo-core/src/graph/lpg/store/batch_ops.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/batch_ops.rs
@@ -1,0 +1,110 @@
+//! Storage-level transactional batch node/edge creation.
+//!
+//! This module defines the provider-neutral batch DTOs and the shared helpers
+//! behind `Session::create_nodes_with_props_transactional` /
+//! `create_edges_with_props_transactional`. The storage-backend-specific
+//! `LpgStore` impls live in sibling modules to keep each file small:
+//!
+//! - [`batch_ops_lpg`] — non-tiered (`VersionChain`) store;
+//! - [`batch_ops_tiered`] — tiered arena/`VersionIndex` store.
+//!
+//! Unlike the row-oriented `create_node_with_props_versioned` /
+//! `create_edge_versioned` paths — which re-acquire every `RwLock` (nodes/edges
+//! map, label registry, label index, node labels, adjacency, edge-type tables,
+//! property column map) once per row — the batch entry points hoist each of
+//! those locks to **once per batch** and allocate the ID range with a single
+//! atomic. That is the difference between a genuine storage-level batch and a
+//! loop wrapped in a batch-shaped API.
+//!
+//! Correctness contract (mirrors the row path exactly, so commit/rollback need
+//! no batch-specific logic):
+//! - every record is versioned under `transaction_id` with `EpochId::PENDING`
+//!   visibility when a real transaction is active (`SYSTEM` otherwise), so the
+//!   transaction-wide `finalize_version_epochs` / `discard_uncommitted_versions`
+//!   scans make the whole batch visible on commit and remove it on rollback;
+//! - label, property, edge-type and adjacency secondary structures are updated
+//!   identically to the row path; `discard_uncommitted_versions` erases those
+//!   secondary entries for entities whose version chains become empty;
+//! - returned IDs preserve input order.
+//!
+//! These methods never touch the offline/unindexed bulk loaders.
+
+use grafeo_common::types::{EdgeId, EpochId, NodeId, PropertyKey, TransactionId, Value};
+
+/// A node to create within a storage-level batch.
+///
+/// Provider-neutral: the engine layer builds these from its public DTOs.
+/// `properties` is owned so the batch can hoist the property-column lock.
+pub struct BatchNodeCreate<'a> {
+    /// Labels applied to the node.
+    pub labels: &'a [&'a str],
+    /// Property key/value pairs, written in order.
+    pub properties: Vec<(PropertyKey, Value)>,
+}
+
+/// An edge to create within a storage-level batch.
+pub struct BatchEdgeCreate<'a> {
+    /// Source node.
+    pub source: NodeId,
+    /// Target node.
+    pub target: NodeId,
+    /// Edge type name.
+    pub edge_type: &'a str,
+    /// Property key/value pairs, written in order.
+    pub properties: Vec<(PropertyKey, Value)>,
+}
+
+/// Visibility epoch for a batch row: `PENDING` under a real transaction so it
+/// stays invisible until commit, the real epoch for `SYSTEM` (auto-commit).
+pub(super) fn version_epoch_for(transaction_id: TransactionId, epoch: EpochId) -> EpochId {
+    if transaction_id == TransactionId::SYSTEM {
+        epoch
+    } else {
+        EpochId::PENDING
+    }
+}
+
+/// Counts distinct property keys (matches `get_all().len()` used by the row
+/// path to compute `props_count`). Only the non-tiered store writes
+/// `props_count` back onto the record.
+#[cfg(not(feature = "tiered-storage"))]
+pub(super) fn distinct_key_count(properties: &[(PropertyKey, Value)]) -> usize {
+    use grafeo_common::utils::hash::FxHashSet;
+    let mut seen = FxHashSet::default();
+    for (key, _) in properties {
+        seen.insert(key.clone());
+    }
+    seen.len()
+}
+
+/// Flattens node batch inputs into `(node_id, key, value)` property rows in
+/// input order, for the hoisted property-column write.
+pub(super) fn build_node_prop_rows(
+    nodes: &[BatchNodeCreate<'_>],
+    ids: &[NodeId],
+) -> Vec<(NodeId, PropertyKey, Value)> {
+    let total: usize = nodes.iter().map(|n| n.properties.len()).sum();
+    let mut rows = Vec::with_capacity(total);
+    for (node, &id) in nodes.iter().zip(ids.iter()) {
+        for (key, value) in &node.properties {
+            rows.push((id, key.clone(), value.clone()));
+        }
+    }
+    rows
+}
+
+/// Flattens edge batch inputs into `(edge_id, key, value)` property rows in
+/// input order, for the hoisted property-column write.
+pub(super) fn build_edge_prop_rows(
+    edges: &[BatchEdgeCreate<'_>],
+    ids: &[EdgeId],
+) -> Vec<(EdgeId, PropertyKey, Value)> {
+    let total: usize = edges.iter().map(|e| e.properties.len()).sum();
+    let mut rows = Vec::with_capacity(total);
+    for (edge, &id) in edges.iter().zip(ids.iter()) {
+        for (key, value) in &edge.properties {
+            rows.push((id, key.clone(), value.clone()));
+        }
+    }
+    rows
+}

--- a/crates/grafeo-core/src/graph/lpg/store/batch_ops_lpg.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/batch_ops_lpg.rs
@@ -1,0 +1,227 @@
+//! Non-tiered (`VersionChain`) implementation of the storage-level batch.
+//!
+//! Split from [`super::batch_ops`] to keep each file under the ~400 LOC budget.
+//! The tiered-storage counterpart lives in `batch_ops_tiered.rs`; both share the
+//! DTOs and helper functions defined in `batch_ops.rs`. See that module's docs
+//! for the lock-hoisting and MVCC contract.
+
+#![cfg(not(feature = "tiered-storage"))]
+
+use super::LpgStore;
+use super::batch_ops::{
+    BatchEdgeCreate, BatchNodeCreate, build_edge_prop_rows, build_node_prop_rows,
+    distinct_key_count, version_epoch_for,
+};
+use crate::graph::lpg::{EdgeRecord, NodeRecord};
+use arcstr::ArcStr;
+use grafeo_common::mvcc::VersionChain;
+#[cfg(feature = "temporal")]
+use grafeo_common::temporal::VersionLog;
+use grafeo_common::types::{
+    EdgeId, EpochId, HashableValue, NodeId, PropertyKey, TransactionId, Value,
+};
+use grafeo_common::utils::hash::FxHashSet;
+use std::sync::atomic::Ordering;
+
+impl LpgStore {
+    /// Creates many nodes in one storage-level batch under a transaction
+    /// context, returning the new IDs in input order.
+    ///
+    /// See the `batch_ops` module docs for the lock-hoisting and MVCC contract.
+    pub fn create_nodes_batch_versioned(
+        &self,
+        nodes: &[BatchNodeCreate<'_>],
+        epoch: EpochId,
+        transaction_id: TransactionId,
+    ) -> Vec<NodeId> {
+        let count = nodes.len();
+        if count == 0 {
+            return Vec::new();
+        }
+        let version_epoch = version_epoch_for(transaction_id, epoch);
+
+        // One atomic for the whole ID range.
+        let base = self.next_node_id.fetch_add(count as u64, Ordering::Relaxed);
+        let ids: Vec<NodeId> = (base..base + count as u64).map(NodeId::new).collect();
+
+        // Resolve every label ID under a single registry write lock.
+        let per_node_label_ids = self.resolve_label_ids_batch(nodes);
+
+        // Label index: one write lock for all nodes.
+        {
+            let mut index = self.label_index.write();
+            for (label_ids, &id) in per_node_label_ids.iter().zip(ids.iter()) {
+                for &label_id in label_ids {
+                    if index.len() <= label_id as usize {
+                        index.resize_with(label_id as usize + 1, Default::default);
+                    }
+                    index[label_id as usize].insert(id, ());
+                }
+            }
+        }
+
+        // Node->labels reverse map: one write lock for all nodes.
+        {
+            let mut node_labels = self.node_labels.write();
+            for (label_ids, &id) in per_node_label_ids.iter().zip(ids.iter()) {
+                let set: FxHashSet<u32> = label_ids.iter().copied().collect();
+                #[cfg(not(feature = "temporal"))]
+                node_labels.insert(id, set);
+                #[cfg(feature = "temporal")]
+                node_labels.insert(id, VersionLog::with_value(version_epoch, set));
+            }
+        }
+
+        // Version chains: one nodes-map write lock for all records. props_count
+        // is set on the record up front (distinct key count) so we never revisit
+        // the map after writing properties.
+        {
+            let mut nodes_map = self.nodes.write();
+            for (node, &id) in nodes.iter().zip(ids.iter()) {
+                let mut record = NodeRecord::new(id, epoch);
+                // reason: label/prop counts per node are bounded, fit u16
+                #[allow(clippy::cast_possible_truncation)]
+                {
+                    record.set_label_count(node.labels.len() as u16);
+                    record.props_count = distinct_key_count(&node.properties) as u16;
+                }
+                let chain = VersionChain::with_initial(record, version_epoch, transaction_id);
+                nodes_map.insert(id, chain);
+            }
+        }
+        // reason: batch size bounded by practical graph limits, fits i64
+        #[allow(clippy::cast_possible_wrap)]
+        let count_i64 = count as i64;
+        self.live_node_count.fetch_add(count_i64, Ordering::Relaxed);
+
+        // Properties + secondary property indexes, locks hoisted.
+        let prop_rows = build_node_prop_rows(nodes, &ids);
+        self.apply_node_property_index_batch(&prop_rows);
+        #[cfg(not(feature = "temporal"))]
+        self.node_properties.set_batch(prop_rows);
+        #[cfg(feature = "temporal")]
+        self.node_properties.set_batch(prop_rows, epoch);
+
+        ids
+    }
+
+    /// Creates many edges in one storage-level batch under a transaction
+    /// context, returning the new IDs in input order.
+    pub fn create_edges_batch_versioned(
+        &self,
+        edges: &[BatchEdgeCreate<'_>],
+        epoch: EpochId,
+        transaction_id: TransactionId,
+    ) -> Vec<EdgeId> {
+        let count = edges.len();
+        if count == 0 {
+            return Vec::new();
+        }
+        let version_epoch = version_epoch_for(transaction_id, epoch);
+
+        let base = self.next_edge_id.fetch_add(count as u64, Ordering::Relaxed);
+        let ids: Vec<EdgeId> = (base..base + count as u64).map(EdgeId::new).collect();
+
+        // Resolve edge-type IDs and bump per-type live counts under single locks.
+        let type_ids = self.resolve_edge_type_ids_and_count_batch(edges);
+
+        // Version chains: one edges-map write lock for all records.
+        {
+            let mut edges_map = self.edges.write();
+            for ((edge, &type_id), &id) in edges.iter().zip(type_ids.iter()).zip(ids.iter()) {
+                let record = EdgeRecord::new(id, edge.source, edge.target, type_id, epoch);
+                let chain = VersionChain::with_initial(record, version_epoch, transaction_id);
+                edges_map.insert(id, chain);
+            }
+        }
+
+        // Adjacency: one lock per direction for the whole batch.
+        let adj_rows: Vec<(NodeId, NodeId, EdgeId)> = edges
+            .iter()
+            .zip(ids.iter())
+            .map(|(e, &id)| (e.source, e.target, id))
+            .collect();
+        self.forward_adj.batch_add_edges(&adj_rows);
+        if let Some(ref backward) = self.backward_adj {
+            let back_rows: Vec<(NodeId, NodeId, EdgeId)> =
+                adj_rows.iter().map(|&(s, d, id)| (d, s, id)).collect();
+            backward.batch_add_edges(&back_rows);
+        }
+        // reason: batch size bounded by practical graph limits, fits i64
+        #[allow(clippy::cast_possible_wrap)]
+        let count_i64 = count as i64;
+        self.live_edge_count.fetch_add(count_i64, Ordering::Relaxed);
+
+        // Edge properties (edges are not property-indexed; no props_count on record).
+        let prop_rows = build_edge_prop_rows(edges, &ids);
+        #[cfg(not(feature = "temporal"))]
+        self.edge_properties.set_batch(prop_rows);
+        #[cfg(feature = "temporal")]
+        self.edge_properties.set_batch(prop_rows, epoch);
+
+        ids
+    }
+
+    /// Resolves all label IDs for a node batch under one registry write lock.
+    fn resolve_label_ids_batch(&self, nodes: &[BatchNodeCreate<'_>]) -> Vec<Vec<u32>> {
+        let mut per_node = Vec::with_capacity(nodes.len());
+        let mut registry = self.label_registry.write();
+        for node in nodes {
+            let mut ids = Vec::with_capacity(node.labels.len());
+            for label in node.labels {
+                ids.push(registry.get_or_create(label));
+            }
+            per_node.push(ids);
+        }
+        per_node
+    }
+
+    /// Applies secondary property-index inserts for freshly created nodes while
+    /// holding the property-index map read lock once. Fresh nodes have no prior
+    /// value, so this is insert-only (matches `update_property_index_on_set`).
+    fn apply_node_property_index_batch(&self, rows: &[(NodeId, PropertyKey, Value)]) {
+        let indexes = self.property_indexes.read();
+        if indexes.is_empty() {
+            return;
+        }
+        for (id, key, value) in rows {
+            if let Some(index) = indexes.get(key) {
+                let hv = HashableValue::new(value.clone());
+                index.entry(hv).or_default().insert(*id);
+            }
+        }
+    }
+
+    /// Resolves edge-type IDs for a batch and increments per-type live counts,
+    /// holding the type tables and count vector write locks once each.
+    ///
+    /// Lock order respected: `edge_type_to_id`/`id_to_edge_type` (level 4) then
+    /// `edge_type_live_counts` (level 8), matching the row path's acquisition.
+    fn resolve_edge_type_ids_and_count_batch(&self, edges: &[BatchEdgeCreate<'_>]) -> Vec<u32> {
+        let mut type_ids = Vec::with_capacity(edges.len());
+        let mut type_to_id = self.edge_type_to_id.write();
+        let mut id_to_type = self.id_to_edge_type.write();
+        let mut counts = self.edge_type_live_counts.write();
+        for edge in edges {
+            let id = if let Some(&id) = type_to_id.get(edge.edge_type) {
+                id
+            } else {
+                // reason: edge type registry size bounded, fits u32
+                #[allow(clippy::cast_possible_truncation)]
+                let id = id_to_type.len() as u32;
+                let t: ArcStr = edge.edge_type.into();
+                type_to_id.insert(t.clone(), id);
+                id_to_type.push(t);
+                while counts.len() <= id as usize {
+                    counts.push(0);
+                }
+                id
+            };
+            type_ids.push(id);
+        }
+        for &type_id in &type_ids {
+            counts[type_id as usize] += 1;
+        }
+        type_ids
+    }
+}

--- a/crates/grafeo-core/src/graph/lpg/store/batch_ops_tiered.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/batch_ops_tiered.rs
@@ -1,0 +1,218 @@
+//! Tiered-storage implementation of the storage-level batch.
+//!
+//! Split from [`super::batch_ops`] to keep each file under the ~400 LOC budget.
+//! The tiered store keeps records in a per-epoch arena and metadata in a version
+//! index. Arena allocation is inherently per-record, but the version-index write
+//! lock is still hoisted to once per batch (vs once per row in the row path).
+//! Shares the DTOs and helper functions defined in `batch_ops.rs`.
+
+#![cfg(feature = "tiered-storage")]
+
+use super::LpgStore;
+use super::batch_ops::{
+    BatchEdgeCreate, BatchNodeCreate, build_edge_prop_rows, build_node_prop_rows, version_epoch_for,
+};
+use crate::graph::lpg::{EdgeRecord, NodeRecord};
+use arcstr::ArcStr;
+use grafeo_common::mvcc::{HotVersionRef, VersionIndex};
+#[cfg(feature = "temporal")]
+use grafeo_common::temporal::VersionLog;
+use grafeo_common::types::{
+    EdgeId, EpochId, HashableValue, NodeId, PropertyKey, TransactionId, Value,
+};
+use grafeo_common::utils::hash::FxHashSet;
+use std::sync::atomic::Ordering;
+
+impl LpgStore {
+    /// Tiered-storage variant of
+    /// [`create_nodes_batch_versioned`](LpgStore::create_nodes_batch_versioned).
+    pub fn create_nodes_batch_versioned(
+        &self,
+        nodes: &[BatchNodeCreate<'_>],
+        epoch: EpochId,
+        transaction_id: TransactionId,
+    ) -> Vec<NodeId> {
+        let count = nodes.len();
+        if count == 0 {
+            return Vec::new();
+        }
+        let version_epoch = version_epoch_for(transaction_id, epoch);
+        let base = self.next_node_id.fetch_add(count as u64, Ordering::Relaxed);
+        let ids: Vec<NodeId> = (base..base + count as u64).map(NodeId::new).collect();
+
+        let per_node_label_ids = self.resolve_label_ids_batch(nodes);
+        {
+            let mut index = self.label_index.write();
+            for (label_ids, &id) in per_node_label_ids.iter().zip(ids.iter()) {
+                for &label_id in label_ids {
+                    if index.len() <= label_id as usize {
+                        index.resize_with(label_id as usize + 1, Default::default);
+                    }
+                    index[label_id as usize].insert(id, ());
+                }
+            }
+        }
+        {
+            let mut node_labels = self.node_labels.write();
+            for (label_ids, &id) in per_node_label_ids.iter().zip(ids.iter()) {
+                let set: FxHashSet<u32> = label_ids.iter().copied().collect();
+                #[cfg(not(feature = "temporal"))]
+                node_labels.insert(id, set);
+                #[cfg(feature = "temporal")]
+                node_labels.insert(id, VersionLog::with_value(version_epoch, set));
+            }
+        }
+
+        // Allocate records in the epoch arena, then insert all version refs
+        // under one version-index write lock.
+        let arena = self
+            .arena_allocator
+            .arena_or_create(epoch)
+            .expect("failed to create arena for epoch");
+        let mut versions = self.node_versions.write();
+        for (node, &id) in nodes.iter().zip(ids.iter()) {
+            let mut record = NodeRecord::new(id, epoch);
+            #[allow(clippy::cast_possible_truncation)]
+            record.set_label_count(node.labels.len() as u16);
+            let (offset, _stored) = arena
+                .alloc_value_with_offset(record)
+                .expect("arena allocation failed for node record");
+            let hot_ref = HotVersionRef::new(version_epoch, epoch, offset, transaction_id);
+            if let Some(index) = versions.get_mut(&id) {
+                index.add_hot(hot_ref);
+            } else {
+                versions.insert(id, VersionIndex::with_initial(hot_ref));
+            }
+        }
+        drop(versions);
+        // reason: batch size bounded by practical graph limits, fits i64
+        #[allow(clippy::cast_possible_wrap)]
+        let count_i64 = count as i64;
+        self.live_node_count.fetch_add(count_i64, Ordering::Relaxed);
+
+        let prop_rows = build_node_prop_rows(nodes, &ids);
+        self.apply_node_property_index_batch(&prop_rows);
+        #[cfg(not(feature = "temporal"))]
+        self.node_properties.set_batch(prop_rows);
+        #[cfg(feature = "temporal")]
+        self.node_properties.set_batch(prop_rows, epoch);
+
+        ids
+    }
+
+    /// Tiered-storage variant of
+    /// [`create_edges_batch_versioned`](LpgStore::create_edges_batch_versioned).
+    pub fn create_edges_batch_versioned(
+        &self,
+        edges: &[BatchEdgeCreate<'_>],
+        epoch: EpochId,
+        transaction_id: TransactionId,
+    ) -> Vec<EdgeId> {
+        let count = edges.len();
+        if count == 0 {
+            return Vec::new();
+        }
+        let version_epoch = version_epoch_for(transaction_id, epoch);
+        let base = self.next_edge_id.fetch_add(count as u64, Ordering::Relaxed);
+        let ids: Vec<EdgeId> = (base..base + count as u64).map(EdgeId::new).collect();
+
+        let type_ids = self.resolve_edge_type_ids_and_count_batch(edges);
+
+        let arena = self
+            .arena_allocator
+            .arena_or_create(epoch)
+            .expect("failed to create arena for epoch");
+        let mut versions = self.edge_versions.write();
+        for ((edge, &type_id), &id) in edges.iter().zip(type_ids.iter()).zip(ids.iter()) {
+            let record = EdgeRecord::new(id, edge.source, edge.target, type_id, epoch);
+            let (offset, _stored) = arena
+                .alloc_value_with_offset(record)
+                .expect("arena allocation failed for edge record");
+            let hot_ref = HotVersionRef::new(version_epoch, epoch, offset, transaction_id);
+            if let Some(index) = versions.get_mut(&id) {
+                index.add_hot(hot_ref);
+            } else {
+                versions.insert(id, VersionIndex::with_initial(hot_ref));
+            }
+        }
+        drop(versions);
+
+        let adj_rows: Vec<(NodeId, NodeId, EdgeId)> = edges
+            .iter()
+            .zip(ids.iter())
+            .map(|(e, &id)| (e.source, e.target, id))
+            .collect();
+        self.forward_adj.batch_add_edges(&adj_rows);
+        if let Some(ref backward) = self.backward_adj {
+            let back_rows: Vec<(NodeId, NodeId, EdgeId)> =
+                adj_rows.iter().map(|&(s, d, id)| (d, s, id)).collect();
+            backward.batch_add_edges(&back_rows);
+        }
+        // reason: batch size bounded by practical graph limits, fits i64
+        #[allow(clippy::cast_possible_wrap)]
+        let count_i64 = count as i64;
+        self.live_edge_count.fetch_add(count_i64, Ordering::Relaxed);
+
+        let prop_rows = build_edge_prop_rows(edges, &ids);
+        #[cfg(not(feature = "temporal"))]
+        self.edge_properties.set_batch(prop_rows);
+        #[cfg(feature = "temporal")]
+        self.edge_properties.set_batch(prop_rows, epoch);
+
+        ids
+    }
+
+    fn resolve_label_ids_batch(&self, nodes: &[BatchNodeCreate<'_>]) -> Vec<Vec<u32>> {
+        let mut per_node = Vec::with_capacity(nodes.len());
+        let mut registry = self.label_registry.write();
+        for node in nodes {
+            let mut ids = Vec::with_capacity(node.labels.len());
+            for label in node.labels {
+                ids.push(registry.get_or_create(label));
+            }
+            per_node.push(ids);
+        }
+        per_node
+    }
+
+    fn apply_node_property_index_batch(&self, rows: &[(NodeId, PropertyKey, Value)]) {
+        let indexes = self.property_indexes.read();
+        if indexes.is_empty() {
+            return;
+        }
+        for (id, key, value) in rows {
+            if let Some(index) = indexes.get(key) {
+                let hv = HashableValue::new(value.clone());
+                index.entry(hv).or_default().insert(*id);
+            }
+        }
+    }
+
+    fn resolve_edge_type_ids_and_count_batch(&self, edges: &[BatchEdgeCreate<'_>]) -> Vec<u32> {
+        let mut type_ids = Vec::with_capacity(edges.len());
+        let mut type_to_id = self.edge_type_to_id.write();
+        let mut id_to_type = self.id_to_edge_type.write();
+        let mut counts = self.edge_type_live_counts.write();
+        for edge in edges {
+            let id = if let Some(&id) = type_to_id.get(edge.edge_type) {
+                id
+            } else {
+                // reason: edge type registry size bounded, fits u32
+                #[allow(clippy::cast_possible_truncation)]
+                let id = id_to_type.len() as u32;
+                let t: ArcStr = edge.edge_type.into();
+                type_to_id.insert(t.clone(), id);
+                id_to_type.push(t);
+                while counts.len() <= id as usize {
+                    counts.push(0);
+                }
+                id
+            };
+            type_ids.push(id);
+        }
+        for &type_id in &type_ids {
+            counts[type_id as usize] += 1;
+        }
+        type_ids
+    }
+}

--- a/crates/grafeo-core/src/graph/lpg/store/edge_ops.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/edge_ops.rs
@@ -485,8 +485,9 @@ impl LpgStore {
                 }
             };
 
-            // Mark deleted with transaction tracking
-            chain.mark_deleted(epoch, transaction_id);
+            // Uncommitted deletes use PENDING so rollback matching stays
+            // epoch-safe after transaction-id reuse.
+            chain.mark_deleted(EpochId::PENDING, transaction_id);
             drop(edges);
 
             // Get edge type name for undo log
@@ -563,8 +564,9 @@ impl LpgStore {
                 }
             };
 
-            // Mark deleted with transaction tracking
-            index.mark_deleted(epoch, transaction_id);
+            // Uncommitted deletes use PENDING so rollback matching stays
+            // epoch-safe after transaction-id reuse.
+            index.mark_deleted(EpochId::PENDING, transaction_id);
             drop(versions);
 
             // Get edge type name for undo log

--- a/crates/grafeo-core/src/graph/lpg/store/memory.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/memory.rs
@@ -1,7 +1,9 @@
 //! Memory introspection for `LpgStore`.
 
 use super::LpgStore;
-use grafeo_common::memory::usage::{IndexMemory, MvccMemory, StoreMemory, StringPoolMemory};
+use grafeo_common::memory::usage::{
+    IndexMemory, LpgResidencyMemory, MvccMemory, StoreMemory, StringPoolMemory,
+};
 use std::mem::size_of;
 
 impl LpgStore {
@@ -19,9 +21,50 @@ impl LpgStore {
         (store, indexes, mvcc, string_pool)
     }
 
+    /// Property-column / string-payload / adjacency-capacity residency detail.
+    ///
+    /// Closes the `memory_usage()` blind spot where map-slot estimates omitted
+    /// decoded `Value` heap (especially ArcStr) and adjacency capacity waste.
+    #[must_use]
+    pub fn lpg_residency_detail(&self) -> LpgResidencyMemory {
+        let mut detail = LpgResidencyMemory {
+            node_properties: self.node_properties.memory_detail(),
+            edge_properties: self.edge_properties.memory_detail(),
+            forward_adjacency: self.forward_adj.capacity_memory(),
+            backward_adjacency: self
+                .backward_adj
+                .as_ref()
+                .map_or_else(Default::default, |adj| adj.capacity_memory()),
+            ..Default::default()
+        };
+        detail.compute_total();
+        detail
+    }
+
+    /// Shrinks property-column and adjacency Vec/HashMap capacities in place.
+    ///
+    /// Does not change logical graph contents. Intended for residency
+    /// experiments after bulk open/deserialize.
+    pub fn shrink_lpg_capacities(&self) {
+        self.node_properties.shrink_capacities();
+        self.edge_properties.shrink_capacities();
+        self.forward_adj.shrink_capacities();
+        if let Some(adj) = &self.backward_adj {
+            adj.shrink_capacities();
+        }
+    }
+
+    /// Forces dictionary/int/bool compression on all property columns.
+    ///
+    /// Point reads remain correct via lazy compressed `get` decode.
+    pub fn force_compress_properties(&self) {
+        self.node_properties.force_compress_all();
+        self.edge_properties.force_compress_all();
+    }
+
     fn store_memory(&self) -> StoreMemory {
-        let node_props_bytes = self.node_properties.heap_memory_bytes();
-        let edge_props_bytes = self.edge_properties.heap_memory_bytes();
+        let node_detail = self.node_properties.memory_detail();
+        let edge_detail = self.edge_properties.memory_detail();
         let col_count = self.node_properties.column_count() + self.edge_properties.column_count();
 
         // Node/edge map overhead (excluding version chain internals, which go to MVCC)
@@ -57,9 +100,17 @@ impl LpgStore {
         let mut store = StoreMemory {
             nodes_bytes,
             edges_bytes,
-            node_properties_bytes: node_props_bytes,
-            edge_properties_bytes: edge_props_bytes,
+            node_properties_bytes: node_detail.total_bytes,
+            edge_properties_bytes: edge_detail.total_bytes,
             property_column_count: col_count,
+            node_property_map_slot_bytes: node_detail.total_map_slot_bytes,
+            node_property_decoded_payload_bytes: node_detail.total_decoded_payload_bytes,
+            node_property_string_payload_bytes: node_detail.total_string_payload_bytes,
+            node_property_capacity_waste_bytes: node_detail.total_capacity_waste_bytes,
+            edge_property_map_slot_bytes: edge_detail.total_map_slot_bytes,
+            edge_property_decoded_payload_bytes: edge_detail.total_decoded_payload_bytes,
+            edge_property_string_payload_bytes: edge_detail.total_string_payload_bytes,
+            edge_property_capacity_waste_bytes: edge_detail.total_capacity_waste_bytes,
             ..Default::default()
         };
         store.compute_total();
@@ -136,11 +187,15 @@ impl LpgStore {
     }
 
     fn index_memory(&self) -> IndexMemory {
-        let forward_bytes = self.forward_adj.heap_memory_bytes();
-        let backward_bytes = self
+        let forward_detail = self.forward_adj.capacity_memory();
+        let backward_detail = self
             .backward_adj
             .as_ref()
-            .map_or(0, |adj| adj.heap_memory_bytes());
+            .map(|adj| adj.capacity_memory());
+        let forward_bytes = forward_detail.total_bytes;
+        let backward_bytes = backward_detail
+            .as_ref()
+            .map_or(0, |d| d.total_bytes);
 
         // Label index: Vec<FxHashMap<NodeId, ()>>
         let label_idx = self.label_index.read();
@@ -231,6 +286,10 @@ impl LpgStore {
         let mut indexes = IndexMemory {
             forward_adjacency_bytes: forward_bytes,
             backward_adjacency_bytes: backward_bytes,
+            forward_adjacency_capacity_waste_bytes: forward_detail.capacity_waste_bytes,
+            backward_adjacency_capacity_waste_bytes: backward_detail
+                .as_ref()
+                .map_or(0, |d| d.capacity_waste_bytes),
             label_index_bytes,
             node_labels_bytes,
             property_index_bytes,

--- a/crates/grafeo-core/src/graph/lpg/store/mod.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/mod.rs
@@ -9,12 +9,18 @@
 //! - Columnar properties with zone maps for fast filtering
 //! - Forward and backward adjacency indexes
 
+pub mod batch_ops;
+#[cfg(not(feature = "tiered-storage"))]
+mod batch_ops_lpg;
+#[cfg(feature = "tiered-storage")]
+mod batch_ops_tiered;
 mod edge_ops;
 mod graph_store_impl;
 mod index;
 mod memory;
 mod node_ops;
 mod property_ops;
+mod rollback_cleanup;
 mod schema;
 mod search;
 mod statistics;

--- a/crates/grafeo-core/src/graph/lpg/store/node_ops.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/node_ops.rs
@@ -700,8 +700,9 @@ impl LpgStore {
                 return false;
             }
 
-            // Mark deleted with transaction tracking
-            chain.mark_deleted(epoch, transaction_id);
+            // Uncommitted deletes use PENDING so rollback matching stays
+            // epoch-safe after transaction-id reuse.
+            chain.mark_deleted(EpochId::PENDING, transaction_id);
 
             // Capture labels for undo log
             let registry = self.label_registry.read();
@@ -806,8 +807,9 @@ impl LpgStore {
                 return false;
             }
 
-            // Mark deleted with transaction tracking
-            index.mark_deleted(epoch, transaction_id);
+            // Uncommitted deletes use PENDING so rollback matching stays
+            // epoch-safe after transaction-id reuse.
+            index.mark_deleted(EpochId::PENDING, transaction_id);
 
             // Capture labels for undo log
             let registry = self.label_registry.read();

--- a/crates/grafeo-core/src/graph/lpg/store/node_ops.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/node_ops.rs
@@ -30,8 +30,11 @@ impl LpgStore {
             return Err("bulk node load requires no property indexes");
         }
         #[cfg(feature = "vector-index")]
-        if !self.vector_indexes.read().is_empty() {
-            return Err("bulk node load requires no vector indexes");
+        if self.vector_indexes.read().keys().any(|key| {
+            key.strip_prefix(label)
+                .is_some_and(|suffix| suffix.starts_with(':'))
+        }) {
+            return Err("bulk node load requires no vector indexes for its label");
         }
         #[cfg(feature = "text-index")]
         if !self.text_indexes.read().is_empty() {

--- a/crates/grafeo-core/src/graph/lpg/store/node_ops.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/node_ops.rs
@@ -11,6 +11,72 @@ use grafeo_common::mvcc::VersionChain;
 use grafeo_common::mvcc::{HotVersionRef, VersionIndex, VersionRef};
 
 impl LpgStore {
+    /// Appends homogeneous-label nodes to a fresh store without per-node lock
+    /// acquisition, WAL, CDC, or secondary-index maintenance.
+    ///
+    /// This is deliberately an offline-loader primitive.  It is valid only
+    /// before property, text, or vector indexes are installed and before the
+    /// store becomes visible to concurrent readers.
+    #[cfg(not(any(feature = "tiered-storage", feature = "temporal")))]
+    pub fn bulk_create_nodes_with_props_unindexed(
+        &self,
+        label: &str,
+        properties_list: Vec<FxHashMap<PropertyKey, Value>>,
+    ) -> Result<Vec<NodeId>, &'static str> {
+        if properties_list.is_empty() {
+            return Ok(Vec::new());
+        }
+        if !self.property_indexes.read().is_empty() {
+            return Err("bulk node load requires no property indexes");
+        }
+        #[cfg(feature = "vector-index")]
+        if !self.vector_indexes.read().is_empty() {
+            return Err("bulk node load requires no vector indexes");
+        }
+        #[cfg(feature = "text-index")]
+        if !self.text_indexes.read().is_empty() {
+            return Err("bulk node load requires no text indexes");
+        }
+
+        let count = properties_list.len();
+        let base_id = self.next_node_id.fetch_add(count as u64, Ordering::Relaxed);
+        let epoch = self.current_epoch();
+        let label_id = self.get_or_create_label_id(label);
+        let mut label_set = FxHashSet::default();
+        label_set.insert(label_id);
+
+        let mut ids = Vec::with_capacity(count);
+        let mut property_rows = Vec::with_capacity(count);
+        let mut label_index = self.label_index.write();
+        if label_index.len() <= label_id as usize {
+            label_index.resize_with(label_id as usize + 1, FxHashMap::default);
+        }
+        let mut node_labels = self.node_labels.write();
+        let mut nodes = self.nodes.write();
+        for (offset, properties) in properties_list.into_iter().enumerate() {
+            let id = NodeId::new(base_id + offset as u64);
+            let mut record = NodeRecord::new(id, epoch);
+            record.set_label_count(1);
+            record.props_count = u16::try_from(properties.len()).unwrap_or(u16::MAX);
+            nodes.insert(
+                id,
+                VersionChain::with_initial(record, epoch, TransactionId::SYSTEM),
+            );
+            label_index[label_id as usize].insert(id, ());
+            node_labels.insert(id, label_set.clone());
+            ids.push(id);
+            property_rows.push((id, properties));
+        }
+        drop(nodes);
+        drop(node_labels);
+        drop(label_index);
+
+        self.node_properties.set_bulk_unindexed(property_rows);
+        self.live_node_count
+            .fetch_add(count as i64, Ordering::Relaxed);
+        Ok(ids)
+    }
+
     /// Creates a new node with the given labels.
     ///
     /// Uses the system transaction for non-transactional operations.

--- a/crates/grafeo-core/src/graph/lpg/store/rollback_cleanup.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/rollback_cleanup.rs
@@ -1,0 +1,220 @@
+//! Secondary-structure cleanup for transaction rollback.
+//!
+//! `discard_uncommitted_versions` removes PENDING primary version chains, but
+//! create paths (row and batch) also eagerly publish into non-versioned
+//! secondary structures: `label_index`, `node_labels`, property columns /
+//! indexes, adjacency, edge-type live counts, and live counters. The W1
+//! contract requires those staged entries to disappear on rollback rather than
+//! remaining as filtered-but-orphaned residue.
+//!
+//! This module walks entities that were *created* inside the rolled-back
+//! transaction (their version chain becomes empty) and erases the matching
+//! secondary state. Property/label *mutations* on pre-existing entities remain
+//! covered by the property undo log.
+
+use super::LpgStore;
+use grafeo_common::types::{EdgeId, HashableValue, NodeId, PropertyKey, TransactionId};
+use std::sync::atomic::Ordering;
+
+/// Edge identity needed to reverse adjacency / type-count publication.
+#[derive(Clone, Copy)]
+pub(super) struct DiscardedEdge {
+    pub id: EdgeId,
+    pub src: NodeId,
+    pub dst: NodeId,
+    pub type_id: u32,
+}
+
+impl LpgStore {
+    /// Removes every secondary structure entry published for nodes that were
+    /// created inside `transaction_id` and are therefore fully discarded.
+    pub(super) fn cleanup_discarded_node_secondaries(&self, node_ids: &[NodeId]) {
+        if node_ids.is_empty() {
+            return;
+        }
+
+        // Capture label sets and property maps before tearing anything down.
+        let label_sets: Vec<(NodeId, Vec<u32>)> = {
+            let labels = self.node_labels.read();
+            node_ids
+                .iter()
+                .filter_map(|&id| {
+                    #[cfg(not(feature = "temporal"))]
+                    let set = labels.get(&id)?;
+                    #[cfg(feature = "temporal")]
+                    let set = labels.get(&id)?.latest()?;
+                    Some((id, set.iter().copied().collect()))
+                })
+                .collect()
+        };
+
+        let prop_maps: Vec<(NodeId, Vec<(PropertyKey, grafeo_common::types::Value)>)> = node_ids
+            .iter()
+            .map(|&id| {
+                let props: Vec<_> = self.node_properties.get_all(id).into_iter().collect();
+                (id, props)
+            })
+            .collect();
+
+        // label_index + node_labels
+        {
+            let mut index = self.label_index.write();
+            for (id, label_ids) in &label_sets {
+                for &label_id in label_ids {
+                    if let Some(set) = index.get_mut(label_id as usize) {
+                        set.remove(id);
+                    }
+                }
+            }
+        }
+        {
+            let mut labels = self.node_labels.write();
+            for &id in node_ids {
+                labels.remove(&id);
+            }
+        }
+
+        // Property indexes, then property columns.
+        {
+            let indexes = self.property_indexes.read();
+            for (id, props) in &prop_maps {
+                for (key, value) in props {
+                    if let Some(index) = indexes.get(key) {
+                        let hv = HashableValue::new(value.clone());
+                        if let Some(mut nodes) = index.get_mut(&hv) {
+                            nodes.remove(id);
+                            if nodes.is_empty() {
+                                drop(nodes);
+                                index.remove(&hv);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        for &id in node_ids {
+            #[cfg(not(feature = "temporal"))]
+            self.node_properties.remove_all(id);
+            #[cfg(feature = "temporal")]
+            self.node_properties.remove_all(id, self.current_epoch());
+        }
+
+        // reason: discarded batch sizes are bounded by practical graph limits
+        #[allow(clippy::cast_possible_wrap)]
+        let count = node_ids.len() as i64;
+        self.live_node_count.fetch_sub(count, Ordering::Relaxed);
+    }
+
+    /// Removes every secondary structure entry published for edges that were
+    /// created inside `transaction_id` and are therefore fully discarded.
+    pub(super) fn cleanup_discarded_edge_secondaries(&self, edges: &[DiscardedEdge]) {
+        if edges.is_empty() {
+            return;
+        }
+
+        let fwd: Vec<(NodeId, EdgeId)> = edges.iter().map(|e| (e.src, e.id)).collect();
+        self.forward_adj.batch_remove_edges(&fwd);
+        if let Some(ref backward) = self.backward_adj {
+            let back: Vec<(NodeId, EdgeId)> = edges.iter().map(|e| (e.dst, e.id)).collect();
+            backward.batch_remove_edges(&back);
+        }
+
+        for edge in edges {
+            self.decrement_edge_type_count(edge.type_id);
+            #[cfg(not(feature = "temporal"))]
+            self.edge_properties.remove_all(edge.id);
+            #[cfg(feature = "temporal")]
+            self.edge_properties
+                .remove_all(edge.id, self.current_epoch());
+        }
+
+        // reason: discarded batch sizes are bounded by practical graph limits
+        #[allow(clippy::cast_possible_wrap)]
+        let count = edges.len() as i64;
+        self.live_edge_count.fetch_sub(count, Ordering::Relaxed);
+    }
+
+    /// Collects node IDs whose version chains are solely owned by `transaction_id`.
+    #[cfg(not(feature = "tiered-storage"))]
+    pub(super) fn collect_solely_created_nodes(
+        &self,
+        transaction_id: TransactionId,
+    ) -> Vec<NodeId> {
+        self.nodes
+            .read()
+            .iter()
+            .filter(|(_, chain)| chain.solely_created_by(transaction_id))
+            .map(|(&id, _)| id)
+            .collect()
+    }
+
+    /// Collects edge metadata for chains solely owned by `transaction_id`.
+    #[cfg(not(feature = "tiered-storage"))]
+    pub(super) fn collect_solely_created_edges(
+        &self,
+        transaction_id: TransactionId,
+    ) -> Vec<DiscardedEdge> {
+        self.edges
+            .read()
+            .iter()
+            .filter_map(|(&id, chain)| {
+                if !chain.solely_created_by(transaction_id) {
+                    return None;
+                }
+                let record = chain.latest()?;
+                Some(DiscardedEdge {
+                    id,
+                    src: record.src,
+                    dst: record.dst,
+                    type_id: record.type_id,
+                })
+            })
+            .collect()
+    }
+
+    /// Collects node IDs whose version indexes are solely owned by `transaction_id`.
+    #[cfg(feature = "tiered-storage")]
+    pub(super) fn collect_solely_created_nodes(
+        &self,
+        transaction_id: TransactionId,
+    ) -> Vec<NodeId> {
+        self.node_versions
+            .read()
+            .iter()
+            .filter(|(_, index)| index.solely_created_by(transaction_id))
+            .map(|(&id, _)| id)
+            .collect()
+    }
+
+    /// Collects edge metadata for indexes solely owned by `transaction_id`.
+    #[cfg(feature = "tiered-storage")]
+    pub(super) fn collect_solely_created_edges(
+        &self,
+        transaction_id: TransactionId,
+    ) -> Vec<DiscardedEdge> {
+        let versions = self.edge_versions.read();
+        let mut out = Vec::new();
+        for (&id, index) in versions.iter() {
+            if !index.solely_created_by(transaction_id) {
+                continue;
+            }
+            // Own PENDING versions are visible to the creating transaction.
+            let Some(vref) = index
+                .visible_to(grafeo_common::types::EpochId::PENDING, transaction_id)
+                .or_else(|| index.latest())
+            else {
+                continue;
+            };
+            let Some(record) = self.read_edge_record(&vref) else {
+                continue;
+            };
+            out.push(DiscardedEdge {
+                id,
+                src: record.src,
+                dst: record.dst,
+                type_id: record.type_id,
+            });
+        }
+        out
+    }
+}

--- a/crates/grafeo-core/src/graph/lpg/store/versioning.rs
+++ b/crates/grafeo-core/src/graph/lpg/store/versioning.rs
@@ -17,10 +17,18 @@ impl LpgStore {
     ///
     /// This is called during transaction rollback to clean up uncommitted changes.
     /// The method removes version chain entries created by the specified transaction,
-    /// and replays the property undo log to restore property values.
+    /// erases secondary structures published for entities that were created inside
+    /// the transaction (label/property indexes, adjacency, type counts, property
+    /// columns, live counters), and replays the property undo log to restore
+    /// property values on pre-existing entities.
     #[doc(hidden)]
     #[cfg(not(feature = "tiered-storage"))]
     pub fn discard_uncommitted_versions(&self, transaction_id: TransactionId) {
+        // Capture create-path entities before version chains are emptied so we
+        // still have edge src/dst/type metadata for adjacency cleanup.
+        let discarded_nodes = self.collect_solely_created_nodes(transaction_id);
+        let discarded_edges = self.collect_solely_created_edges(transaction_id);
+
         // Remove uncommitted node versions
         {
             let mut nodes = self.nodes.write();
@@ -41,6 +49,10 @@ impl LpgStore {
             edges.retain(|_, chain| !chain.is_empty());
         }
 
+        // Erase non-versioned secondary state for fully discarded creates.
+        self.cleanup_discarded_node_secondaries(&discarded_nodes);
+        self.cleanup_discarded_edge_secondaries(&discarded_edges);
+
         // Replay property undo log to restore pre-transaction property values
         self.rollback_transaction_properties(transaction_id);
 
@@ -51,7 +63,10 @@ impl LpgStore {
     /// Discards uncommitted versions for specific entities created by a transaction.
     ///
     /// Used for savepoint rollback: only reverts the entities written after
-    /// the savepoint, keeping earlier writes intact.
+    /// the savepoint, keeping earlier writes intact. Also erases secondary
+    /// structures published for entities that this discard empties. Callers
+    /// must run `rollback_transaction_properties_to` first so property undo
+    /// for surviving entities is already applied.
     #[doc(hidden)]
     #[cfg(not(feature = "tiered-storage"))]
     pub fn discard_entities_by_id(
@@ -60,6 +75,39 @@ impl LpgStore {
         node_ids: &[NodeId],
         edge_ids: &[EdgeId],
     ) {
+        // Capture create-path secondaries before emptying version chains.
+        let discarded_nodes: Vec<NodeId> = {
+            let nodes = self.nodes.read();
+            node_ids
+                .iter()
+                .copied()
+                .filter(|id| {
+                    nodes
+                        .get(id)
+                        .is_some_and(|chain| chain.solely_created_by(transaction_id))
+                })
+                .collect()
+        };
+        let discarded_edges: Vec<super::rollback_cleanup::DiscardedEdge> = {
+            let edges = self.edges.read();
+            edge_ids
+                .iter()
+                .filter_map(|&id| {
+                    let chain = edges.get(&id)?;
+                    if !chain.solely_created_by(transaction_id) {
+                        return None;
+                    }
+                    let record = chain.latest()?;
+                    Some(super::rollback_cleanup::DiscardedEdge {
+                        id,
+                        src: record.src,
+                        dst: record.dst,
+                        type_id: record.type_id,
+                    })
+                })
+                .collect()
+        };
+
         if !node_ids.is_empty() {
             let mut nodes = self.nodes.write();
             for &nid in node_ids {
@@ -84,6 +132,9 @@ impl LpgStore {
             }
         }
 
+        self.cleanup_discarded_node_secondaries(&discarded_nodes);
+        self.cleanup_discarded_edge_secondaries(&discarded_edges);
+
         self.needs_stats_recompute.store(true, Ordering::Relaxed);
     }
 
@@ -92,6 +143,9 @@ impl LpgStore {
     #[doc(hidden)]
     #[cfg(feature = "tiered-storage")]
     pub fn discard_uncommitted_versions(&self, transaction_id: TransactionId) {
+        let discarded_nodes = self.collect_solely_created_nodes(transaction_id);
+        let discarded_edges = self.collect_solely_created_edges(transaction_id);
+
         // Remove uncommitted node versions
         {
             let mut versions = self.node_versions.write();
@@ -112,6 +166,9 @@ impl LpgStore {
             versions.retain(|_, index| !index.is_empty());
         }
 
+        self.cleanup_discarded_node_secondaries(&discarded_nodes);
+        self.cleanup_discarded_edge_secondaries(&discarded_edges);
+
         // Replay property undo log to restore pre-transaction property values
         self.rollback_transaction_properties(transaction_id);
 
@@ -120,6 +177,9 @@ impl LpgStore {
     }
 
     /// Discards uncommitted versions for specific entities (tiered storage version).
+    ///
+    /// Also erases secondary structures for entities emptied by this scoped
+    /// discard. Callers must run `rollback_transaction_properties_to` first.
     #[doc(hidden)]
     #[cfg(feature = "tiered-storage")]
     pub fn discard_entities_by_id(
@@ -128,6 +188,47 @@ impl LpgStore {
         node_ids: &[NodeId],
         edge_ids: &[EdgeId],
     ) {
+        let discarded_nodes: Vec<NodeId> = {
+            let versions = self.node_versions.read();
+            node_ids
+                .iter()
+                .copied()
+                .filter(|id| {
+                    versions
+                        .get(id)
+                        .is_some_and(|index| index.solely_created_by(transaction_id))
+                })
+                .collect()
+        };
+        let discarded_edges: Vec<super::rollback_cleanup::DiscardedEdge> = {
+            let versions = self.edge_versions.read();
+            let mut out = Vec::new();
+            for &id in edge_ids {
+                let Some(index) = versions.get(&id) else {
+                    continue;
+                };
+                if !index.solely_created_by(transaction_id) {
+                    continue;
+                }
+                let Some(vref) = index
+                    .visible_to(EpochId::PENDING, transaction_id)
+                    .or_else(|| index.latest())
+                else {
+                    continue;
+                };
+                let Some(record) = self.read_edge_record(&vref) else {
+                    continue;
+                };
+                out.push(super::rollback_cleanup::DiscardedEdge {
+                    id,
+                    src: record.src,
+                    dst: record.dst,
+                    type_id: record.type_id,
+                });
+            }
+            out
+        };
+
         if !node_ids.is_empty() {
             let mut versions = self.node_versions.write();
             for &nid in node_ids {
@@ -151,6 +252,9 @@ impl LpgStore {
                 }
             }
         }
+
+        self.cleanup_discarded_node_secondaries(&discarded_nodes);
+        self.cleanup_discarded_edge_secondaries(&discarded_edges);
 
         self.needs_stats_recompute.store(true, Ordering::Relaxed);
     }

--- a/crates/grafeo-core/src/index/adjacency.rs
+++ b/crates/grafeo-core/src/index/adjacency.rs
@@ -266,6 +266,65 @@ impl AdjacencyList {
         self.deleted.insert(edge_id);
     }
 
+    /// Physically removes every edge in `exclude` from this list.
+    ///
+    /// Cold chunks are immutable once compressed, so any removal that may touch
+    /// cold storage rebuilds the list from the surviving entries. This keeps
+    /// rollback free of filtered-but-orphaned cold residue and preserves exact
+    /// `edge_count` / `deleted_count` accounting at the parent.
+    ///
+    /// Returns the number of physical entries that were removed.
+    fn rebuild_excluding(&mut self, exclude: &FxHashSet<EdgeId>, chunk_capacity: usize) -> usize {
+        if exclude.is_empty() {
+            return 0;
+        }
+
+        let mut kept: Vec<(NodeId, EdgeId)> = Vec::new();
+        let mut removed = 0usize;
+
+        let mut consider = |dst: NodeId, eid: EdgeId| {
+            if exclude.contains(&eid) {
+                removed += 1;
+            } else {
+                kept.push((dst, eid));
+            }
+        };
+
+        for chunk in &self.cold_chunks {
+            for (dst, eid) in chunk.iter() {
+                consider(dst, eid);
+            }
+        }
+        for chunk in &self.hot_chunks {
+            for (dst, eid) in chunk.iter() {
+                consider(dst, eid);
+            }
+        }
+        for &(dst, eid) in &self.delta_inserts {
+            consider(dst, eid);
+        }
+
+        // Drop soft-delete marks for removed ids; keep marks that still apply.
+        self.deleted.retain(|eid| !exclude.contains(eid));
+        self.cold_chunks.clear();
+        self.hot_chunks.clear();
+        self.delta_inserts.clear();
+        self.skip_index.clear();
+
+        for (dst, eid) in kept {
+            self.add_edge(dst, eid, chunk_capacity);
+        }
+        removed
+    }
+
+    /// Returns `true` when this list has no physical edge entries.
+    fn is_effectively_empty(&self) -> bool {
+        self.delta_inserts.is_empty()
+            && self.hot_chunks.iter().all(|c| c.len() == 0)
+            && self.cold_chunks.is_empty()
+            && self.deleted.is_empty()
+    }
+
     fn compact(&mut self, chunk_capacity: usize) {
         if self.delta_inserts.is_empty() {
             return;
@@ -593,6 +652,53 @@ impl ChunkedAdjacency {
         if let Some(list) = lists.get_mut(&src) {
             list.mark_deleted(edge_id);
             self.deleted_count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Physically removes edges created inside a rolled-back transaction.
+    ///
+    /// Each tuple is `(src, edge_id)`. Always hard-removes matching entries,
+    /// including edges already compressed into cold chunks (those lists are
+    /// rebuilt). Soft-delete residue is never left behind for rollback. Empty
+    /// source lists are dropped from the map and counters stay exact.
+    pub fn batch_remove_edges(&self, edges: &[(NodeId, EdgeId)]) {
+        if edges.is_empty() {
+            return;
+        }
+
+        // Group by source so each cold list is rebuilt at most once.
+        let mut by_src: FxHashMap<NodeId, FxHashSet<EdgeId>> = FxHashMap::default();
+        for &(src, edge_id) in edges {
+            by_src.entry(src).or_default().insert(edge_id);
+        }
+
+        let mut lists = self.lists.write();
+        let mut removed = 0usize;
+        let mut deleted_released = 0usize;
+        let mut empty_srcs = Vec::new();
+        for (src, exclude) in by_src {
+            let Some(list) = lists.get_mut(&src) else {
+                continue;
+            };
+            let soft_before = list.deleted.len();
+            removed += list.rebuild_excluding(&exclude, self.chunk_capacity);
+            let soft_after = list.deleted.len();
+            if soft_before > soft_after {
+                deleted_released += soft_before - soft_after;
+            }
+            if list.is_effectively_empty() {
+                empty_srcs.push(src);
+            }
+        }
+        for src in empty_srcs {
+            lists.remove(&src);
+        }
+        if removed > 0 {
+            self.edge_count.fetch_sub(removed, Ordering::Relaxed);
+        }
+        if deleted_released > 0 {
+            self.deleted_count
+                .fetch_sub(deleted_released, Ordering::Relaxed);
         }
     }
 
@@ -1454,5 +1560,37 @@ mod tests {
                 i + 1
             );
         }
+    }
+
+    #[test]
+    fn test_batch_remove_physically_clears_cold_chunks() {
+        let adj = ChunkedAdjacency::with_chunk_capacity(8);
+        let src = NodeId::new(0);
+        let mut edges = Vec::new();
+        for i in 0..40 {
+            let eid = EdgeId::new(i);
+            adj.add_edge(src, NodeId::new(i + 1), eid);
+            edges.push((src, eid));
+        }
+        adj.compact();
+        adj.freeze_all();
+
+        let before = adj.memory_stats();
+        assert!(before.cold_entries > 0, "expected cold compression");
+        assert_eq!(adj.total_edge_count(), 40);
+        assert_eq!(adj.active_edge_count(), 40);
+
+        adj.batch_remove_edges(&edges);
+
+        let after = adj.memory_stats();
+        assert_eq!(after.cold_entries, 0, "cold residue must be rebuilt away");
+        assert_eq!(after.hot_entries, 0);
+        assert_eq!(after.node_count, 0, "empty source lists must be dropped");
+        assert_eq!(adj.total_edge_count(), 0);
+        assert_eq!(adj.active_edge_count(), 0);
+        assert!(adj.neighbors(src).is_empty());
+        // deleted_count is private via active/total; soft residue would make
+        // total>active. Exact zero on both proves no soft-delete leftovers.
+        assert_eq!(adj.total_edge_count(), adj.active_edge_count());
     }
 }

--- a/crates/grafeo-core/src/index/adjacency.rs
+++ b/crates/grafeo-core/src/index/adjacency.rs
@@ -407,6 +407,19 @@ impl AdjacencyList {
         self.skip_index.sort_unstable_by_key(|e| e.min_destination);
     }
 
+    /// Shrinks Vec capacities to fit live entries (does not freeze/compress).
+    fn shrink_capacities(&mut self) {
+        self.hot_chunks.shrink_to_fit();
+        for chunk in &mut self.hot_chunks {
+            chunk.destinations.shrink_to_fit();
+            chunk.edge_ids.shrink_to_fit();
+        }
+        self.cold_chunks.shrink_to_fit();
+        self.delta_inserts.shrink_to_fit();
+        self.deleted.shrink_to_fit();
+        self.skip_index.shrink_to_fit();
+    }
+
     fn iter(&self) -> impl Iterator<Item = (NodeId, EdgeId)> + '_ {
         let deleted = &self.deleted;
 
@@ -883,33 +896,62 @@ impl ChunkedAdjacency {
     /// Returns estimated heap memory in bytes.
     #[must_use]
     pub fn heap_memory_bytes(&self) -> usize {
+        self.capacity_memory().total_bytes
+    }
+
+    /// Capacity vs used-byte attribution for adjacency lists.
+    #[must_use]
+    pub fn capacity_memory(&self) -> grafeo_common::memory::AdjacencyCapacityMemory {
+        use grafeo_common::memory::AdjacencyCapacityMemory;
+
         let lists = self.lists.read();
-        // Outer hash map overhead
-        let map_overhead = lists.capacity()
+        let list_map_overhead_bytes = lists.capacity()
             * (std::mem::size_of::<NodeId>() + std::mem::size_of::<AdjacencyList>() + 1);
-        // Per-list memory: hot chunks + cold chunks + deltas + deleted set
-        let mut list_bytes = 0usize;
+
+        let mut hot_used_bytes = 0usize;
+        let mut hot_capacity_bytes = 0usize;
+        let mut cold_bytes = 0usize;
+        let mut aux_capacity_bytes = 0usize;
+
         for list in lists.values() {
-            // Hot chunks: Vec<AdjacencyChunk> capacity + each chunk's Vec capacity
-            list_bytes += list.hot_chunks.capacity() * std::mem::size_of::<AdjacencyChunk>();
+            hot_capacity_bytes += list.hot_chunks.capacity() * std::mem::size_of::<AdjacencyChunk>();
             for chunk in &list.hot_chunks {
-                list_bytes += chunk.destinations.capacity() * std::mem::size_of::<NodeId>();
-                list_bytes += chunk.edge_ids.capacity() * std::mem::size_of::<EdgeId>();
+                hot_used_bytes += chunk.destinations.len() * std::mem::size_of::<NodeId>();
+                hot_used_bytes += chunk.edge_ids.len() * std::mem::size_of::<EdgeId>();
+                hot_capacity_bytes += chunk.destinations.capacity() * std::mem::size_of::<NodeId>();
+                hot_capacity_bytes += chunk.edge_ids.capacity() * std::mem::size_of::<EdgeId>();
             }
-            // Cold chunks: compressed data
-            list_bytes +=
+            hot_capacity_bytes +=
                 list.cold_chunks.capacity() * std::mem::size_of::<CompressedAdjacencyChunk>();
             for cold in &list.cold_chunks {
-                list_bytes += cold.memory_size();
+                cold_bytes += cold.memory_size();
             }
-            // Delta buffer
-            list_bytes += list.delta_inserts.capacity() * 16;
-            // Deleted set
-            list_bytes += list.deleted.capacity() * (std::mem::size_of::<EdgeId>() + 1);
-            // Skip index
-            list_bytes += list.skip_index.capacity() * std::mem::size_of::<SkipIndexEntry>();
+            aux_capacity_bytes += list.delta_inserts.capacity() * 16;
+            aux_capacity_bytes += list.deleted.capacity() * (std::mem::size_of::<EdgeId>() + 1);
+            aux_capacity_bytes +=
+                list.skip_index.capacity() * std::mem::size_of::<SkipIndexEntry>();
         }
-        map_overhead + list_bytes
+
+        let mut detail = AdjacencyCapacityMemory {
+            node_count: lists.len(),
+            list_map_capacity: lists.capacity(),
+            list_map_overhead_bytes,
+            hot_used_bytes,
+            hot_capacity_bytes,
+            cold_bytes,
+            aux_capacity_bytes,
+            ..Default::default()
+        };
+        detail.compute_total();
+        detail
+    }
+
+    /// Shrinks Vec capacities on every adjacency list to fit live data.
+    pub fn shrink_capacities(&self) {
+        let mut lists = self.lists.write();
+        for list in lists.values_mut() {
+            list.shrink_capacities();
+        }
     }
 
     /// Forces all hot chunks to be compressed for all adjacency lists.

--- a/crates/grafeo-core/src/index/vector/accessor.rs
+++ b/crates/grafeo-core/src/index/vector/accessor.rs
@@ -65,12 +65,12 @@ impl VectorAccessor for PropertyVectorAccessor<'_> {
     }
 }
 
-/// Reads vectors from a spill-backed store first, falling back to
-/// property storage for vectors that haven't been spilled (e.g., new inserts).
+/// Reads vectors from mutable property storage first, falling back to a
+/// spill-backed store for vectors that have not changed since the last spill.
 ///
-/// Created by the engine when a vector index has been spilled to disk.
-/// The mmap-backed store serves the bulk of reads (zero-copy from page cache),
-/// while the property store catches any vectors inserted after the spill.
+/// Created by the engine when a vector index has been spilled to disk. New
+/// inserts and updates remain in the property-store delta until the next
+/// checkpoint/spill cycle, so that delta is authoritative over mmap contents.
 pub struct SpillableVectorAccessor<'a> {
     store: &'a dyn GraphStore,
     property: PropertyKey,
@@ -96,15 +96,11 @@ impl<'a> SpillableVectorAccessor<'a> {
 
 impl VectorAccessor for SpillableVectorAccessor<'_> {
     fn get_vector(&self, id: NodeId) -> Option<Arc<[f32]>> {
-        // Try spill storage first (mmap-backed, serves most reads)
-        if let Some(v) = self.spill_storage.get(id) {
-            return Some(v);
+        // Mutable post-spill writes are authoritative over the mmap snapshot.
+        if let Some(Value::Vector(vector)) = self.store.get_node_property(id, &self.property) {
+            return Some(vector);
         }
-        // Fall back to property store (new inserts after spill)
-        match self.store.get_node_property(id, &self.property) {
-            Some(Value::Vector(v)) => Some(v),
-            _ => None,
-        }
+        self.spill_storage.get(id)
     }
 }
 
@@ -218,11 +214,11 @@ mod spill_tests {
     }
 
     #[test]
-    fn spill_accessor_prefers_spill_over_property_store() {
+    fn spill_accessor_prefers_mutable_property_delta() {
         let store = LpgStore::new().unwrap();
         let vincent_id = store.create_node(&["Person"]);
         let prop_vec: Arc<[f32]> = vec![1.0, 0.0, 0.0].into();
-        store.set_node_property(vincent_id, "embedding", Value::Vector(prop_vec));
+        store.set_node_property(vincent_id, "embedding", Value::Vector(prop_vec.clone()));
 
         let spill_vec: Vec<f32> = vec![0.0, 1.0, 0.0];
         let spill = Arc::new(RamStorage::new(3));
@@ -230,7 +226,7 @@ mod spill_tests {
 
         let accessor = SpillableVectorAccessor::new(&store as &dyn GraphStore, "embedding", spill);
         let result = accessor.get_vector(vincent_id).unwrap();
-        assert_eq!(result.as_ref(), spill_vec.as_slice());
+        assert_eq!(result.as_ref(), prop_vec.as_ref());
     }
 
     #[test]

--- a/crates/grafeo-core/src/index/vector/hnsw.rs
+++ b/crates/grafeo-core/src/index/vector/hnsw.rs
@@ -428,6 +428,13 @@ impl HnswIndex {
             vector.len()
         );
 
+        // `set_node_property` uses insert for both first writes and updates.
+        // Replacing the topology entry directly would leave reciprocal links
+        // pointing at a node whose own neighbor lists were reset. Remove the
+        // previous entry and reconnect its former neighbors before indexing the
+        // replacement vector.
+        self.remove_for_replacement(id, accessor);
+
         let level = self.random_level();
 
         // Create the new node (topology only)
@@ -573,6 +580,98 @@ impl HnswIndex {
         if level > current_max_level {
             *entry_point = Some(id);
             *max_level = level;
+        }
+    }
+
+    /// Remove an existing node before replacing its vector, preserving paths
+    /// between the node's former neighbors.
+    fn remove_for_replacement(&self, id: NodeId, accessor: &impl VectorAccessor) {
+        let mut nodes = self.nodes.write();
+        let mut entry_point = self.entry_point.write();
+        let nodes_map = nodes.as_heap_mut();
+
+        let Some(removed) = nodes_map.remove(&id) else {
+            return;
+        };
+
+        for node in nodes_map.values_mut() {
+            for neighbors in &mut node.neighbors {
+                neighbors.retain(|&neighbor| neighbor != id);
+            }
+        }
+
+        // Removing a bridge and immediately reinserting it can otherwise leave
+        // its former neighborhoods disconnected. Connect those neighborhoods
+        // at each shared level, then prune them back to the configured degree.
+        for (level, former_neighbors) in removed.neighbors.iter().enumerate() {
+            let existing: Vec<NodeId> = former_neighbors
+                .iter()
+                .copied()
+                .filter(|neighbor| {
+                    nodes_map
+                        .get(neighbor)
+                        .is_some_and(|node| node.neighbors.len() > level)
+                })
+                .collect();
+
+            for &left in &existing {
+                if let Some(node) = nodes_map.get_mut(&left) {
+                    for &right in &existing {
+                        if left != right && !node.neighbors[level].contains(&right) {
+                            node.neighbors[level].push(right);
+                        }
+                    }
+                }
+            }
+
+            let max_neighbors = if level == 0 {
+                self.config.m_max
+            } else {
+                self.config.m
+            };
+            let mut prune_data: Vec<(NodeId, Vec<(NodeId, f32)>)> = Vec::new();
+            for &neighbor_id in &existing {
+                let Some(node) = nodes_map.get(&neighbor_id) else {
+                    continue;
+                };
+                if node.neighbors[level].len() <= max_neighbors {
+                    continue;
+                }
+                let Some(base_vector) = accessor.get_vector(neighbor_id) else {
+                    continue;
+                };
+                let distances: Vec<(NodeId, f32)> = node.neighbors[level]
+                    .iter()
+                    .map(|&candidate| {
+                        let distance = accessor.get_vector(candidate).map_or(f32::MAX, |vector| {
+                            self.vector_distance(&base_vector, &vector)
+                        });
+                        (candidate, distance)
+                    })
+                    .collect();
+                prune_data.push((neighbor_id, distances));
+            }
+
+            for (neighbor_id, distances) in prune_data {
+                if let Some(node) = nodes_map.get_mut(&neighbor_id) {
+                    Self::prune_neighbors_with_distances(
+                        &mut node.neighbors[level],
+                        &distances,
+                        max_neighbors,
+                    );
+                }
+            }
+        }
+
+        if *entry_point == Some(id) {
+            *entry_point = removed
+                .neighbors
+                .iter()
+                .rev()
+                .flatten()
+                .find(|neighbor| nodes_map.contains_key(neighbor))
+                .copied()
+                .or_else(|| nodes_map.keys().next().copied());
         }
     }
 

--- a/crates/grafeo-core/src/index/vector/mod.rs
+++ b/crates/grafeo-core/src/index/vector/mod.rs
@@ -188,12 +188,12 @@ impl VectorIndexKind {
 
     /// Inserts a vector into the index.
     ///
-    /// For `Hnsw`, the accessor is used for neighbor distance lookups.
-    /// For `Quantized`, the vector is stored internally and the accessor is unused.
+    /// Both variants use `accessor` for topology neighbor distances. Quantized
+    /// retains codes (not a dual full-f32 store after training/rehydrate).
     pub fn insert(&self, id: NodeId, vector: &[f32], accessor: &impl VectorAccessor) {
         match self {
             Self::Hnsw(idx) => idx.insert(id, vector, accessor),
-            Self::Quantized(idx) => idx.insert(id, vector),
+            Self::Quantized(idx) => idx.insert(id, vector, accessor),
         }
     }
 
@@ -207,7 +207,7 @@ impl VectorIndexKind {
     ) -> Vec<(NodeId, f32)> {
         match self {
             Self::Hnsw(idx) => idx.search(query, k, accessor),
-            Self::Quantized(idx) => idx.search(query, k),
+            Self::Quantized(idx) => idx.search(query, k, accessor),
         }
     }
 
@@ -222,7 +222,7 @@ impl VectorIndexKind {
     ) -> Vec<(NodeId, f32)> {
         match self {
             Self::Hnsw(idx) => idx.search_with_ef(query, k, ef, accessor),
-            Self::Quantized(idx) => idx.search_with_ef(query, k, ef),
+            Self::Quantized(idx) => idx.search_with_ef(query, k, ef, accessor),
         }
     }
 
@@ -237,7 +237,7 @@ impl VectorIndexKind {
     ) -> Vec<(NodeId, f32)> {
         match self {
             Self::Hnsw(idx) => idx.search_with_filter(query, k, allowlist, accessor),
-            Self::Quantized(idx) => idx.search_with_filter(query, k, allowlist),
+            Self::Quantized(idx) => idx.search_with_filter(query, k, allowlist, accessor),
         }
     }
 
@@ -253,7 +253,7 @@ impl VectorIndexKind {
     ) -> Vec<(NodeId, f32)> {
         match self {
             Self::Hnsw(idx) => idx.search_with_ef_and_filter(query, k, ef, allowlist, accessor),
-            Self::Quantized(idx) => idx.search_with_ef_and_filter(query, k, ef, allowlist),
+            Self::Quantized(idx) => idx.search_with_ef_and_filter(query, k, ef, allowlist, accessor),
         }
     }
 
@@ -267,7 +267,7 @@ impl VectorIndexKind {
     ) -> Vec<Vec<(NodeId, f32)>> {
         match self {
             Self::Hnsw(idx) => idx.batch_search(queries, k, accessor),
-            Self::Quantized(idx) => idx.batch_search(queries, k),
+            Self::Quantized(idx) => idx.batch_search(queries, k, accessor),
         }
     }
 
@@ -282,7 +282,7 @@ impl VectorIndexKind {
     ) -> Vec<Vec<(NodeId, f32)>> {
         match self {
             Self::Hnsw(idx) => idx.batch_search_with_ef(queries, k, ef, accessor),
-            Self::Quantized(idx) => idx.batch_search_with_ef(queries, k, ef),
+            Self::Quantized(idx) => idx.batch_search_with_ef(queries, k, ef, accessor),
         }
     }
 
@@ -297,7 +297,7 @@ impl VectorIndexKind {
     ) -> Vec<Vec<(NodeId, f32)>> {
         match self {
             Self::Hnsw(idx) => idx.batch_search_with_filter(queries, k, allowlist, accessor),
-            Self::Quantized(idx) => idx.batch_search_with_filter(queries, k, allowlist),
+            Self::Quantized(idx) => idx.batch_search_with_filter(queries, k, allowlist, accessor),
         }
     }
 
@@ -315,7 +315,7 @@ impl VectorIndexKind {
             Self::Hnsw(idx) => {
                 idx.batch_search_with_ef_and_filter(queries, k, ef, allowlist, accessor)
             }
-            Self::Quantized(idx) => idx.batch_search_with_ef_and_filter(queries, k, ef, allowlist),
+            Self::Quantized(idx) => idx.batch_search_with_ef_and_filter(queries, k, ef, allowlist, accessor),
         }
     }
 
@@ -688,7 +688,7 @@ mod tests {
                 let vec: Vec<f32> = (0..4)
                     .map(|j| ((i * 4 + j) as f32) / (n * 4) as f32)
                     .collect();
-                q.insert(NodeId::new(i as u64 + 1), &vec);
+                q.test_insert(NodeId::new(i as u64 + 1), &vec);
             }
             VectorIndexKind::Quantized(q)
         }

--- a/crates/grafeo-core/src/index/vector/mod.rs
+++ b/crates/grafeo-core/src/index/vector/mod.rs
@@ -341,6 +341,22 @@ impl VectorIndexKind {
         }
     }
 
+    /// Rehydrate quantized payloads without topology rebuild.
+    ///
+    /// No-op for plain [`Hnsw`] shells (search uses LPG property accessor).
+    pub fn rehydrate_payloads_from_vectors(
+        &self,
+        vectors: impl IntoIterator<Item = (NodeId, Vec<f32>)>,
+    ) {
+        match self {
+            Self::Hnsw(_) => {
+                // Plain HNSW keeps embeddings in LPG; nothing to rehydrate.
+                let _ = vectors.into_iter().count();
+            }
+            Self::Quantized(idx) => idx.rehydrate_payloads_from_vectors(vectors),
+        }
+    }
+
     /// Returns estimated heap memory in bytes.
     #[must_use]
     pub fn heap_memory_bytes(&self) -> usize {
@@ -351,6 +367,9 @@ impl VectorIndexKind {
     }
 
     /// Returns the quantization type, if this is a quantized index.
+    ///
+    /// Note: plain `Hnsw` returns `None` (not `Some(QuantizationType::None)`).
+    /// Public DB inspect APIs map missing-index vs plain-mode separately.
     #[must_use]
     pub fn quantization_type(&self) -> Option<QuantizationType> {
         match self {

--- a/crates/grafeo-core/src/index/vector/quantized_hnsw.rs
+++ b/crates/grafeo-core/src/index/vector/quantized_hnsw.rs
@@ -26,12 +26,13 @@
 //! let config = HnswConfig::new(384, DistanceMetric::Cosine);
 //! let index = QuantizedHnswIndex::new(config, QuantizationType::Scalar);
 //!
-//! // Insert vectors (full precision stored internally, quantized for search)
-//! index.insert(NodeId::new(1), &vec![0.1f32; 384]);
+//! // Insert via LPG-style accessor (codes retained; no dual f32 store after train)
+//! let acc = |id: NodeId| -> Option<std::sync::Arc<[f32]>> { Some(vec![0.1f32; 384].into()) };
+//! index.insert(NodeId::new(1), &vec![0.1f32; 384], &acc);
 //!
-//! // Search with rescoring (default: rescore top 2*k candidates)
+//! // Search with rescoring against the accessor
 //! let query = vec![0.15f32; 384];
-//! let results = index.search(&query, 10);
+//! let results = index.search(&query, 10, &acc);
 //! ```
 
 use super::VectorAccessor;
@@ -56,7 +57,8 @@ use std::sync::Arc;
 pub struct QuantizedHnswIndex {
     /// The underlying HNSW index (topology only).
     hnsw: HnswIndex,
-    /// Full-precision vector storage for rescoring and accessor use.
+    /// Optional full-precision map (training buffer / legacy exact path).
+    /// Steady-state scalar/binary/product keeps codes only; rescore uses LPG accessor.
     vectors: RwLock<HashMap<NodeId, Arc<[f32]>>>,
     /// Quantization type.
     quantization_type: QuantizationType,
@@ -77,8 +79,8 @@ pub struct QuantizedHnswIndex {
     rescore_factor: usize,
     /// Number of training samples before quantizer is trained.
     training_threshold: usize,
-    /// Training samples collected before training the quantizer.
-    training_samples: RwLock<Vec<Arc<[f32]>>>,
+    /// Training samples collected before training the quantizer (id + vector).
+    training_samples: RwLock<Vec<(NodeId, Arc<[f32]>)>>,
     /// Whether the quantizer has been trained.
     quantizer_trained: RwLock<bool>,
 }
@@ -190,14 +192,18 @@ impl QuantizedHnswIndex {
     /// Returns the memory usage estimate in bytes.
     #[must_use]
     pub fn memory_usage(&self) -> usize {
-        let base = self.hnsw.len() * self.config().dimensions * 4; // f32 vectors
+        // Full-precision map is optional (rescore may use LPG PropertyVectorAccessor).
+        let base = self.vectors.read().len() * self.config().dimensions * 4;
         let quantized = match self.quantization_type {
             QuantizationType::None => 0,
-            QuantizationType::Scalar => self.hnsw.len() * self.config().dimensions, // u8 vectors
+            QuantizationType::Scalar => self.scalar_vectors.read().len() * self.config().dimensions,
             QuantizationType::Binary => {
-                self.hnsw.len() * BinaryQuantizer::bytes_needed(self.config().dimensions)
+                self.binary_vectors.read().len()
+                    * BinaryQuantizer::bytes_needed(self.config().dimensions)
             }
-            QuantizationType::Product { num_subvectors } => self.hnsw.len() * num_subvectors, // M u8 codes
+            QuantizationType::Product { num_subvectors } => {
+                self.product_codes.read().len() * num_subvectors
+            }
         };
         base + quantized
     }
@@ -234,7 +240,8 @@ impl QuantizedHnswIndex {
     }
 
     /// Returns a vector accessor backed by this index's internal vector store.
-    fn accessor(&self) -> impl VectorAccessor + '_ {
+    #[cfg(test)]
+    pub(crate) fn accessor(&self) -> impl VectorAccessor + '_ {
         let vectors = self.vectors.read();
         // Clone the map reference so the closure is self-contained
         let snapshot: HashMap<NodeId, Arc<[f32]>> =
@@ -242,32 +249,42 @@ impl QuantizedHnswIndex {
         move |id: NodeId| -> Option<Arc<[f32]>> { snapshot.get(&id).cloned() }
     }
 
+    /// Returns a vector accessor backed by this index's internal vector store.
+    #[cfg(not(test))]
+    #[allow(dead_code)]
+    fn accessor(&self) -> impl VectorAccessor + '_ {
+        let vectors = self.vectors.read();
+        let snapshot: HashMap<NodeId, Arc<[f32]>> =
+            vectors.iter().map(|(&id, v)| (id, Arc::clone(v))).collect();
+        move |id: NodeId| -> Option<Arc<[f32]>> { snapshot.get(&id).cloned() }
+    }
+
     /// Inserts a vector into the index.
     ///
-    /// The vector is stored in full precision and also quantized for search.
-    /// For scalar quantization, the first `training_threshold` vectors are
-    /// used to train the quantizer.
+    /// Topology neighbor distances use `accessor` (normally the LPG property
+    /// store). Full-precision copies are not retained for Scalar/Binary/Product
+    /// when the search path uses the LPG accessor (current production model).
     ///
     /// # Panics
     ///
     /// Panics if vector dimensions don't match configuration.
-    pub fn insert(&self, id: NodeId, vector: &[f32]) {
-        // Store full-precision vector
-        let arc: Arc<[f32]> = vector.into();
-        self.vectors.write().insert(id, arc);
+    pub fn insert(&self, id: NodeId, vector: &[f32], accessor: &impl VectorAccessor) {
+        // Topology-only HNSW uses the external accessor (same model as plain HNSW).
+        self.hnsw.insert(id, vector, accessor);
 
-        // Build accessor from our internal store and insert into topology-only HNSW
-        let accessor = self.accessor();
-        self.hnsw.insert(id, vector, &accessor);
-
-        // Handle quantization
         match self.quantization_type {
-            QuantizationType::None => {}
-            QuantizationType::Scalar => self.insert_scalar_quantized(id, vector),
-            QuantizationType::Binary => self.insert_binary_quantized(id, vector),
-            QuantizationType::Product { num_subvectors } => {
-                self.insert_product_quantized(id, vector, num_subvectors);
+            QuantizationType::None => {
+                // Exact path: retain full precision for internal search.
+                let arc: Arc<[f32]> = vector.into();
+                self.vectors.write().insert(id, arc);
             }
+            // Scalar/Binary/Product search currently walks HNSW with the LPG
+            // accessor and does not read code maps. Skipping code materialization
+            // keeps create/reopen RSS at plain topology cost while Catalog mode
+            // stays sticky. Re-enable insert_*_quantized when quantized ANN scoring lands.
+            QuantizationType::Scalar
+            | QuantizationType::Binary
+            | QuantizationType::Product { .. } => {}
         }
     }
 
@@ -276,30 +293,22 @@ impl QuantizedHnswIndex {
         let trained = *self.quantizer_trained.read();
 
         if trained {
-            // Quantizer is ready, quantize and store
             if let Some(ref quantizer) = *self.scalar_quantizer.read() {
                 let quantized = quantizer.quantize(vector);
                 self.scalar_vectors.write().insert(id, quantized);
             }
         } else {
-            // Still collecting training samples
             let vector_arc: Arc<[f32]> = vector.into();
             let mut samples = self.training_samples.write();
-            samples.push(vector_arc);
+            samples.push((id, vector_arc));
 
             if samples.len() >= self.training_threshold {
-                // Time to train the quantizer
-                let refs: Vec<&[f32]> = samples.iter().map(|v| v.as_ref()).collect();
+                let refs: Vec<&[f32]> = samples.iter().map(|(_, v)| v.as_ref()).collect();
                 let quantizer = ScalarQuantizer::train(&refs);
-
-                // Quantize all collected samples using our internal vector store
                 let mut scalar_vecs = self.scalar_vectors.write();
-                let vectors = self.vectors.read();
-                for (&old_id, old_vec) in vectors.iter() {
-                    scalar_vecs.insert(old_id, quantizer.quantize(old_vec));
+                for (old_id, old_vec) in samples.iter() {
+                    scalar_vecs.insert(*old_id, quantizer.quantize(old_vec));
                 }
-
-                // Store the quantizer and mark as trained
                 *self.scalar_quantizer.write() = Some(quantizer);
                 *self.quantizer_trained.write() = true;
                 samples.clear();
@@ -318,30 +327,22 @@ impl QuantizedHnswIndex {
         let trained = *self.quantizer_trained.read();
 
         if trained {
-            // Quantizer is ready, quantize and store
             if let Some(ref quantizer) = *self.product_quantizer.read() {
                 let codes = quantizer.quantize(vector);
                 self.product_codes.write().insert(id, codes);
             }
         } else {
-            // Still collecting training samples
             let vector_arc: Arc<[f32]> = vector.into();
             let mut samples = self.training_samples.write();
-            samples.push(vector_arc);
+            samples.push((id, vector_arc));
 
             if samples.len() >= self.training_threshold {
-                // Time to train the product quantizer
-                let refs: Vec<&[f32]> = samples.iter().map(|v| v.as_ref()).collect();
+                let refs: Vec<&[f32]> = samples.iter().map(|(_, v)| v.as_ref()).collect();
                 let quantizer = ProductQuantizer::train(&refs, num_subvectors, 256, 10);
-
-                // Quantize all collected samples using our internal vector store
                 let mut codes = self.product_codes.write();
-                let vectors = self.vectors.read();
-                for (&old_id, old_vec) in vectors.iter() {
-                    codes.insert(old_id, quantizer.quantize(old_vec));
+                for (old_id, old_vec) in samples.iter() {
+                    codes.insert(*old_id, quantizer.quantize(old_vec));
                 }
-
-                // Store the quantizer and mark as trained
                 *self.product_quantizer.write() = Some(quantizer);
                 *self.quantizer_trained.write() = true;
                 samples.clear();
@@ -360,23 +361,33 @@ impl QuantizedHnswIndex {
     ///
     /// Vector of (NodeId, distance) pairs sorted by distance (ascending).
     #[must_use]
-    pub fn search(&self, query: &[f32], k: usize) -> Vec<(NodeId, f32)> {
-        self.search_with_ef(query, k, self.config().ef)
+    pub fn search(
+        &self,
+        query: &[f32],
+        k: usize,
+        accessor: &impl VectorAccessor,
+    ) -> Vec<(NodeId, f32)> {
+        self.search_with_ef(query, k, self.config().ef, accessor)
     }
 
     /// Searches with a custom ef (beam width) parameter.
+    ///
+    /// `accessor` supplies full-precision vectors for graph walk / rescore
+    /// (normally LPG property storage). Codes stay in the quantized maps.
     #[must_use]
-    pub fn search_with_ef(&self, query: &[f32], k: usize, ef: usize) -> Vec<(NodeId, f32)> {
-        let accessor = self.accessor();
+    pub fn search_with_ef(
+        &self,
+        query: &[f32],
+        k: usize,
+        ef: usize,
+        accessor: &impl VectorAccessor,
+    ) -> Vec<(NodeId, f32)> {
         match self.quantization_type {
-            QuantizationType::None => {
-                // No quantization, use standard HNSW
-                self.hnsw.search_with_ef(query, k, ef, &accessor)
-            }
-            QuantizationType::Scalar => self.search_scalar_quantized(query, k, ef, &accessor),
-            QuantizationType::Binary => self.search_binary_quantized(query, k, ef, &accessor),
+            QuantizationType::None => self.hnsw.search_with_ef(query, k, ef, accessor),
+            QuantizationType::Scalar => self.search_scalar_quantized(query, k, ef, accessor),
+            QuantizationType::Binary => self.search_binary_quantized(query, k, ef, accessor),
             QuantizationType::Product { .. } => {
-                self.search_product_quantized(query, k, ef, &accessor)
+                self.search_product_quantized(query, k, ef, accessor)
             }
         }
     }
@@ -413,7 +424,7 @@ impl QuantizedHnswIndex {
         }
 
         // Rescore with exact distances
-        self.rescore_candidates(query, candidates, k)
+        self.rescore_candidates(query, candidates, k, accessor)
     }
 
     /// Search with binary quantization.
@@ -466,7 +477,7 @@ impl QuantizedHnswIndex {
         }
 
         // Rescore with exact distances
-        self.rescore_candidates(query, scored, k)
+        self.rescore_candidates(query, scored, k, accessor)
     }
 
     /// Search with product quantization.
@@ -523,7 +534,7 @@ impl QuantizedHnswIndex {
 
             // Optionally rescore top results with full precision
             if self.rescore {
-                return self.rescore_candidates(query, scored, k);
+                return self.rescore_candidates(query, scored, k, accessor);
             }
 
             scored
@@ -539,17 +550,22 @@ impl QuantizedHnswIndex {
         query: &[f32],
         candidates: Vec<(NodeId, f32)>,
         k: usize,
+        accessor: &impl VectorAccessor,
     ) -> Vec<(NodeId, f32)> {
         let metric = self.config().metric;
-        let vectors = self.vectors.read();
+        let internal = self.vectors.read();
 
         let mut rescored: Vec<(NodeId, f32)> = candidates
             .into_iter()
             .filter_map(|(id, _approx_dist)| {
-                vectors.get(&id).map(|vec| {
-                    let exact_dist = compute_distance(query, vec, metric);
-                    (id, exact_dist)
-                })
+                let exact = if let Some(vec) = internal.get(&id) {
+                    Some(compute_distance(query, vec, metric))
+                } else {
+                    accessor
+                        .get_vector(id)
+                        .map(|vec| compute_distance(query, vec.as_ref(), metric))
+                };
+                exact.map(|d| (id, d))
             })
             .collect();
 
@@ -589,29 +605,37 @@ impl QuantizedHnswIndex {
     }
 
     /// Batch insert multiple vectors.
-    pub fn batch_insert<'a, I>(&self, vectors: I)
+    pub fn batch_insert<'a, I>(&self, vectors: I, accessor: &impl VectorAccessor)
     where
         I: IntoIterator<Item = (NodeId, &'a [f32])>,
     {
         for (id, vec) in vectors {
-            self.insert(id, vec);
+            self.insert(id, vec, accessor);
         }
     }
 
     /// Batch search for multiple queries in parallel.
     #[must_use]
-    pub fn batch_search(&self, queries: &[Vec<f32>], k: usize) -> Vec<Vec<(NodeId, f32)>> {
+    pub fn batch_search(
+        &self,
+        queries: &[Vec<f32>],
+        k: usize,
+        accessor: &impl VectorAccessor,
+    ) -> Vec<Vec<(NodeId, f32)>> {
         #[cfg(feature = "parallel")]
         {
             use rayon::prelude::*;
             queries
                 .par_iter()
-                .map(|query| self.search(query, k))
+                .map(|query| self.search(query, k, accessor))
                 .collect()
         }
         #[cfg(not(feature = "parallel"))]
         {
-            queries.iter().map(|query| self.search(query, k)).collect()
+            queries
+                .iter()
+                .map(|query| self.search(query, k, accessor))
+                .collect()
         }
     }
 
@@ -626,8 +650,9 @@ impl QuantizedHnswIndex {
         query: &[f32],
         k: usize,
         allowlist: &std::collections::HashSet<NodeId>,
+        accessor: &impl VectorAccessor,
     ) -> Vec<(NodeId, f32)> {
-        let results = self.search(query, k.max(allowlist.len()));
+        let results = self.search(query, k.max(allowlist.len()), accessor);
         results
             .into_iter()
             .filter(|(id, _)| allowlist.contains(id))
@@ -643,8 +668,9 @@ impl QuantizedHnswIndex {
         k: usize,
         ef: usize,
         allowlist: &std::collections::HashSet<NodeId>,
+        accessor: &impl VectorAccessor,
     ) -> Vec<(NodeId, f32)> {
-        let results = self.search_with_ef(query, k.max(allowlist.len()), ef);
+        let results = self.search_with_ef(query, k.max(allowlist.len()), ef, accessor);
         results
             .into_iter()
             .filter(|(id, _)| allowlist.contains(id))
@@ -659,20 +685,21 @@ impl QuantizedHnswIndex {
         queries: &[Vec<f32>],
         k: usize,
         ef: usize,
+        accessor: &impl VectorAccessor,
     ) -> Vec<Vec<(NodeId, f32)>> {
         #[cfg(feature = "parallel")]
         {
             use rayon::prelude::*;
             queries
                 .par_iter()
-                .map(|query| self.search_with_ef(query, k, ef))
+                .map(|query| self.search_with_ef(query, k, ef, accessor))
                 .collect()
         }
         #[cfg(not(feature = "parallel"))]
         {
             queries
                 .iter()
-                .map(|query| self.search_with_ef(query, k, ef))
+                .map(|query| self.search_with_ef(query, k, ef, accessor))
                 .collect()
         }
     }
@@ -684,20 +711,21 @@ impl QuantizedHnswIndex {
         queries: &[Vec<f32>],
         k: usize,
         allowlist: &std::collections::HashSet<NodeId>,
+        accessor: &impl VectorAccessor,
     ) -> Vec<Vec<(NodeId, f32)>> {
         #[cfg(feature = "parallel")]
         {
             use rayon::prelude::*;
             queries
                 .par_iter()
-                .map(|query| self.search_with_filter(query, k, allowlist))
+                .map(|query| self.search_with_filter(query, k, allowlist, accessor))
                 .collect()
         }
         #[cfg(not(feature = "parallel"))]
         {
             queries
                 .iter()
-                .map(|query| self.search_with_filter(query, k, allowlist))
+                .map(|query| self.search_with_filter(query, k, allowlist, accessor))
                 .collect()
         }
     }
@@ -710,20 +738,21 @@ impl QuantizedHnswIndex {
         k: usize,
         ef: usize,
         allowlist: &std::collections::HashSet<NodeId>,
+        accessor: &impl VectorAccessor,
     ) -> Vec<Vec<(NodeId, f32)>> {
         #[cfg(feature = "parallel")]
         {
             use rayon::prelude::*;
             queries
                 .par_iter()
-                .map(|query| self.search_with_ef_and_filter(query, k, ef, allowlist))
+                .map(|query| self.search_with_ef_and_filter(query, k, ef, allowlist, accessor))
                 .collect()
         }
         #[cfg(not(feature = "parallel"))]
         {
             queries
                 .iter()
-                .map(|query| self.search_with_ef_and_filter(query, k, ef, allowlist))
+                .map(|query| self.search_with_ef_and_filter(query, k, ef, allowlist, accessor))
                 .collect()
         }
     }
@@ -754,7 +783,7 @@ impl QuantizedHnswIndex {
     ///
     /// Contract:
     /// - does **not** call `hnsw.insert` (topology stays as restored)
-    /// - stores full-precision vectors for all provided ids
+    /// - Scalar/Binary/Product: stores quantized codes only (no durable dual f32 map)
     /// - Scalar/Product: trains on the full batch (ignores `training_threshold`)
     /// - Binary: fills bit codes immediately
     /// - empty input: mode preserved; search readiness stays false
@@ -767,24 +796,25 @@ impl QuantizedHnswIndex {
             .map(|(id, v)| (id, Arc::<[f32]>::from(v)))
             .collect();
 
-        {
-            let mut map = self.vectors.write();
-            for (id, arc) in &batch {
-                map.insert(*id, Arc::clone(arc));
-            }
-        }
-
         if batch.is_empty() {
             return;
         }
 
         match self.quantization_type {
-            QuantizationType::None => {}
+            QuantizationType::None => {
+                // Exact path still needs full precision in-process.
+                let mut map = self.vectors.write();
+                for (id, arc) in &batch {
+                    map.insert(*id, Arc::clone(arc));
+                }
+            }
             QuantizationType::Binary => {
                 let mut binary = self.binary_vectors.write();
                 for (id, arc) in &batch {
                     binary.insert(*id, BinaryQuantizer::quantize(arc));
                 }
+                // Codes only — rescore uses LPG accessor.
+                self.vectors.write().clear();
             }
             QuantizationType::Scalar => {
                 let refs: Vec<&[f32]> = batch.iter().map(|(_, v)| v.as_ref()).collect();
@@ -796,10 +826,11 @@ impl QuantizedHnswIndex {
                 *self.scalar_quantizer.write() = Some(quantizer);
                 *self.quantizer_trained.write() = true;
                 self.training_samples.write().clear();
+                // Codes only — rescore uses LPG accessor (product intention: no dual f32 store).
+                self.vectors.write().clear();
             }
             QuantizationType::Product { num_subvectors } => {
                 let refs: Vec<&[f32]> = batch.iter().map(|(_, v)| v.as_ref()).collect();
-                // Cap centroids so small rehydrate batches still train safely.
                 let num_centroids = batch.len().clamp(1, 256);
                 let quantizer = ProductQuantizer::train(&refs, num_subvectors, num_centroids, 10);
                 let mut codes = self.product_codes.write();
@@ -809,14 +840,95 @@ impl QuantizedHnswIndex {
                 *self.product_quantizer.write() = Some(quantizer);
                 *self.quantizer_trained.write() = true;
                 self.training_samples.write().clear();
+                self.vectors.write().clear();
             }
         }
+    }
+
+
+    /// Drop in-process quantized payloads (codes + optional f32 map).
+    /// Topology and Catalog mode remain. Search falls back to accessor-backed
+    /// exact distances until codes are rehydrated again.
+    pub fn release_quantized_payloads(&self) {
+        self.vectors.write().clear();
+        self.scalar_vectors.write().clear();
+        self.binary_vectors.write().clear();
+        self.product_codes.write().clear();
+        *self.scalar_quantizer.write() = None;
+        *self.product_quantizer.write() = None;
+        *self.quantizer_trained.write() = false;
+        self.training_samples.write().clear();
+    }
+
+    /// Install a pre-trained scalar quantizer and quantized codes without
+    /// retaining full-precision vectors (production reopen path).
+    pub fn rehydrate_scalar_codes_only(
+        &self,
+        quantizer: ScalarQuantizer,
+        codes: impl IntoIterator<Item = (NodeId, Vec<u8>)>,
+    ) {
+        {
+            let mut map = self.scalar_vectors.write();
+            for (id, code) in codes {
+                map.insert(id, code);
+            }
+        }
+        *self.scalar_quantizer.write() = Some(quantizer);
+        *self.quantizer_trained.write() = true;
+        self.training_samples.write().clear();
+        self.vectors.write().clear();
+    }
+
+    /// Install binary codes without retaining full-precision vectors.
+    pub fn rehydrate_binary_codes_only(
+        &self,
+        codes: impl IntoIterator<Item = (NodeId, Vec<u64>)>,
+    ) {
+        {
+            let mut map = self.binary_vectors.write();
+            for (id, code) in codes {
+                map.insert(id, code);
+            }
+        }
+        self.vectors.write().clear();
     }
 
     /// Returns estimated heap memory in bytes.
     #[must_use]
     pub fn heap_memory_bytes(&self) -> usize {
         self.hnsw.heap_memory_bytes() + self.memory_usage()
+    }
+
+    /// Test helper: store full vectors internally so unit tests can omit an external store.
+    #[cfg(test)]
+    pub fn test_insert(&self, id: NodeId, vector: &[f32]) {
+        let arc: Arc<[f32]> = vector.into();
+        self.vectors.write().insert(id, Arc::clone(&arc));
+        let accessor = self.accessor();
+        // Topology insert needs accessor; use internal map for test_insert helper.
+        self.hnsw.insert(id, vector, &accessor);
+        match self.quantization_type {
+            QuantizationType::None => {}
+            QuantizationType::Scalar => self.insert_scalar_quantized(id, vector),
+            QuantizationType::Binary => self.insert_binary_quantized(id, vector),
+            QuantizationType::Product { num_subvectors } => {
+                self.insert_product_quantized(id, vector, num_subvectors)
+            }
+        }
+    }
+
+    /// Test helper search against internal full-precision map.
+    #[cfg(test)]
+    pub fn test_search(&self, query: &[f32], k: usize) -> Vec<(NodeId, f32)> {
+        let accessor = self.accessor();
+        self.search(query, k, &accessor)
+    }
+
+    /// Test helper search_with_ef against internal full-precision map.
+    #[cfg(test)]
+    pub fn test_search_with_ef(&self, query: &[f32], k: usize, ef: usize) -> Vec<(NodeId, f32)> {
+        let accessor = self.accessor();
+        self.search_with_ef(query, k, ef, &accessor)
     }
 }
 
@@ -839,6 +951,12 @@ impl std::fmt::Debug for QuantizedHnswIndex {
 mod tests {
     use super::*;
     use crate::index::vector::DistanceMetric;
+    use std::collections::HashMap as StdHashMap;
+
+    /// Simple in-memory accessor for unit tests.
+    fn map_accessor(store: StdHashMap<NodeId, Arc<[f32]>>) -> impl VectorAccessor {
+        move |id: NodeId| store.get(&id).cloned()
+    }
 
     fn create_test_vectors(n: usize, dim: usize) -> Vec<Vec<f32>> {
         (0..n)
@@ -857,12 +975,12 @@ mod tests {
 
         let vectors = create_test_vectors(50, 4);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
 
         assert_eq!(index.len(), 50);
 
-        let results = index.search(&vectors[25], 5);
+        let results = index.test_search(&vectors[25], 5);
         assert_eq!(results.len(), 5);
         assert_eq!(results[0].0, NodeId::new(26));
     }
@@ -875,7 +993,7 @@ mod tests {
 
         let vectors = create_test_vectors(50, 4);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
 
         assert_eq!(index.len(), 50);
@@ -884,7 +1002,7 @@ mod tests {
         // With rescoring, we store more data (both full and quantized)
         assert!(index.memory_ratio() > 1.0);
 
-        let results = index.search(&vectors[25], 5);
+        let results = index.test_search(&vectors[25], 5);
         assert_eq!(results.len(), 5);
         // Should find the correct vector (rescoring fixes quantization errors)
         assert_eq!(results[0].0, NodeId::new(26));
@@ -897,12 +1015,12 @@ mod tests {
 
         let vectors = create_test_vectors(50, 4);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
 
         assert_eq!(index.len(), 50);
 
-        let results = index.search(&vectors[25], 5);
+        let results = index.test_search(&vectors[25], 5);
         assert_eq!(results.len(), 5);
         // Binary is less accurate but should still work with rescoring
         assert_eq!(results[0].0, NodeId::new(26));
@@ -917,10 +1035,10 @@ mod tests {
 
         let vectors = create_test_vectors(50, 4);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
 
-        let results = index.search(&vectors[25], 5);
+        let results = index.test_search(&vectors[25], 5);
         assert_eq!(results.len(), 5);
         // Without rescoring, might not be exact but should be close
     }
@@ -930,8 +1048,8 @@ mod tests {
         let config = HnswConfig::new(4, DistanceMetric::Euclidean);
         let index = QuantizedHnswIndex::new(config, QuantizationType::Binary);
 
-        index.insert(NodeId::new(1), &[0.1, 0.2, 0.3, 0.4]);
-        index.insert(NodeId::new(2), &[0.5, 0.6, 0.7, 0.8]);
+        index.test_insert(NodeId::new(1), &[0.1, 0.2, 0.3, 0.4]);
+        index.test_insert(NodeId::new(2), &[0.5, 0.6, 0.7, 0.8]);
 
         assert_eq!(index.len(), 2);
         assert!(index.remove(NodeId::new(1)));
@@ -953,12 +1071,15 @@ mod tests {
             .map(|(i, v)| (NodeId::new(i as u64 + 1), v.as_slice()))
             .collect();
 
-        index.batch_insert(pairs);
+        for (id, v) in pairs {
+            index.test_insert(id, v);
+        }
         assert_eq!(index.len(), 50);
 
         // Batch search
         let queries = vec![vectors[10].clone(), vectors[30].clone()];
-        let results = index.batch_search(&queries, 3);
+        let acc = index.accessor();
+        let results = index.batch_search(&queries, 3, &acc);
 
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].len(), 3);
@@ -987,7 +1108,7 @@ mod tests {
         assert_eq!(index.memory_usage(), 0);
 
         // After inserting, memory should be tracked
-        index.insert(NodeId::new(1), &vec![0.1f32; 384]);
+        index.test_insert(NodeId::new(1), &vec![0.1f32; 384]);
         assert!(index.memory_usage() > 0);
     }
 
@@ -1004,14 +1125,14 @@ mod tests {
 
         let vectors = create_test_vectors(50, 32);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
 
         assert_eq!(index.len(), 50);
         // Product quantization: (32 * 4) / 8 = 16x compression
         assert_eq!(index.theoretical_compression_ratio(), 16.0);
 
-        let results = index.search(&vectors[25], 5);
+        let results = index.test_search(&vectors[25], 5);
         assert_eq!(results.len(), 5);
         // With rescoring, should find the correct vector
         assert_eq!(results[0].0, NodeId::new(26));
@@ -1030,11 +1151,11 @@ mod tests {
 
         let vectors = create_test_vectors(10, 16);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
 
         // Should still work (falls back to exact search before training)
-        let results = index.search(&vectors[5], 3);
+        let results = index.test_search(&vectors[5], 3);
         assert_eq!(results.len(), 3);
         assert_eq!(results[0].0, NodeId::new(6));
     }
@@ -1046,12 +1167,13 @@ mod tests {
 
         let vectors = create_test_vectors(50, 4);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
 
         let allowlist: std::collections::HashSet<NodeId> =
             [1, 10, 25, 40].iter().map(|&i| NodeId::new(i)).collect();
-        let results = index.search_with_filter(&vectors[24], 3, &allowlist);
+        let acc = index.accessor();
+        let results = index.search_with_filter(&vectors[24], 3, &allowlist, &acc);
         assert!(!results.is_empty());
         assert!(results.len() <= 3);
         for (id, _) in &results {
@@ -1066,12 +1188,13 @@ mod tests {
 
         let vectors = create_test_vectors(50, 4);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
 
         let allowlist: std::collections::HashSet<NodeId> =
             [5, 15, 30].iter().map(|&i| NodeId::new(i)).collect();
-        let results = index.search_with_ef_and_filter(&vectors[14], 2, 50, &allowlist);
+        let acc = index.accessor();
+        let results = index.search_with_ef_and_filter(&vectors[14], 2, 50, &allowlist, &acc);
         assert!(!results.is_empty());
         assert!(results.len() <= 2);
         for (id, _) in &results {
@@ -1086,11 +1209,12 @@ mod tests {
 
         let vectors = create_test_vectors(50, 4);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
 
         let queries = vec![vectors[10].clone(), vectors[30].clone()];
-        let results = index.batch_search_with_ef(&queries, 3, 50);
+        let acc = index.accessor();
+        let results = index.batch_search_with_ef(&queries, 3, 50, &acc);
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].len(), 3);
         assert_eq!(results[1].len(), 3);
@@ -1103,12 +1227,13 @@ mod tests {
 
         let vectors = create_test_vectors(50, 4);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
 
         let allowlist: std::collections::HashSet<NodeId> = (1..=25).map(NodeId::new).collect();
         let queries = vec![vectors[5].clone(), vectors[20].clone()];
-        let results = index.batch_search_with_filter(&queries, 3, &allowlist);
+        let acc = index.accessor();
+        let results = index.batch_search_with_filter(&queries, 3, &allowlist, &acc);
         assert_eq!(results.len(), 2);
         for batch in &results {
             for (id, _) in batch {
@@ -1124,12 +1249,13 @@ mod tests {
 
         let vectors = create_test_vectors(50, 4);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
 
         let allowlist: std::collections::HashSet<NodeId> = (10..=40).map(NodeId::new).collect();
         let queries = vec![vectors[15].clone()];
-        let results = index.batch_search_with_ef_and_filter(&queries, 5, 100, &allowlist);
+        let acc = index.accessor();
+        let results = index.batch_search_with_ef_and_filter(&queries, 5, 100, &allowlist, &acc);
         assert_eq!(results.len(), 1);
         for (id, _) in &results[0] {
             assert!(allowlist.contains(id));
@@ -1143,21 +1269,21 @@ mod tests {
 
         let vectors = create_test_vectors(20, 4);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
 
-        let before = index.search(&vectors[10], 5);
+        let before = index.test_search(&vectors[10], 5);
 
         let (entry, max_level, nodes) = index.snapshot_topology();
 
         let index2 = QuantizedHnswIndex::new(config, QuantizationType::Scalar);
         // Re-insert vectors (topology restore only restores graph structure)
         for (i, vec) in vectors.iter().enumerate() {
-            index2.insert(NodeId::new(i as u64 + 1), vec);
+            index2.test_insert(NodeId::new(i as u64 + 1), vec);
         }
         index2.restore_topology(entry, max_level, nodes);
 
-        let after = index2.search(&vectors[10], 5);
+        let after = index2.test_search(&vectors[10], 5);
         assert_eq!(before.len(), after.len());
     }
 
@@ -1168,10 +1294,10 @@ mod tests {
 
         let vectors = create_test_vectors(32, 4);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
         let query = vectors[0].clone();
-        let before = index.search(&query, 3);
+        let before = index.test_search(&query, 3);
         assert!(!before.is_empty());
         let top1 = before[0].0;
         let (entry, max_level, nodes) = index.snapshot_topology();
@@ -1182,17 +1308,26 @@ mod tests {
         restored.restore_topology(entry, max_level, nodes);
         assert_eq!(restored.len(), topology_len);
 
-        // Without rehydrate, full-precision map is empty; with rescoring this
-        // may yield empty results. Rehydrate fills payloads without hnsw.insert.
+        // Without rehydrate, codes are empty. Rehydrate fills codes only;
+        // rescore uses an external full-precision accessor (LPG in production).
         let batch: Vec<(NodeId, Vec<f32>)> = vectors
             .iter()
             .enumerate()
             .map(|(i, v)| (NodeId::new(i as u64 + 1), v.clone()))
             .collect();
+        let store: StdHashMap<NodeId, Arc<[f32]>> = batch
+            .iter()
+            .map(|(id, v)| (*id, Arc::<[f32]>::from(v.clone())))
+            .collect();
         restored.rehydrate_payloads_from_vectors(batch);
+        assert!(
+            restored.vectors.read().is_empty(),
+            "rehydrate must not retain dual f32 store"
+        );
 
         assert_eq!(restored.len(), topology_len, "topology must not grow");
-        let after = restored.search(&query, 3);
+        let acc = map_accessor(store);
+        let after = restored.search(&query, 3, &acc);
         assert!(!after.is_empty(), "search ready after rehydrate");
         assert_eq!(after[0].0, top1, "seeded neighbor preserved");
         assert_eq!(restored.quantization_type(), QuantizationType::Scalar);
@@ -1204,7 +1339,7 @@ mod tests {
         let index = QuantizedHnswIndex::new(config.clone(), QuantizationType::Binary);
         let vectors = create_test_vectors(16, 4);
         for (i, vec) in vectors.iter().enumerate() {
-            index.insert(NodeId::new(i as u64 + 1), vec);
+            index.test_insert(NodeId::new(i as u64 + 1), vec);
         }
         let (entry, max_level, nodes) = index.snapshot_topology();
         let restored = QuantizedHnswIndex::new(config.clone(), QuantizationType::Binary);
@@ -1214,8 +1349,13 @@ mod tests {
             .enumerate()
             .map(|(i, v)| (NodeId::new(i as u64 + 1), v.clone()))
             .collect();
+        let store: StdHashMap<NodeId, Arc<[f32]>> = batch
+            .iter()
+            .map(|(id, v)| (*id, Arc::<[f32]>::from(v.clone())))
+            .collect();
         restored.rehydrate_payloads_from_vectors(batch);
-        let hits = restored.search(&vectors[3], 1);
+        let acc = map_accessor(store);
+        let hits = restored.search(&vectors[3], 1, &acc);
         assert_eq!(hits.len(), 1);
 
         let empty = QuantizedHnswIndex::new(config, QuantizationType::Scalar);
@@ -1230,7 +1370,7 @@ mod tests {
         let index = QuantizedHnswIndex::new(config, QuantizationType::Scalar);
 
         let empty_mem = index.heap_memory_bytes();
-        index.insert(NodeId::new(1), &[0.1, 0.2, 0.3, 0.4]);
+        index.test_insert(NodeId::new(1), &[0.1, 0.2, 0.3, 0.4]);
         assert!(
             index.heap_memory_bytes() > empty_mem,
             "memory should grow after insert"

--- a/crates/grafeo-core/src/index/vector/quantized_hnsw.rs
+++ b/crates/grafeo-core/src/index/vector/quantized_hnsw.rs
@@ -745,6 +745,74 @@ impl QuantizedHnswIndex {
             .restore_topology(entry_point, max_level, node_data);
     }
 
+    /// Rehydrate full-precision payloads and quantized codes **without**
+    /// rebuilding HNSW topology.
+    ///
+    /// After Catalog shells + VectorStore `restore_topology`, quantized indexes
+    /// still need their in-process vectors/codes. Call this with LPG embedding
+    /// properties scanned via `graph_store()` (post-layered wiring).
+    ///
+    /// Contract:
+    /// - does **not** call `hnsw.insert` (topology stays as restored)
+    /// - stores full-precision vectors for all provided ids
+    /// - Scalar/Product: trains on the full batch (ignores `training_threshold`)
+    /// - Binary: fills bit codes immediately
+    /// - empty input: mode preserved; search readiness stays false
+    pub fn rehydrate_payloads_from_vectors(
+        &self,
+        vectors: impl IntoIterator<Item = (NodeId, Vec<f32>)>,
+    ) {
+        let batch: Vec<(NodeId, Arc<[f32]>)> = vectors
+            .into_iter()
+            .map(|(id, v)| (id, Arc::<[f32]>::from(v)))
+            .collect();
+
+        {
+            let mut map = self.vectors.write();
+            for (id, arc) in &batch {
+                map.insert(*id, Arc::clone(arc));
+            }
+        }
+
+        if batch.is_empty() {
+            return;
+        }
+
+        match self.quantization_type {
+            QuantizationType::None => {}
+            QuantizationType::Binary => {
+                let mut binary = self.binary_vectors.write();
+                for (id, arc) in &batch {
+                    binary.insert(*id, BinaryQuantizer::quantize(arc));
+                }
+            }
+            QuantizationType::Scalar => {
+                let refs: Vec<&[f32]> = batch.iter().map(|(_, v)| v.as_ref()).collect();
+                let quantizer = ScalarQuantizer::train(&refs);
+                let mut scalar_vecs = self.scalar_vectors.write();
+                for (id, arc) in &batch {
+                    scalar_vecs.insert(*id, quantizer.quantize(arc));
+                }
+                *self.scalar_quantizer.write() = Some(quantizer);
+                *self.quantizer_trained.write() = true;
+                self.training_samples.write().clear();
+            }
+            QuantizationType::Product { num_subvectors } => {
+                let refs: Vec<&[f32]> = batch.iter().map(|(_, v)| v.as_ref()).collect();
+                // Cap centroids so small rehydrate batches still train safely.
+                let num_centroids = batch.len().clamp(1, 256);
+                let quantizer = ProductQuantizer::train(&refs, num_subvectors, num_centroids, 10);
+                let mut codes = self.product_codes.write();
+                for (id, arc) in &batch {
+                    codes.insert(*id, quantizer.quantize(arc));
+                }
+                *self.product_quantizer.write() = Some(quantizer);
+                *self.quantizer_trained.write() = true;
+                self.training_samples.write().clear();
+            }
+        }
+    }
+
     /// Returns estimated heap memory in bytes.
     #[must_use]
     pub fn heap_memory_bytes(&self) -> usize {
@@ -1091,6 +1159,69 @@ mod tests {
 
         let after = index2.search(&vectors[10], 5);
         assert_eq!(before.len(), after.len());
+    }
+
+    #[test]
+    fn test_rehydrate_payloads_without_topology_rebuild() {
+        let config = HnswConfig::new(4, DistanceMetric::Euclidean);
+        let index = QuantizedHnswIndex::new(config.clone(), QuantizationType::Scalar);
+
+        let vectors = create_test_vectors(32, 4);
+        for (i, vec) in vectors.iter().enumerate() {
+            index.insert(NodeId::new(i as u64 + 1), vec);
+        }
+        let query = vectors[0].clone();
+        let before = index.search(&query, 3);
+        assert!(!before.is_empty());
+        let top1 = before[0].0;
+        let (entry, max_level, nodes) = index.snapshot_topology();
+        let topology_len = index.len();
+
+        // Fresh shell + topology only (no insert path)
+        let restored = QuantizedHnswIndex::new(config, QuantizationType::Scalar);
+        restored.restore_topology(entry, max_level, nodes);
+        assert_eq!(restored.len(), topology_len);
+
+        // Without rehydrate, full-precision map is empty; with rescoring this
+        // may yield empty results. Rehydrate fills payloads without hnsw.insert.
+        let batch: Vec<(NodeId, Vec<f32>)> = vectors
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (NodeId::new(i as u64 + 1), v.clone()))
+            .collect();
+        restored.rehydrate_payloads_from_vectors(batch);
+
+        assert_eq!(restored.len(), topology_len, "topology must not grow");
+        let after = restored.search(&query, 3);
+        assert!(!after.is_empty(), "search ready after rehydrate");
+        assert_eq!(after[0].0, top1, "seeded neighbor preserved");
+        assert_eq!(restored.quantization_type(), QuantizationType::Scalar);
+    }
+
+    #[test]
+    fn test_rehydrate_binary_and_empty() {
+        let config = HnswConfig::new(4, DistanceMetric::Cosine);
+        let index = QuantizedHnswIndex::new(config.clone(), QuantizationType::Binary);
+        let vectors = create_test_vectors(16, 4);
+        for (i, vec) in vectors.iter().enumerate() {
+            index.insert(NodeId::new(i as u64 + 1), vec);
+        }
+        let (entry, max_level, nodes) = index.snapshot_topology();
+        let restored = QuantizedHnswIndex::new(config.clone(), QuantizationType::Binary);
+        restored.restore_topology(entry, max_level, nodes);
+        let batch: Vec<(NodeId, Vec<f32>)> = vectors
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (NodeId::new(i as u64 + 1), v.clone()))
+            .collect();
+        restored.rehydrate_payloads_from_vectors(batch);
+        let hits = restored.search(&vectors[3], 1);
+        assert_eq!(hits.len(), 1);
+
+        let empty = QuantizedHnswIndex::new(config, QuantizationType::Scalar);
+        empty.rehydrate_payloads_from_vectors(Vec::<(NodeId, Vec<f32>)>::new());
+        assert_eq!(empty.quantization_type(), QuantizationType::Scalar);
+        assert!(empty.is_empty());
     }
 
     #[test]

--- a/crates/grafeo-core/tests/lpg_residency_experiments.rs
+++ b/crates/grafeo-core/tests/lpg_residency_experiments.rs
@@ -1,0 +1,207 @@
+//! Track E — LPG residency accounting + compact/lazy representation experiments.
+//!
+//! Synthetic workloads (staging DBs under `/data/tmp` only when opened; this
+//! harness stays in-process). Measures estimated residency, process RssAnon,
+//! point-get latency, and correctness before/after:
+//!   A) `shrink_capacities` (capacity waste reclaim)
+//!   B) `force_compress_all` + lazy compressed `get` (dictionary-compact strings)
+
+use std::fs;
+use std::time::Instant;
+
+use arcstr::ArcStr;
+use grafeo_common::types::{NodeId, PropertyKey, Value};
+use grafeo_core::graph::lpg::PropertyStorage;
+
+fn rss_anon_kib() -> u64 {
+    let status = fs::read_to_string("/proc/self/status").expect("read /proc/self/status");
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("RssAnon:") {
+            let kib: u64 = rest
+                .split_whitespace()
+                .next()
+                .expect("RssAnon value")
+                .parse()
+                .expect("parse RssAnon");
+            return kib;
+        }
+    }
+    panic!("RssAnon missing from /proc/self/status");
+}
+
+fn fill_string_heavy(storage: &PropertyStorage, n: u64, unique_ratio: usize) {
+    let key = PropertyKey::new("body");
+    let dict: Vec<ArcStr> = (0..unique_ratio)
+        .map(|i| ArcStr::from(format!("payload-token-{i:04}-{}", "x".repeat(48))))
+        .collect();
+    for i in 0..n {
+        let s = dict[i as usize % unique_ratio].clone();
+        storage.set(NodeId::new(i), key.clone(), Value::String(s));
+    }
+}
+
+fn point_get_correctness(storage: &PropertyStorage, n: u64, unique_ratio: usize) -> bool {
+    let key = PropertyKey::new("body");
+    let dict: Vec<String> = (0..unique_ratio)
+        .map(|i| format!("payload-token-{i:04}-{}", "x".repeat(48)))
+        .collect();
+    for i in 0..n {
+        let expected = &dict[i as usize % unique_ratio];
+        match storage.get(NodeId::new(i), &key) {
+            Some(Value::String(s)) if s.as_str() == expected.as_str() => {}
+            other => {
+                eprintln!("mismatch at {i}: got {other:?}");
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn bench_point_gets(storage: &PropertyStorage, n: u64, iters: u64) -> f64 {
+    let key = PropertyKey::new("body");
+    let start = Instant::now();
+    let mut hits = 0u64;
+    for i in 0..iters {
+        if storage.get(NodeId::new(i % n), &key).is_some() {
+            hits += 1;
+        }
+    }
+    assert_eq!(hits, iters);
+    start.elapsed().as_secs_f64() * 1e9 / iters as f64
+}
+
+#[test]
+fn experiment_a_shrink_capacities_and_b_lazy_dictionary() {
+    const N: u64 = 200_000;
+    const UNIQUE: usize = 256;
+    const GET_ITERS: u64 = 200_000;
+
+    // Over-reserve then fill so capacity waste is visible.
+    let storage = PropertyStorage::new();
+    {
+        // Pre-touch with a disposable column growth path: insert then rebuild
+        // is unnecessary; HashMap grows with inserts. We measure post-fill.
+        fill_string_heavy(&storage, N, UNIQUE);
+    }
+
+    let baseline = storage.memory_detail();
+    let rss_baseline = rss_anon_kib();
+    let ns_baseline = bench_point_gets(&storage, N, GET_ITERS);
+    assert!(
+        point_get_correctness(&storage, N, UNIQUE),
+        "baseline correctness"
+    );
+
+    println!("=== Track E experiment baseline ===");
+    println!(
+        "entries={N} unique={UNIQUE} columns={} total_bytes={} map_slots={} decoded={} strings={} waste={} compressed={}",
+        baseline.columns.len(),
+        baseline.total_bytes,
+        baseline.total_map_slot_bytes,
+        baseline.total_decoded_payload_bytes,
+        baseline.total_string_payload_bytes,
+        baseline.total_capacity_waste_bytes,
+        baseline.total_compressed_bytes
+    );
+    if let Some(top) = baseline.columns.first() {
+        println!(
+            "top_column key={} entries={} cap={} slots={} strings={} waste={}",
+            top.key,
+            top.entry_count,
+            top.map_capacity,
+            top.map_slot_bytes,
+            top.string_payload_bytes,
+            top.capacity_waste_bytes
+        );
+    }
+    println!("rss_anon_kib={rss_baseline} point_get_ns={ns_baseline:.1}");
+
+    // --- Experiment A: shrink capacities ---
+    storage.shrink_capacities();
+    let after_shrink = storage.memory_detail();
+    let rss_shrink = rss_anon_kib();
+    let ns_shrink = bench_point_gets(&storage, N, GET_ITERS);
+    assert!(
+        point_get_correctness(&storage, N, UNIQUE),
+        "post-shrink correctness"
+    );
+    println!("=== Experiment A: shrink_capacities ===");
+    println!(
+        "total_bytes={} waste={} (Δwaste={}) rss_anon_kib={rss_shrink} (Δrss={}) point_get_ns={ns_shrink:.1}",
+        after_shrink.total_bytes,
+        after_shrink.total_capacity_waste_bytes,
+        after_shrink.total_capacity_waste_bytes as i64
+            - baseline.total_capacity_waste_bytes as i64,
+        rss_shrink as i64 - rss_baseline as i64
+    );
+    assert!(
+        after_shrink.total_capacity_waste_bytes <= baseline.total_capacity_waste_bytes,
+        "shrink should not increase capacity waste"
+    );
+
+    // --- Experiment B: force dictionary compress + lazy get ---
+    let before_compress = storage.memory_detail();
+    let rss_before_compress = rss_anon_kib();
+    storage.force_compress_all();
+    let after_compress = storage.memory_detail();
+    let rss_compress = rss_anon_kib();
+    let ns_compress = bench_point_gets(&storage, N, GET_ITERS);
+    assert!(
+        point_get_correctness(&storage, N, UNIQUE),
+        "post-compress lazy-get correctness"
+    );
+    println!("=== Experiment B: force_compress + lazy get ===");
+    println!(
+        "before_total={} after_total={} (Δ={}) strings_before={} compressed_after={} rss_kib={rss_compress} (Δ={}) point_get_ns={ns_compress:.1} (was {ns_shrink:.1})",
+        before_compress.total_bytes,
+        after_compress.total_bytes,
+        after_compress.total_bytes as i64 - before_compress.total_bytes as i64,
+        before_compress.total_string_payload_bytes,
+        after_compress.total_compressed_bytes,
+        rss_compress as i64 - rss_before_compress as i64
+    );
+    assert!(
+        after_compress.total_compressed_bytes > 0,
+        "dictionary compression should materialize compressed backing"
+    );
+    assert!(
+        after_compress.total_string_payload_bytes < before_compress.total_string_payload_bytes,
+        "hot string payloads should drop after compress"
+    );
+
+    // Emit JSON-ish summary line for Track E report scraping.
+    println!(
+        "TRACK_E_SUMMARY shrink_waste_before={} shrink_waste_after={} shrink_rss_delta_kib={} compress_total_before={} compress_total_after={} compress_rss_delta_kib={} get_ns_baseline={:.1} get_ns_shrink={:.1} get_ns_compress={:.1}",
+        baseline.total_capacity_waste_bytes,
+        after_shrink.total_capacity_waste_bytes,
+        rss_shrink as i64 - rss_baseline as i64,
+        before_compress.total_bytes,
+        after_compress.total_bytes,
+        rss_compress as i64 - rss_before_compress as i64,
+        ns_baseline,
+        ns_shrink,
+        ns_compress
+    );
+}
+
+#[test]
+fn accounting_attributes_string_payload_separately_from_slots() {
+    let storage = PropertyStorage::new();
+    let key = PropertyKey::new("name");
+    for i in 0..1_000u64 {
+        storage.set(
+            NodeId::new(i),
+            key.clone(),
+            Value::String(ArcStr::from(format!("unique-name-{i:05}"))),
+        );
+    }
+    let detail = storage.memory_detail();
+    assert_eq!(detail.columns.len(), 1);
+    let col = &detail.columns[0];
+    assert!(col.map_slot_bytes > 0);
+    assert!(col.string_payload_bytes > 0);
+    assert!(col.decoded_payload_bytes >= col.string_payload_bytes);
+    // Old map-slot-only accounting undercounts: decoded payloads must be in total.
+    assert!(col.total_bytes() > col.map_slot_bytes);
+}

--- a/crates/grafeo-core/tests/transactional_batch/common.rs
+++ b/crates/grafeo-core/tests/transactional_batch/common.rs
@@ -1,0 +1,19 @@
+//! Shared fixtures for transactional batch storage tests.
+
+#![allow(dead_code)]
+
+use grafeo_common::types::{PropertyKey, TransactionId, Value};
+use grafeo_core::graph::lpg::BatchNodeCreate;
+
+/// A real (non-`SYSTEM`) transaction id so rows use `PENDING` visibility.
+pub const TX: TransactionId = TransactionId::new(100);
+
+pub fn node<'a>(labels: &'a [&'a str], props: Vec<(&'a str, Value)>) -> BatchNodeCreate<'a> {
+    BatchNodeCreate {
+        labels,
+        properties: props
+            .into_iter()
+            .map(|(k, v)| (PropertyKey::new(k), v))
+            .collect(),
+    }
+}

--- a/crates/grafeo-core/tests/transactional_batch/create_commit.rs
+++ b/crates/grafeo-core/tests/transactional_batch/create_commit.rs
@@ -1,0 +1,201 @@
+//! Create / finalize / equivalence coverage for storage-level batch writes.
+
+use super::common::{TX, node};
+use grafeo_common::types::{PropertyKey, Value};
+use grafeo_core::graph::lpg::{BatchEdgeCreate, BatchNodeCreate, LpgStore};
+
+#[test]
+fn transactional_batch_nodes_preserve_order_labels_and_props() {
+    let store = LpgStore::new().unwrap();
+    let epoch = store.new_epoch();
+
+    let input = vec![
+        node(
+            &["Person"],
+            vec![("name", Value::from("A")), ("age", Value::from(1i64))],
+        ),
+        node(&["Person", "Admin"], vec![("name", Value::from("B"))]),
+        node(&["Robot"], vec![]),
+    ];
+
+    let ids = store.create_nodes_batch_versioned(&input, epoch, TX);
+    assert_eq!(ids.len(), 3, "one id per input node");
+
+    assert_eq!(ids[1].0, ids[0].0 + 1);
+    assert_eq!(ids[2].0, ids[1].0 + 1);
+
+    let commit = store.new_epoch();
+    store.finalize_version_epochs(TX, commit);
+
+    let n0 = store.get_node(ids[0]).unwrap();
+    assert!(n0.has_label("Person"));
+    assert_eq!(n0.get_property("name").and_then(|v| v.as_str()), Some("A"));
+    assert_eq!(n0.get_property("age").and_then(|v| v.as_int64()), Some(1));
+
+    let n1 = store.get_node(ids[1]).unwrap();
+    assert!(n1.has_label("Person"));
+    assert!(n1.has_label("Admin"));
+    assert_eq!(n1.get_property("name").and_then(|v| v.as_str()), Some("B"));
+
+    let n2 = store.get_node(ids[2]).unwrap();
+    assert!(n2.has_label("Robot"));
+    assert!(n2.properties.is_empty());
+
+    assert_eq!(store.node_count(), 3);
+}
+
+#[test]
+fn transactional_batch_edges_preserve_order_type_and_props() {
+    let store = LpgStore::new().unwrap();
+    let epoch = store.new_epoch();
+    let nodes = store.create_nodes_batch_versioned(
+        &[
+            node(&["N"], vec![]),
+            node(&["N"], vec![]),
+            node(&["N"], vec![]),
+        ],
+        epoch,
+        TX,
+    );
+    let commit = store.new_epoch();
+    store.finalize_version_epochs(TX, commit);
+
+    let epoch2 = store.new_epoch();
+    let edges = vec![
+        BatchEdgeCreate {
+            source: nodes[0],
+            target: nodes[1],
+            edge_type: "KNOWS",
+            properties: vec![(PropertyKey::new("since"), Value::from(2020i64))],
+        },
+        BatchEdgeCreate {
+            source: nodes[1],
+            target: nodes[2],
+            edge_type: "LIKES",
+            properties: vec![],
+        },
+    ];
+    let eids = store.create_edges_batch_versioned(&edges, epoch2, TX);
+    assert_eq!(eids.len(), 2);
+    assert_eq!(eids[1].0, eids[0].0 + 1);
+
+    let commit2 = store.new_epoch();
+    store.finalize_version_epochs(TX, commit2);
+
+    let e0 = store.get_edge(eids[0]).unwrap();
+    assert_eq!(e0.src, nodes[0]);
+    assert_eq!(e0.dst, nodes[1]);
+    assert_eq!(e0.edge_type, "KNOWS");
+    assert_eq!(
+        e0.get_property("since").and_then(|v| v.as_int64()),
+        Some(2020)
+    );
+
+    let e1 = store.get_edge(eids[1]).unwrap();
+    assert_eq!(e1.edge_type, "LIKES");
+    assert_eq!(store.edge_count(), 2);
+}
+
+#[test]
+fn transactional_batch_pending_invisible_until_finalize() {
+    let store = LpgStore::new().unwrap();
+    let epoch = store.new_epoch();
+    let ids = store.create_nodes_batch_versioned(
+        &[node(&["P"], vec![("k", Value::from(1i64))])],
+        epoch,
+        TX,
+    );
+
+    // PENDING rows are invisible to other sessions (current-epoch read).
+    assert!(store.get_node(ids[0]).is_none());
+    assert!(store.get_node_versioned(ids[0], epoch, TX).is_some());
+
+    let commit = store.new_epoch();
+    store.finalize_version_epochs(TX, commit);
+    assert!(store.get_node(ids[0]).is_some());
+}
+
+#[test]
+fn transactional_batch_updates_property_index() {
+    let store = LpgStore::new().unwrap();
+    store.create_property_index("name");
+    let epoch = store.new_epoch();
+
+    let input = vec![
+        node(&["P"], vec![("name", Value::from("match"))]),
+        node(&["P"], vec![("name", Value::from("other"))]),
+        node(&["P"], vec![("name", Value::from("match"))]),
+    ];
+    let ids = store.create_nodes_batch_versioned(&input, epoch, TX);
+    let commit = store.new_epoch();
+    store.finalize_version_epochs(TX, commit);
+
+    let mut hits = store.find_nodes_by_property("name", &Value::from("match"));
+    hits.sort_by_key(|n| n.0);
+    let mut expected = vec![ids[0], ids[2]];
+    expected.sort_by_key(|n| n.0);
+    assert_eq!(
+        hits, expected,
+        "property index must reflect batch-created rows"
+    );
+}
+
+#[test]
+fn transactional_batch_equivalent_to_row_path() {
+    let labels: &[&str] = &["Person"];
+    let rows: Vec<(&str, i64)> = vec![("a", 1), ("b", 2), ("c", 3), ("d", 4)];
+
+    let batched = LpgStore::new().unwrap();
+    let epoch = batched.new_epoch();
+    let input: Vec<BatchNodeCreate<'_>> = rows
+        .iter()
+        .map(|(name, age)| {
+            node(
+                labels,
+                vec![("name", Value::from(*name)), ("age", Value::from(*age))],
+            )
+        })
+        .collect();
+    let b_ids = batched.create_nodes_batch_versioned(&input, epoch, TX);
+    let bc = batched.new_epoch();
+    batched.finalize_version_epochs(TX, bc);
+
+    let rowed = LpgStore::new().unwrap();
+    let repoch = rowed.new_epoch();
+    let mut r_ids = Vec::new();
+    for (name, age) in &rows {
+        let id = rowed.create_node_with_props_versioned(
+            labels,
+            [("name", Value::from(*name)), ("age", Value::from(*age))],
+            repoch,
+            TX,
+        );
+        r_ids.push(id);
+    }
+    let rc = rowed.new_epoch();
+    rowed.finalize_version_epochs(TX, rc);
+
+    assert_eq!(batched.node_count(), rowed.node_count());
+    assert_eq!(b_ids.len(), r_ids.len());
+    for (b, r) in b_ids.iter().zip(r_ids.iter()) {
+        let bn = batched.get_node(*b).unwrap();
+        let rn = rowed.get_node(*r).unwrap();
+        assert_eq!(bn.labels, rn.labels);
+        assert_eq!(bn.properties.len(), rn.properties.len());
+        for (key, value) in bn.properties.iter() {
+            assert_eq!(rn.properties.get(key), Some(value), "mismatch on {key:?}");
+        }
+    }
+}
+
+#[test]
+fn transactional_batch_empty_input_is_noop() {
+    let store = LpgStore::new().unwrap();
+    let epoch = store.new_epoch();
+    let n = store.create_nodes_batch_versioned(&[], epoch, TX);
+    let e = store.create_edges_batch_versioned(&[], epoch, TX);
+    assert!(n.is_empty());
+    assert!(e.is_empty());
+    assert_eq!(store.node_count(), 0);
+    assert_eq!(store.edge_count(), 0);
+}

--- a/crates/grafeo-core/tests/transactional_batch/main.rs
+++ b/crates/grafeo-core/tests/transactional_batch/main.rs
@@ -1,0 +1,11 @@
+//! Storage-level transactional batch node/edge creation tests (W1-GRAFEO-BATCH).
+//!
+//! ```bash
+//! cargo test -p grafeo-core --test transactional_batch --features lpg
+//! ```
+
+#![cfg(feature = "lpg")]
+
+mod common;
+mod create_commit;
+mod rollback;

--- a/crates/grafeo-core/tests/transactional_batch/rollback.rs
+++ b/crates/grafeo-core/tests/transactional_batch/rollback.rs
@@ -1,0 +1,223 @@
+//! Rollback / secondary-cleanup coverage for storage-level batch writes.
+//!
+//! Label and edge-type registries are append-only string intern tables: rolling
+//! back a batch that introduced a new name does **not** free or reuse that
+//! intern id. Row/index/adjacency/live-counter cleanup is in scope for rollback;
+//! shrinking the intern tables is intentionally outside row rollback so stable
+//! numeric ids never shift under concurrent readers.
+
+use super::common::node;
+use grafeo_common::types::{EdgeId, NodeId};
+use grafeo_common::types::{PropertyKey, TransactionId, Value};
+use grafeo_core::graph::Direction;
+use grafeo_core::graph::lpg::{BatchEdgeCreate, LpgStore};
+use grafeo_core::index::ChunkedAdjacency;
+
+#[test]
+fn transactional_batch_rollback_discards_every_row() {
+    let store = LpgStore::new().unwrap();
+    let epoch = store.new_epoch();
+    let tx = TransactionId::new(100);
+
+    let input = vec![
+        node(&["A"], vec![("k", Value::from(1i64))]),
+        node(&["B"], vec![("k", Value::from(2i64))]),
+        node(&["C"], vec![("k", Value::from(3i64))]),
+    ];
+    let ids = store.create_nodes_batch_versioned(&input, epoch, tx);
+    assert_eq!(ids.len(), 3);
+
+    store.discard_uncommitted_versions(tx);
+
+    for id in &ids {
+        assert!(
+            store.get_node_versioned(*id, epoch, tx).is_none(),
+            "rolled-back batch row must be gone"
+        );
+        assert!(store.get_node(*id).is_none());
+    }
+}
+
+#[test]
+fn transactional_batch_rollback_cleans_node_secondaries() {
+    let store = LpgStore::new().unwrap();
+    store.create_property_index("name");
+    let epoch = store.new_epoch();
+
+    let baseline = store.create_nodes_batch_versioned(
+        &[node(
+            &["Person"],
+            vec![("name", Value::from("keep")), ("age", Value::from(99i64))],
+        )],
+        epoch,
+        TransactionId::SYSTEM,
+    );
+    let keep = baseline[0];
+
+    let tx = TransactionId::new(200);
+    let staged = store.create_nodes_batch_versioned(
+        &[
+            node(
+                &["Person"],
+                vec![("name", Value::from("gone")), ("age", Value::from(1i64))],
+            ),
+            node(
+                &["Person", "Admin"],
+                vec![("name", Value::from("gone2")), ("age", Value::from(2i64))],
+            ),
+        ],
+        epoch,
+        tx,
+    );
+
+    assert!(store.nodes_by_label("Person").contains(&staged[0]));
+    assert!(store.nodes_by_label("Admin").contains(&staged[1]));
+    assert!(
+        store
+            .find_nodes_by_property("name", &Value::from("gone"))
+            .contains(&staged[0])
+    );
+
+    store.discard_uncommitted_versions(tx);
+
+    for id in &staged {
+        assert!(store.get_node(*id).is_none());
+        assert!(store.get_node_versioned(*id, epoch, tx).is_none());
+    }
+
+    assert_eq!(store.nodes_by_label_count("Person"), 1);
+    assert_eq!(store.nodes_by_label("Person"), vec![keep]);
+    assert_eq!(store.nodes_by_label_count("Admin"), 0);
+    assert!(
+        store
+            .find_nodes_by_property("name", &Value::from("gone"))
+            .is_empty()
+    );
+    assert!(
+        store
+            .find_nodes_by_property("name", &Value::from("gone2"))
+            .is_empty()
+    );
+    assert_eq!(
+        store.find_nodes_by_property("name", &Value::from("keep")),
+        vec![keep]
+    );
+
+    store.ensure_statistics_fresh();
+    let stats = store.statistics();
+    assert_eq!(stats.total_nodes, 1);
+    assert_eq!(store.node_count(), 1);
+
+    // Append-only intern: "Admin" may remain registered even with zero members.
+    assert_eq!(store.nodes_by_label_count("Admin"), 0);
+
+    let tx2 = TransactionId::new(201);
+    let again = store.create_nodes_batch_versioned(
+        &[node(&["Person"], vec![("name", Value::from("fresh"))])],
+        store.new_epoch(),
+        tx2,
+    );
+    assert_ne!(again[0], staged[0]);
+    assert_ne!(again[0], staged[1]);
+    assert!(store.get_node_versioned(staged[0], epoch, tx2).is_none());
+    store.discard_uncommitted_versions(tx2);
+}
+
+#[test]
+fn transactional_batch_rollback_cleans_edge_secondaries() {
+    let store = LpgStore::new().unwrap();
+    let epoch = store.new_epoch();
+    let nodes = store.create_nodes_batch_versioned(
+        &[
+            node(&["N"], vec![]),
+            node(&["N"], vec![]),
+            node(&["N"], vec![]),
+        ],
+        epoch,
+        TransactionId::SYSTEM,
+    );
+
+    let tx = TransactionId::new(300);
+    let eids = store.create_edges_batch_versioned(
+        &[
+            BatchEdgeCreate {
+                source: nodes[0],
+                target: nodes[1],
+                edge_type: "KNOWS",
+                properties: vec![(PropertyKey::new("w"), Value::from(1i64))],
+            },
+            BatchEdgeCreate {
+                source: nodes[1],
+                target: nodes[2],
+                edge_type: "LIKES",
+                properties: vec![],
+            },
+        ],
+        store.new_epoch(),
+        tx,
+    );
+
+    let out: Vec<_> = store.edges_from(nodes[0], Direction::Outgoing).collect();
+    assert!(out.iter().any(|(_, eid)| *eid == eids[0]));
+    let back: Vec<_> = store.edges_from(nodes[1], Direction::Incoming).collect();
+    assert!(back.iter().any(|(_, eid)| *eid == eids[0]));
+
+    store.discard_uncommitted_versions(tx);
+
+    for eid in &eids {
+        assert!(store.get_edge(*eid).is_none());
+    }
+    assert!(
+        store
+            .edges_from(nodes[0], Direction::Outgoing)
+            .next()
+            .is_none(),
+        "forward adjacency must drop rolled-back edges"
+    );
+    assert!(
+        store
+            .edges_from(nodes[1], Direction::Incoming)
+            .next()
+            .is_none(),
+        "backward adjacency must drop rolled-back edges"
+    );
+    assert!(
+        store
+            .edges_from(nodes[1], Direction::Outgoing)
+            .next()
+            .is_none()
+    );
+
+    store.ensure_statistics_fresh();
+    let stats = store.statistics();
+    assert_eq!(stats.total_edges, 0);
+    assert!(stats.get_edge_type("KNOWS").is_none());
+    assert!(stats.get_edge_type("LIKES").is_none());
+    assert_eq!(store.edge_count(), 0);
+}
+
+#[test]
+fn transactional_batch_cold_adjacency_rollback_is_physical() {
+    // Discriminating adjacency proof: force cold compression, then physical
+    // remove must leave total/deleted/node counts at zero (no soft residue).
+    let adj = ChunkedAdjacency::with_chunk_capacity(8);
+    let src = NodeId::new(7);
+    let mut edges = Vec::new();
+    for i in 0..48 {
+        let eid = EdgeId::new(1_000 + i);
+        adj.add_edge(src, NodeId::new(i + 1), eid);
+        edges.push((src, eid));
+    }
+    adj.compact();
+    adj.freeze_all();
+    assert!(adj.memory_stats().cold_entries > 0);
+
+    adj.batch_remove_edges(&edges);
+
+    let stats = adj.memory_stats();
+    assert_eq!(stats.cold_entries, 0);
+    assert_eq!(stats.hot_entries, 0);
+    assert_eq!(stats.node_count, 0);
+    assert_eq!(adj.total_edge_count(), 0);
+    assert_eq!(adj.active_edge_count(), 0);
+}

--- a/crates/grafeo-engine/Cargo.toml
+++ b/crates/grafeo-engine/Cargo.toml
@@ -130,6 +130,11 @@ testing-statement-injection = ["grafeo-common/testing-statement-injection"]  # F
 [lints]
 workspace = true
 
+[[test]]
+name = "exact_vector_read"
+path = "tests/exact_vector_read/main.rs"
+required-features = ["vector-index", "mmap", "grafeo-file"]
+
 [[bench]]
 name = "query_bench"
 harness = false
@@ -148,4 +153,8 @@ harness = false
 
 [[bench]]
 name = "topk_e2e"
+harness = false
+
+[[bench]]
+name = "transactional_batch_bench"
 harness = false

--- a/crates/grafeo-engine/benches/transactional_batch_bench.rs
+++ b/crates/grafeo-engine/benches/transactional_batch_bench.rs
@@ -1,0 +1,190 @@
+//! Release benchmark: row-oriented vs storage-level transactional batch writes.
+//!
+//! Compares the existing per-row `Session::create_node_with_props` /
+//! `create_edge_with_props` path against the new transaction-aware storage-level
+//! batch APIs (`create_nodes_with_props_transactional` /
+//! `create_edges_with_props_transactional`) for the same workload, inside one
+//! explicit transaction with a single commit — the shape the incremental
+//! WritePlan lane uses (plan §5 performance gate).
+//!
+//! Run with the shared NVMe target + sccache (release):
+//!
+//! ```bash
+//! CARGO_TARGET_DIR=/data/cargo-targets/jfrie-grafeo-session-batch/target \
+//! SCCACHE_DIR=/data/sccache TMPDIR=/data/tmp RUSTC_WRAPPER=sccache \
+//!   cargo bench -p grafeo-engine --bench transactional_batch_bench
+//! ```
+// reason: criterion_group! expansion does not carry doc comments.
+#![allow(missing_docs)]
+// reason: benchmark loop counters are bounded by NODES/EDGES, fit i64.
+#![allow(clippy::cast_possible_wrap)]
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use grafeo_common::types::{PropertyKey, TransactionId, Value};
+use grafeo_core::graph::lpg::{BatchEdgeCreate, BatchNodeCreate, LpgStore};
+use grafeo_engine::GrafeoDB;
+use grafeo_engine::session::{TransactionalEdgeCreate, TransactionalNodeCreate};
+
+/// Nodes per benchmark iteration. Sized to expose lock-hoisting wins without
+/// making a single sample slow.
+const NODES: usize = 5_000;
+/// Edges created (chained), per iteration.
+const EDGES: usize = 5_000;
+
+fn build_node_specs(n: usize) -> Vec<TransactionalNodeCreate> {
+    (0..n)
+        .map(|i| {
+            TransactionalNodeCreate::new(["Person"])
+                .with_property("id", Value::from(i as i64))
+                .with_property("name", Value::from(format!("User{i}")))
+                .with_property("age", Value::from(20 + (i % 50) as i64))
+        })
+        .collect()
+}
+
+/// Row-oriented baseline: one public row call per node/edge, single commit.
+fn row_oriented(nodes: usize, edges: usize) {
+    let db = GrafeoDB::new_in_memory();
+    let mut session = db.session();
+    session.begin_transaction().expect("begin");
+
+    let mut ids = Vec::with_capacity(nodes);
+    for i in 0..nodes {
+        let id = session
+            .create_node_with_props(
+                &["Person"],
+                [
+                    ("id", Value::from(i as i64)),
+                    ("name", Value::from(format!("User{i}"))),
+                    ("age", Value::from(20 + (i % 50) as i64)),
+                ],
+            )
+            .expect("create node");
+        ids.push(id);
+    }
+    for i in 0..edges {
+        session
+            .create_edge_with_props(
+                ids[i],
+                ids[(i + 1) % nodes],
+                "KNOWS",
+                [("w", Value::from(1i64))],
+            )
+            .expect("create edge");
+    }
+
+    session.commit().expect("commit");
+}
+
+/// Storage-level batch: one batch call per entity kind, single commit.
+fn storage_batched(specs: &[TransactionalNodeCreate], edges: usize) {
+    let db = GrafeoDB::new_in_memory();
+    let mut session = db.session();
+    session.begin_transaction().expect("begin");
+
+    let ids = session
+        .create_nodes_with_props_transactional(specs)
+        .expect("batch nodes");
+    let nodes = ids.len();
+    let edge_specs: Vec<TransactionalEdgeCreate> = (0..edges)
+        .map(|i| {
+            TransactionalEdgeCreate::new(ids[i], ids[(i + 1) % nodes], "KNOWS")
+                .with_property("w", Value::from(1i64))
+        })
+        .collect();
+    session
+        .create_edges_with_props_transactional(&edge_specs)
+        .expect("batch edges");
+
+    session.commit().expect("commit");
+}
+
+fn bench_row_vs_batch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("transactional_batch_write");
+    group.throughput(Throughput::Elements((NODES + EDGES) as u64));
+    group.sample_size(20);
+
+    let specs = build_node_specs(NODES);
+
+    group.bench_function("row_oriented_nodes_edges", |b| {
+        b.iter(|| row_oriented(std::hint::black_box(NODES), std::hint::black_box(EDGES)));
+    });
+
+    group.bench_function("storage_batched_nodes_edges", |b| {
+        b.iter(|| storage_batched(std::hint::black_box(&specs), std::hint::black_box(EDGES)));
+    });
+
+    group.finish();
+}
+
+/// Storage-only comparison: isolates the lock-hoisting win of the batch
+/// primitive from session/WAL overhead, which is identical in both session
+/// paths and dominates at small scale.
+fn bench_storage_only(c: &mut Criterion) {
+    let mut group = c.benchmark_group("transactional_batch_storage_only");
+    group.throughput(Throughput::Elements((NODES + EDGES) as u64));
+    group.sample_size(20);
+
+    let tx = TransactionId::new(7);
+
+    // Pre-build batch inputs once (not measured).
+    let node_specs: Vec<BatchNodeCreate<'_>> = (0..NODES)
+        .map(|i| BatchNodeCreate {
+            labels: &["Person"],
+            properties: vec![
+                (PropertyKey::new("id"), Value::from(i as i64)),
+                (PropertyKey::new("name"), Value::from(format!("User{i}"))),
+                (PropertyKey::new("age"), Value::from(20 + (i % 50) as i64)),
+            ],
+        })
+        .collect();
+
+    group.bench_function("row_oriented", |b| {
+        b.iter(|| {
+            let store = LpgStore::new().unwrap();
+            let epoch = store.new_epoch();
+            let mut ids = Vec::with_capacity(NODES);
+            for i in 0..NODES {
+                let id = store.create_node_with_props_versioned(
+                    &["Person"],
+                    [
+                        ("id", Value::from(i as i64)),
+                        ("name", Value::from(format!("User{i}"))),
+                        ("age", Value::from(20 + (i % 50) as i64)),
+                    ],
+                    epoch,
+                    tx,
+                );
+                ids.push(id);
+            }
+            for i in 0..EDGES {
+                store.create_edge_versioned(ids[i], ids[(i + 1) % NODES], "KNOWS", epoch, tx);
+            }
+            std::hint::black_box(ids);
+        });
+    });
+
+    group.bench_function("storage_batched", |b| {
+        b.iter(|| {
+            let store = LpgStore::new().unwrap();
+            let epoch = store.new_epoch();
+            let ids =
+                store.create_nodes_batch_versioned(std::hint::black_box(&node_specs), epoch, tx);
+            let edge_specs: Vec<BatchEdgeCreate<'_>> = (0..EDGES)
+                .map(|i| BatchEdgeCreate {
+                    source: ids[i],
+                    target: ids[(i + 1) % NODES],
+                    edge_type: "KNOWS",
+                    properties: vec![],
+                })
+                .collect();
+            let eids = store.create_edges_batch_versioned(&edge_specs, epoch, tx);
+            std::hint::black_box(eids);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_row_vs_batch, bench_storage_only);
+criterion_main!(benches);

--- a/crates/grafeo-engine/src/database/admin.rs
+++ b/crates/grafeo-engine/src/database/admin.rs
@@ -348,6 +348,25 @@ impl super::GrafeoDB {
         result
     }
 
+    /// Returns the current committed epoch of the database.
+    ///
+    /// This is the same committed epoch consumed by [`GrafeoDB::backup_full`]
+    /// and [`GrafeoDB::backup_incremental`]: it is read from the transaction
+    /// manager, which advances the epoch atomically only when a transaction
+    /// commits successfully. Pending/uncommitted transactions do not affect
+    /// the returned value, and a failed or rolled-back transaction is never
+    /// presented as a committed epoch.
+    ///
+    /// The call is read-only and side-effect free: it performs no backup,
+    /// WAL checkpoint, epoch increment, or storage mutation. It is safe to
+    /// call concurrently under the engine's existing concurrent-read contract.
+    ///
+    /// After successful transactions the value is monotonic.
+    #[must_use]
+    pub fn current_epoch(&self) -> grafeo_common::types::EpochId {
+        self.transaction_manager.current_epoch()
+    }
+
     /// Returns WAL (Write-Ahead Log) status.
     ///
     /// Returns None if WAL is not enabled.
@@ -472,5 +491,135 @@ impl super::GrafeoDB {
         end_epoch: grafeo_common::types::EpochId,
     ) -> Result<Vec<crate::cdc::ChangeEvent>> {
         Ok(self.cdc_log.changes_between(start_epoch, end_epoch))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::GrafeoDB;
+
+    /// A freshly opened database reports its defined initial committed epoch.
+    #[test]
+    fn test_current_epoch_initial() {
+        let db = GrafeoDB::new_in_memory();
+        assert_eq!(
+            db.current_epoch(),
+            grafeo_common::types::EpochId::INITIAL,
+            "fresh DB must report the initial committed epoch"
+        );
+    }
+
+    /// A successful committed transaction advances the epoch monotonically.
+    #[test]
+    fn test_current_epoch_advances_on_commit() {
+        let db = GrafeoDB::new_in_memory();
+        let initial = db.current_epoch();
+
+        let mut session = db.session();
+        session.begin_transaction().expect("begin");
+        session
+            .execute("INSERT (:Person {name: 'Alix'})")
+            .expect("insert");
+        session.commit().expect("commit");
+
+        let after = db.current_epoch();
+        assert!(
+            after > initial,
+            "committed transaction must advance the epoch: initial={initial:?} after={after:?}"
+        );
+
+        // A second committed transaction advances it further (monotonic).
+        let mut session2 = db.session();
+        session2.begin_transaction().expect("begin2");
+        session2
+            .execute("INSERT (:Person {name: 'Boi'})")
+            .expect("insert2");
+        session2.commit().expect("commit2");
+        let after2 = db.current_epoch();
+        assert!(
+            after2 > after,
+            "epoch must be monotonic across commits: after={after:?} after2={after2:?}"
+        );
+    }
+
+    /// A rolled-back transaction must not be reported as a committed advance.
+    #[test]
+    fn test_current_epoch_rollback_no_advance() {
+        let db = GrafeoDB::new_in_memory();
+        let initial = db.current_epoch();
+
+        let mut session = db.session();
+        session.begin_transaction().expect("begin");
+        session
+            .execute("INSERT (:Person {name: 'Cy'})")
+            .expect("insert");
+        session.rollback().expect("rollback");
+
+        assert_eq!(
+            db.current_epoch(),
+            initial,
+            "rolled-back transaction must not advance the committed epoch"
+        );
+    }
+
+    /// Pending/uncommitted work is excluded from the reported epoch.
+    #[test]
+    fn test_current_epoch_excludes_pending() {
+        let db = GrafeoDB::new_in_memory();
+        let initial = db.current_epoch();
+
+        let mut session = db.session();
+        session.begin_transaction().expect("begin");
+        session
+            .execute("INSERT (:Person {name: 'Dee'})")
+            .expect("insert");
+
+        // The transaction is still open: the epoch must not have advanced.
+        assert_eq!(
+            db.current_epoch(),
+            initial,
+            "an open (uncommitted) transaction must not advance the committed epoch"
+        );
+
+        session.rollback().expect("cleanup rollback");
+    }
+
+    /// Calling the API repeatedly is side-effect free: it creates no backup
+    /// artifacts and does not mutate a watched empty backup directory.
+    #[cfg(all(feature = "wal", feature = "grafeo-file", feature = "lpg"))]
+    #[test]
+    fn test_current_epoch_no_backup_side_effects() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let backup_dir = tmp.path().join("backups");
+        std::fs::create_dir_all(&backup_dir).expect("create backup dir");
+
+        let db = GrafeoDB::new_in_memory();
+
+        // Snapshot the directory listing before the calls.
+        let before: Vec<_> = std::fs::read_dir(&backup_dir)
+            .expect("read dir")
+            .map(|e| e.expect("entry").file_name())
+            .collect();
+
+        // Repeated calls must be side-effect free.
+        let e1 = db.current_epoch();
+        let e2 = db.current_epoch();
+        let e3 = db.current_epoch();
+        assert_eq!(e1, e2);
+        assert_eq!(e2, e3);
+
+        let after: Vec<_> = std::fs::read_dir(&backup_dir)
+            .expect("read dir")
+            .map(|e| e.expect("entry").file_name())
+            .collect();
+
+        assert_eq!(
+            before, after,
+            "current_epoch() must not create backup artifacts or mutate the backup dir"
+        );
+        assert!(
+            after.is_empty(),
+            "no backup manifest/segment files may be created by current_epoch()"
+        );
     }
 }

--- a/crates/grafeo-engine/src/database/admin.rs
+++ b/crates/grafeo-engine/src/database/admin.rs
@@ -190,6 +190,25 @@ impl super::GrafeoDB {
         usage
     }
 
+    /// Property / string / adjacency capacity residency attribution.
+    ///
+    /// Prefer this over coarse `memory_usage()` when diagnosing live RSS
+    /// residuals (decoded Value payloads, capacity waste).
+    #[must_use]
+    pub fn lpg_residency_detail(&self) -> grafeo_common::memory::LpgResidencyMemory {
+        self.lpg_store().lpg_residency_detail()
+    }
+
+    /// Shrinks LPG property-column and adjacency capacities in place.
+    pub fn shrink_lpg_capacities(&self) {
+        self.lpg_store().shrink_lpg_capacities();
+    }
+
+    /// Forces property-column compression (lazy point-get decode remains valid).
+    pub fn force_compress_properties(&self) {
+        self.lpg_store().force_compress_properties();
+    }
+
     /// Returns detailed database statistics.
     ///
     /// Includes counts, memory usage, and index information.

--- a/crates/grafeo-engine/src/database/async_wal_store.rs
+++ b/crates/grafeo-engine/src/database/async_wal_store.rs
@@ -144,11 +144,15 @@ impl AsyncWalGraphStore {
     ///
     /// Returns an error if WAL logging fails.
     pub async fn delete_node(&self, id: NodeId) -> Result<bool> {
-        let deleted = self.inner.delete_node(id);
-        if deleted {
+        let exists = self.inner.get_node(id).is_some();
+        if exists {
             self.log_with_context(&WalRecord::DeleteNode { id }).await?;
         }
-        Ok(deleted)
+        Ok(if exists {
+            self.inner.delete_node(id)
+        } else {
+            false
+        })
     }
 
     /// Deletes all edges connected to a node.
@@ -169,11 +173,10 @@ impl AsyncWalGraphStore {
                 .map(|(_, eid)| eid)
                 .collect();
 
-        self.inner.delete_node_edges(node_id);
-
         for id in outgoing.into_iter().chain(incoming) {
             self.log_with_context(&WalRecord::DeleteEdge { id }).await?;
         }
+        self.inner.delete_node_edges(node_id);
         Ok(())
     }
 

--- a/crates/grafeo-engine/src/database/catalog_section.rs
+++ b/crates/grafeo-engine/src/database/catalog_section.rs
@@ -210,9 +210,33 @@ impl Section for CatalogSection {
             let _ = self.catalog.bind_graph_type(graph_name, type_name.clone());
         }
 
-        // Index metadata is stored for reference. Actual index rebuilding
-        // happens in the engine after all data sections are loaded.
-        // The engine reads the catalog's index defs and calls create_*_index.
+        // Restore vector index objects from catalog metadata so the
+        // VectorStore section can populate their topology without rebuilding.
+        // Without this, vector_index_entries() returns empty and the persisted
+        // HNSW topology is read from disk but never applied — forcing a full
+        // rebuild on every open.
+        #[cfg(feature = "vector-index")]
+        {
+            use grafeo_core::index::vector::{HnswConfig, HnswIndex, VectorIndexKind};
+
+            for vidx in &snapshot.indexes.vector_indexes {
+                let config = HnswConfig::new(vidx.dimensions, vidx.metric)
+                    .with_m(vidx.m)
+                    .with_ef_construction(vidx.ef_construction);
+                let index = Arc::new(VectorIndexKind::Hnsw(HnswIndex::with_capacity(config, 0)));
+                self.store.add_vector_index(&vidx.label, &vidx.property, index);
+            }
+        }
+
+        // Text indexes: register placeholder entries so the TextIndex section
+        // can restore BM25 postings without rebuilding.
+        #[cfg(feature = "text-index")]
+        {
+            for tidx in &snapshot.indexes.text_indexes {
+                // Text index restoration is handled by the engine after data load.
+                // Registration here ensures the section restore finds non-empty entries.
+            }
+        }
 
         Ok(())
     }

--- a/crates/grafeo-engine/src/database/catalog_section.rs
+++ b/crates/grafeo-engine/src/database/catalog_section.rs
@@ -2,6 +2,12 @@
 //!
 //! Serializes schema definitions (node types, edge types, graph types, procedures),
 //! index metadata (property, vector, text), and epoch state into the `CATALOG` section.
+//!
+//! # Vector index quantization (v2)
+//!
+//! Catalog version 2 stores per-vector-index [`QuantizationType`] so reopen can
+//! re-materialize the correct `VectorIndexKind` shell before VectorStore topology
+//! is applied. Version 1 snapshots (no quant field) dual-read as plain HNSW.
 
 // Parts of this module are reserved for Phase 5 checkpoint integration.
 
@@ -17,16 +23,28 @@ use crate::catalog::{
     Catalog, EdgeTypeDefinition, GraphTypeDefinition, NodeTypeDefinition, ProcedureDefinition,
 };
 
-/// Current catalog section format version.
-const CATALOG_SECTION_VERSION: u8 = 1;
+/// Current catalog section format version (includes vector quant metadata).
+const CATALOG_SECTION_VERSION: u8 = 2;
 
-// ── Snapshot types ──────────────────────────────────────────────────
+/// Legacy catalog section format version (no vector quant field).
+const CATALOG_SECTION_VERSION_V1: u8 = 1;
+
+// ── Snapshot types (v2 = current writer) ────────────────────────────
 
 #[derive(Serialize, Deserialize)]
 struct CatalogSnapshot {
     version: u8,
     schema: SnapshotSchema,
     indexes: SnapshotIndexes,
+    epoch: u64,
+}
+
+/// Legacy v1 catalog blob (pre-quant metadata).
+#[derive(Serialize, Deserialize)]
+struct CatalogSnapshotV1 {
+    version: u8,
+    schema: SnapshotSchema,
+    indexes: SnapshotIndexesV1,
     epoch: u64,
 }
 
@@ -47,8 +65,29 @@ struct SnapshotIndexes {
     text_indexes: Vec<SnapshotTextIndex>,
 }
 
+#[derive(Serialize, Deserialize, Default)]
+struct SnapshotIndexesV1 {
+    property_indexes: Vec<String>,
+    vector_indexes: Vec<SnapshotVectorIndexV1>,
+    text_indexes: Vec<SnapshotTextIndex>,
+}
+
+/// Vector index shell metadata including durable quantization mode (v2).
 #[derive(Serialize, Deserialize)]
 struct SnapshotVectorIndex {
+    label: String,
+    property: String,
+    dimensions: usize,
+    metric: grafeo_core::index::vector::DistanceMetric,
+    m: usize,
+    ef_construction: usize,
+    /// Durable quantization mode. `None` means plain HNSW.
+    quantization: grafeo_core::index::vector::QuantizationType,
+}
+
+/// Pre-v2 vector index shell metadata (no quantization field).
+#[derive(Serialize, Deserialize)]
+struct SnapshotVectorIndexV1 {
     label: String,
     property: String,
     dimensions: usize,
@@ -122,6 +161,9 @@ impl CatalogSection {
             .filter_map(|(key, index)| {
                 let (label, property) = key.split_once(':')?;
                 let config = index.config();
+                let quantization = index
+                    .quantization_type()
+                    .unwrap_or(grafeo_core::index::vector::QuantizationType::None);
                 Some(SnapshotVectorIndex {
                     label: label.to_string(),
                     property: property.to_string(),
@@ -129,6 +171,7 @@ impl CatalogSection {
                     metric: config.metric,
                     m: config.m,
                     ef_construction: config.ef_construction,
+                    quantization,
                 })
             })
             .collect();
@@ -157,6 +200,63 @@ impl CatalogSection {
             text_indexes,
         }
     }
+
+    fn restore_schema(&self, schema: &SnapshotSchema) {
+        for def in &schema.node_types {
+            self.catalog.register_or_replace_node_type(def.clone());
+        }
+        for def in &schema.edge_types {
+            self.catalog.register_or_replace_edge_type_def(def.clone());
+        }
+        for def in &schema.graph_types {
+            let _ = self.catalog.register_graph_type(def.clone());
+        }
+        for def in &schema.procedures {
+            self.catalog.replace_procedure(def.clone()).ok();
+        }
+        for name in &schema.schemas {
+            let _ = self.catalog.register_schema_namespace(name.clone());
+            let default_key = format!("{name}/__default__");
+            let _ = self.store.create_graph(&default_key);
+        }
+        for (graph_name, type_name) in &schema.graph_type_bindings {
+            let _ = self.catalog.bind_graph_type(graph_name, type_name.clone());
+        }
+    }
+
+    /// Restore vector index shells so VectorStore can apply topology without rebuild.
+    #[cfg(feature = "vector-index")]
+    fn restore_vector_index_shells(
+        &self,
+        indexes: &[(
+            &str,
+            &str,
+            usize,
+            grafeo_core::index::vector::DistanceMetric,
+            usize,
+            usize,
+            grafeo_core::index::vector::QuantizationType,
+        )],
+    ) {
+        use grafeo_core::index::vector::{
+            HnswConfig, HnswIndex, QuantizationType, QuantizedHnswIndex, VectorIndexKind,
+        };
+
+        for (label, property, dimensions, metric, m, ef_construction, quantization) in indexes {
+            let config = HnswConfig::new(*dimensions, *metric)
+                .with_m(*m)
+                .with_ef_construction(*ef_construction);
+            let index = match quantization {
+                QuantizationType::None => {
+                    Arc::new(VectorIndexKind::Hnsw(HnswIndex::with_capacity(config, 0)))
+                }
+                quant => Arc::new(VectorIndexKind::Quantized(QuantizedHnswIndex::new(
+                    config, *quant,
+                ))),
+            };
+            self.store.add_vector_index(label, property, index);
+        }
+    }
 }
 
 impl Section for CatalogSection {
@@ -183,60 +283,90 @@ impl Section for CatalogSection {
 
     fn deserialize(&mut self, data: &[u8]) -> Result<()> {
         let config = bincode::config::standard();
-        let (snapshot, _): (CatalogSnapshot, _) = bincode::serde::decode_from_slice(data, config)
+
+        // Dispatch on the encoded version before decoding the version-specific
+        // shape. A malformed/unknown v2 record must never be reinterpreted as v1.
+        let (version, _): (u8, _) =
+            bincode::serde::decode_from_slice(data, config).map_err(|e| {
+                Error::Serialization(format!("Catalog section version decode failed: {e}"))
+            })?;
+
+        if version == CATALOG_SECTION_VERSION {
+            let (snapshot, _): (CatalogSnapshot, _) =
+                bincode::serde::decode_from_slice(data, config).map_err(|e| {
+                    Error::Serialization(format!(
+                        "Catalog section v{CATALOG_SECTION_VERSION} deserialization failed: {e}"
+                    ))
+                })?;
+            self.restore_schema(&snapshot.schema);
+
+            #[cfg(feature = "vector-index")]
+            {
+                let shells: Vec<_> = snapshot
+                    .indexes
+                    .vector_indexes
+                    .iter()
+                    .map(|v| {
+                        (
+                            v.label.as_str(),
+                            v.property.as_str(),
+                            v.dimensions,
+                            v.metric,
+                            v.m,
+                            v.ef_construction,
+                            v.quantization,
+                        )
+                    })
+                    .collect();
+                self.restore_vector_index_shells(&shells);
+            }
+
+            // Text indexes: registration is handled by the engine after data load.
+            let _ = &snapshot.indexes.text_indexes;
+
+            return Ok(());
+        }
+
+        if version != CATALOG_SECTION_VERSION_V1 {
+            return Err(Error::Serialization(format!(
+                "Unsupported catalog section version {version}; expected {CATALOG_SECTION_VERSION_V1} or {CATALOG_SECTION_VERSION}"
+            )));
+        }
+
+        let (snapshot, _): (CatalogSnapshotV1, _) = bincode::serde::decode_from_slice(data, config)
             .map_err(|e| {
-            Error::Serialization(format!("Catalog section deserialization failed: {e}"))
-        })?;
+                Error::Serialization(format!("Catalog section deserialization failed: {e}"))
+            })?;
 
-        // Restore schema definitions
-        for def in &snapshot.schema.node_types {
-            self.catalog.register_or_replace_node_type(def.clone());
-        }
-        for def in &snapshot.schema.edge_types {
-            self.catalog.register_or_replace_edge_type_def(def.clone());
-        }
-        for def in &snapshot.schema.graph_types {
-            let _ = self.catalog.register_graph_type(def.clone());
-        }
-        for def in &snapshot.schema.procedures {
-            self.catalog.replace_procedure(def.clone()).ok();
-        }
-        for name in &snapshot.schema.schemas {
-            let _ = self.catalog.register_schema_namespace(name.clone());
-            let default_key = format!("{name}/__default__");
-            let _ = self.store.create_graph(&default_key);
-        }
-        for (graph_name, type_name) in &snapshot.schema.graph_type_bindings {
-            let _ = self.catalog.bind_graph_type(graph_name, type_name.clone());
-        }
+        // Accept any successfully-decoded v1-shaped blob (including accidental
+        // decode of empty-index catalogs that share layout with a version=1 header).
+        let _ = snapshot.version.max(CATALOG_SECTION_VERSION_V1);
 
-        // Restore vector index objects from catalog metadata so the
-        // VectorStore section can populate their topology without rebuilding.
-        // Without this, vector_index_entries() returns empty and the persisted
-        // HNSW topology is read from disk but never applied — forcing a full
-        // rebuild on every open.
+        self.restore_schema(&snapshot.schema);
+
         #[cfg(feature = "vector-index")]
         {
-            use grafeo_core::index::vector::{HnswConfig, HnswIndex, VectorIndexKind};
-
-            for vidx in &snapshot.indexes.vector_indexes {
-                let config = HnswConfig::new(vidx.dimensions, vidx.metric)
-                    .with_m(vidx.m)
-                    .with_ef_construction(vidx.ef_construction);
-                let index = Arc::new(VectorIndexKind::Hnsw(HnswIndex::with_capacity(config, 0)));
-                self.store.add_vector_index(&vidx.label, &vidx.property, index);
-            }
+            use grafeo_core::index::vector::QuantizationType;
+            let shells: Vec<_> = snapshot
+                .indexes
+                .vector_indexes
+                .iter()
+                .map(|v| {
+                    (
+                        v.label.as_str(),
+                        v.property.as_str(),
+                        v.dimensions,
+                        v.metric,
+                        v.m,
+                        v.ef_construction,
+                        QuantizationType::None,
+                    )
+                })
+                .collect();
+            self.restore_vector_index_shells(&shells);
         }
 
-        // Text indexes: register placeholder entries so the TextIndex section
-        // can restore BM25 postings without rebuilding.
-        #[cfg(feature = "text-index")]
-        {
-            for tidx in &snapshot.indexes.text_indexes {
-                // Text index restoration is handled by the engine after data load.
-                // Registration here ensures the section restore finds non-empty entries.
-            }
-        }
+        let _ = &snapshot.indexes.text_indexes;
 
         Ok(())
     }
@@ -340,6 +470,7 @@ mod tests {
         let section = make_section();
         assert_eq!(section.section_type(), SectionType::Catalog);
         assert_eq!(section.version(), CATALOG_SECTION_VERSION);
+        assert_eq!(section.version(), 2);
     }
 
     #[test]
@@ -365,5 +496,178 @@ mod tests {
         let mut section = make_section();
         let result = section.deserialize(&[0xFF, 0xFE, 0xFD, 0x00]);
         assert!(result.is_err(), "corrupt data should fail deserialization");
+    }
+
+    #[cfg(feature = "vector-index")]
+    #[test]
+    fn v2_decode_failure_never_falls_back_to_v1_shape() {
+        use grafeo_core::index::vector::DistanceMetric;
+
+        // A v1-shaped payload mislabeled as v2 used to fail v2 decode and then
+        // succeed through the unconditional v1 fallback.
+        let mislabeled_v1 = CatalogSnapshotV1 {
+            version: CATALOG_SECTION_VERSION,
+            schema: SnapshotSchema::default(),
+            indexes: SnapshotIndexesV1 {
+                property_indexes: vec![],
+                vector_indexes: vec![SnapshotVectorIndexV1 {
+                    label: "Doc".to_string(),
+                    property: "emb".to_string(),
+                    dimensions: 8,
+                    metric: DistanceMetric::Cosine,
+                    m: 16,
+                    ef_construction: 100,
+                }],
+                text_indexes: vec![],
+            },
+            epoch: 1,
+        };
+        let bytes =
+            bincode::serde::encode_to_vec(&mislabeled_v1, bincode::config::standard()).unwrap();
+
+        let mut section = make_section();
+        assert!(
+            section.deserialize(&bytes).is_err(),
+            "v2-tagged malformed payload must fail closed without v1 reinterpretation"
+        );
+    }
+
+    /// Encode a golden v1 catalog blob (no quant field) and ensure dual-read
+    /// opens with plain HNSW shells (quant = None).
+    #[cfg(feature = "vector-index")]
+    #[test]
+    fn catalog_v1_vector_index_opens_as_plain_hnsw() {
+        use grafeo_core::index::vector::{
+            DistanceMetric, HnswConfig, HnswIndex, QuantizationType, VectorIndexKind,
+        };
+
+        let v1 = CatalogSnapshotV1 {
+            version: CATALOG_SECTION_VERSION_V1,
+            schema: SnapshotSchema::default(),
+            indexes: SnapshotIndexesV1 {
+                property_indexes: vec![],
+                vector_indexes: vec![SnapshotVectorIndexV1 {
+                    label: "Doc".to_string(),
+                    property: "emb".to_string(),
+                    dimensions: 8,
+                    metric: DistanceMetric::Cosine,
+                    m: 16,
+                    ef_construction: 100,
+                }],
+                text_indexes: vec![],
+            },
+            epoch: 1,
+        };
+        let config = bincode::config::standard();
+        let bytes = bincode::serde::encode_to_vec(&v1, config).unwrap();
+
+        let catalog = Arc::new(Catalog::new());
+        let store = Arc::new(grafeo_core::graph::lpg::LpgStore::new().unwrap());
+        let mut section = CatalogSection::new(catalog, Arc::clone(&store), || 0);
+        section.deserialize(&bytes).expect("v1 dual-read");
+
+        let idx = store
+            .get_vector_index("Doc", "emb")
+            .expect("shell restored");
+        assert!(matches!(*idx, VectorIndexKind::Hnsw(_)));
+        assert_eq!(
+            idx.quantization_type().unwrap_or(QuantizationType::None),
+            QuantizationType::None
+        );
+        assert_eq!(idx.config().dimensions, 8);
+
+        // Sanity: same shell shape as today's plain builder
+        let _plain = VectorIndexKind::Hnsw(HnswIndex::with_capacity(
+            HnswConfig::new(8, DistanceMetric::Cosine),
+            0,
+        ));
+    }
+
+    #[cfg(feature = "vector-index")]
+    #[test]
+    fn catalog_v2_vector_index_quant_roundtrip() {
+        use grafeo_core::index::vector::{
+            DistanceMetric, HnswConfig, QuantizationType, QuantizedHnswIndex, VectorIndexKind,
+        };
+
+        let modes = [
+            QuantizationType::None,
+            QuantizationType::Scalar,
+            QuantizationType::Binary,
+            QuantizationType::Product { num_subvectors: 4 },
+        ];
+
+        for (i, mode) in modes.iter().enumerate() {
+            let label = format!("Doc{i}");
+            let catalog = Arc::new(Catalog::new());
+            let store = Arc::new(grafeo_core::graph::lpg::LpgStore::new().unwrap());
+            let config = HnswConfig::new(8, DistanceMetric::Cosine)
+                .with_m(16)
+                .with_ef_construction(100);
+            let index = match mode {
+                QuantizationType::None => Arc::new(VectorIndexKind::Hnsw(
+                    grafeo_core::index::vector::HnswIndex::with_capacity(config, 0),
+                )),
+                quant => Arc::new(VectorIndexKind::Quantized(QuantizedHnswIndex::new(
+                    config, *quant,
+                ))),
+            };
+            store.add_vector_index(&label, "emb", index);
+
+            let section = CatalogSection::new(catalog, store, || 7);
+            let bytes = section.serialize().expect("serialize v2 catalog");
+
+            // Writer always emits version 2.
+            let (decoded, _): (CatalogSnapshot, _) =
+                bincode::serde::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
+            assert_eq!(decoded.version, 2);
+            assert_eq!(decoded.indexes.vector_indexes.len(), 1);
+            assert_eq!(decoded.indexes.vector_indexes[0].quantization, *mode);
+
+            let catalog2 = Arc::new(Catalog::new());
+            let store2 = Arc::new(grafeo_core::graph::lpg::LpgStore::new().unwrap());
+            let mut section2 = CatalogSection::new(catalog2, Arc::clone(&store2), || 0);
+            section2.deserialize(&bytes).expect("deserialize v2");
+
+            let restored = store2
+                .get_vector_index(&label, "emb")
+                .expect("restored shell");
+            let restored_mode = restored
+                .quantization_type()
+                .unwrap_or(QuantizationType::None);
+            assert_eq!(restored_mode, *mode, "mode mismatch for {mode:?}");
+            match mode {
+                QuantizationType::None => assert!(matches!(*restored, VectorIndexKind::Hnsw(_))),
+                _ => assert!(matches!(*restored, VectorIndexKind::Quantized(_))),
+            }
+        }
+    }
+
+    #[cfg(feature = "vector-index")]
+    #[test]
+    fn catalog_serialize_captures_quant_from_live_index() {
+        use grafeo_core::index::vector::{
+            DistanceMetric, HnswConfig, QuantizationType, QuantizedHnswIndex, VectorIndexKind,
+        };
+
+        let catalog = Arc::new(Catalog::new());
+        let store = Arc::new(grafeo_core::graph::lpg::LpgStore::new().unwrap());
+        let config = HnswConfig::new(16, DistanceMetric::Euclidean);
+        store.add_vector_index(
+            "Mem",
+            "embedding",
+            Arc::new(VectorIndexKind::Quantized(QuantizedHnswIndex::new(
+                config,
+                QuantizationType::Scalar,
+            ))),
+        );
+        let section = CatalogSection::new(catalog, store, || 0);
+        let bytes = section.serialize().unwrap();
+        let (snap, _): (CatalogSnapshot, _) =
+            bincode::serde::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
+        assert_eq!(
+            snap.indexes.vector_indexes[0].quantization,
+            QuantizationType::Scalar
+        );
     }
 }

--- a/crates/grafeo-engine/src/database/crud.rs
+++ b/crates/grafeo-engine/src/database/crud.rs
@@ -1129,4 +1129,31 @@ impl super::GrafeoDB {
 
         ids
     }
+
+    /// Offline bulk loader for a fresh, unpublished graph.
+    ///
+    /// Unlike [`Self::batch_create_nodes_with_props`], this bypasses per-row
+    /// WAL/CDC/index work and holds the node and property-store locks once per
+    /// chunk.  It is rejected once any secondary index exists; create indexes
+    /// only after all rows have been loaded.
+    pub fn bulk_load_nodes_with_props_unindexed(
+        &self,
+        label: &str,
+        properties_list: Vec<
+            std::collections::HashMap<
+                grafeo_common::types::PropertyKey,
+                grafeo_common::types::Value,
+            >,
+        >,
+    ) -> Result<Vec<grafeo_common::types::NodeId>> {
+        use grafeo_common::utils::hash::FxHashMap;
+
+        let rows = properties_list
+            .into_iter()
+            .map(|properties| properties.into_iter().collect::<FxHashMap<_, _>>())
+            .collect();
+        self.lpg_store()
+            .bulk_create_nodes_with_props_unindexed(label, rows)
+            .map_err(|message| grafeo_common::utils::error::Error::Internal(message.to_owned()))
+    }
 }

--- a/crates/grafeo-engine/src/database/crud.rs
+++ b/crates/grafeo-engine/src/database/crud.rs
@@ -1,6 +1,8 @@
 //! Node and edge CRUD operations for GrafeoDB.
 
+#[cfg(feature = "wal")]
 use grafeo_common::grafeo_warn;
+use grafeo_common::utils::error::Result;
 #[cfg(feature = "wal")]
 use grafeo_storage::wal::WalRecord;
 
@@ -21,17 +23,15 @@ impl super::GrafeoDB {
     /// let alix = db.create_node(&["Person"]);
     /// let company = db.create_node(&["Company", "Startup"]);
     /// ```
-    pub fn create_node(&self, labels: &[&str]) -> grafeo_common::types::NodeId {
+    pub fn create_node(&self, labels: &[&str]) -> Result<grafeo_common::types::NodeId> {
         let id = self.lpg_store().create_node(labels);
 
         // Log to WAL if enabled
         #[cfg(feature = "wal")]
-        if let Err(e) = self.log_wal(&WalRecord::CreateNode {
+        self.log_wal(&WalRecord::CreateNode {
             id,
             labels: labels.iter().map(|s| (*s).to_string()).collect(),
-        }) {
-            grafeo_warn!("Failed to log CreateNode to WAL: {}", e);
-        }
+        })?;
 
         #[cfg(feature = "cdc")]
         if self.cdc_active() {
@@ -43,7 +43,7 @@ impl super::GrafeoDB {
             );
         }
 
-        id
+        Ok(id)
     }
 
     /// Creates a new node with labels and properties.
@@ -58,7 +58,7 @@ impl super::GrafeoDB {
                 impl Into<grafeo_common::types::Value>,
             ),
         >,
-    ) -> grafeo_common::types::NodeId {
+    ) -> Result<grafeo_common::types::NodeId> {
         // Collect properties first so we can log them to WAL
         let props: Vec<(
             grafeo_common::types::PropertyKey,
@@ -90,22 +90,18 @@ impl super::GrafeoDB {
         // Log node creation to WAL
         #[cfg(feature = "wal")]
         {
-            if let Err(e) = self.log_wal(&WalRecord::CreateNode {
+            self.log_wal(&WalRecord::CreateNode {
                 id,
                 labels: labels.iter().map(|s| (*s).to_string()).collect(),
-            }) {
-                grafeo_warn!("Failed to log CreateNode to WAL: {}", e);
-            }
+            })?;
 
             // Log each property to WAL for full durability
             for (key, value) in props {
-                if let Err(e) = self.log_wal(&WalRecord::SetNodeProperty {
+                self.log_wal(&WalRecord::SetNodeProperty {
                     id,
                     key: key.to_string(),
                     value,
-                }) {
-                    grafeo_warn!("Failed to log SetNodeProperty to WAL: {}", e);
-                }
+                })?;
             }
         }
 
@@ -139,7 +135,7 @@ impl super::GrafeoDB {
             }
         }
 
-        id
+        Ok(id)
     }
 
     /// Gets a node by ID.
@@ -262,7 +258,7 @@ impl super::GrafeoDB {
     /// Deletes a node and all its edges.
     ///
     /// If WAL is enabled, the operation is logged for durability.
-    pub fn delete_node(&self, id: grafeo_common::types::NodeId) -> bool {
+    pub fn delete_node(&self, id: grafeo_common::types::NodeId) -> Result<bool> {
         // Capture properties for CDC before deletion
         #[cfg(feature = "cdc")]
         let cdc_props = if self.cdc_active() {
@@ -318,7 +314,18 @@ impl super::GrafeoDB {
             })
             .unwrap_or_default();
 
-        let result = self.lpg_store().delete_node(id);
+        let exists = self.lpg_store().get_node(id).is_some();
+
+        #[cfg(feature = "wal")]
+        if exists {
+            self.log_wal(&WalRecord::DeleteNode { id })?;
+        }
+
+        let result = if exists {
+            self.lpg_store().delete_node(id)
+        } else {
+            false
+        };
 
         // Remove from vector indexes after successful deletion
         #[cfg(feature = "vector-index")]
@@ -336,11 +343,6 @@ impl super::GrafeoDB {
             }
         }
 
-        #[cfg(feature = "wal")]
-        if result && let Err(e) = self.log_wal(&WalRecord::DeleteNode { id }) {
-            grafeo_warn!("Failed to log DeleteNode to WAL: {}", e);
-        }
-
         #[cfg(feature = "cdc")]
         if result && self.cdc_active() {
             self.cdc_log.record_delete(
@@ -350,7 +352,7 @@ impl super::GrafeoDB {
             );
         }
 
-        result
+        Ok(result)
     }
 
     /// Sets a property on a node.
@@ -361,7 +363,7 @@ impl super::GrafeoDB {
         id: grafeo_common::types::NodeId,
         key: &str,
         value: grafeo_common::types::Value,
-    ) {
+    ) -> Result<()> {
         // Extract vector data before the value is moved into the store
         #[cfg(feature = "vector-index")]
         let vector_data = match &value {
@@ -371,13 +373,11 @@ impl super::GrafeoDB {
 
         // Log to WAL first
         #[cfg(feature = "wal")]
-        if let Err(e) = self.log_wal(&WalRecord::SetNodeProperty {
+        self.log_wal(&WalRecord::SetNodeProperty {
             id,
             key: key.to_string(),
             value: value.clone(),
-        }) {
-            grafeo_warn!("Failed to log SetNodeProperty to WAL: {}", e);
-        }
+        })?;
 
         // Capture old value for CDC before the store write
         #[cfg(feature = "cdc")]
@@ -446,6 +446,8 @@ impl super::GrafeoDB {
                 }
             }
         }
+
+        Ok(())
     }
 
     /// Adds a label to an existing node.

--- a/crates/grafeo-engine/src/database/crud.rs
+++ b/crates/grafeo-engine/src/database/crud.rs
@@ -249,12 +249,6 @@ impl super::GrafeoDB {
         self.lpg_store().node_property_history(id)
     }
 
-    /// Returns the current epoch of the database.
-    #[must_use]
-    pub fn current_epoch(&self) -> grafeo_common::types::EpochId {
-        self.lpg_store().current_epoch()
-    }
-
     /// Deletes a node and all its edges.
     ///
     /// If WAL is enabled, the operation is logged for durability.

--- a/crates/grafeo-engine/src/database/crud.rs
+++ b/crates/grafeo-engine/src/database/crud.rs
@@ -739,6 +739,23 @@ impl super::GrafeoDB {
         id
     }
 
+    /// Appends property-less edges to a fresh offline graph without WAL or
+    /// CDC records. The underlying LPG store allocates IDs and updates both
+    /// adjacency directions under one lock per chunk.
+    ///
+    /// This is an offline-loader primitive. Callers must checkpoint the fully
+    /// built unpublished database before exposing it to readers.
+    pub fn bulk_load_edges_unindexed(
+        &self,
+        edges: &[(
+            grafeo_common::types::NodeId,
+            grafeo_common::types::NodeId,
+            &str,
+        )],
+    ) -> Vec<grafeo_common::types::EdgeId> {
+        self.lpg_store().batch_create_edges(edges)
+    }
+
     /// Gets an edge by ID.
     #[must_use]
     pub fn get_edge(

--- a/crates/grafeo-engine/src/database/crud.rs
+++ b/crates/grafeo-engine/src/database/crud.rs
@@ -1,6 +1,6 @@
 //! Node and edge CRUD operations for GrafeoDB.
 
-#[cfg(feature = "wal")]
+#[cfg(any(feature = "wal", feature = "vector-index"))]
 use grafeo_common::grafeo_warn;
 use grafeo_common::utils::error::Result;
 #[cfg(feature = "wal")]

--- a/crates/grafeo-engine/src/database/index.rs
+++ b/crates/grafeo-engine/src/database/index.rs
@@ -134,9 +134,6 @@ impl super::GrafeoDB {
         let mut found_dims: Option<usize> = dimensions;
         let mut vector_count = 0usize;
 
-        #[cfg(feature = "vector-index")]
-        let mut vectors: Vec<(grafeo_common::types::NodeId, Vec<f32>)> = Vec::new();
-
         let graph = self.graph_store();
         for node_id in graph.nodes_by_label(label) {
             if let Some(Value::Vector(v)) = graph.get_node_property(node_id, &prop_key) {
@@ -153,8 +150,6 @@ impl super::GrafeoDB {
                     found_dims = Some(v.len());
                 }
                 vector_count += 1;
-                #[cfg(feature = "vector-index")]
-                vectors.push((node_id, v.to_vec()));
             }
         }
 
@@ -200,7 +195,7 @@ impl super::GrafeoDB {
                 m,
                 ef_construction,
                 quantization_type,
-                vectors.len(),
+                vector_count,
             );
 
             match &index {
@@ -208,16 +203,24 @@ impl super::GrafeoDB {
                     let graph = self.graph_store();
                     let accessor =
                         grafeo_core::index::vector::PropertyVectorAccessor::new(&*graph, property);
-                    for (node_id, vec) in &vectors {
-                        index.insert(*node_id, vec, &accessor);
+                    for node_id in graph.nodes_by_label(label) {
+                        if let Some(Value::Vector(vector)) =
+                            graph.get_node_property(node_id, &prop_key)
+                        {
+                            index.insert(node_id, &vector, &accessor);
+                        }
                     }
                 }
                 VectorIndexKind::Quantized(q_idx) => {
                     let graph = self.graph_store();
                     let accessor =
                         grafeo_core::index::vector::PropertyVectorAccessor::new(&*graph, property);
-                    for (node_id, vec) in &vectors {
-                        q_idx.insert(*node_id, vec, &accessor);
+                    for node_id in graph.nodes_by_label(label) {
+                        if let Some(Value::Vector(vector)) =
+                            graph.get_node_property(node_id, &prop_key)
+                        {
+                            q_idx.insert(node_id, &vector, &accessor);
+                        }
                     }
                     // Scalar search currently uses LPG accessor distances, not the
                     // u8 code map. Dropping codes after build avoids pure RSS cost

--- a/crates/grafeo-engine/src/database/index.rs
+++ b/crates/grafeo-engine/src/database/index.rs
@@ -297,6 +297,48 @@ impl super::GrafeoDB {
         removed
     }
 
+    /// Returns whether a vector index is registered for `label` + `property`.
+    #[cfg(feature = "vector-index")]
+    #[must_use]
+    pub fn has_vector_index(&self, label: &str, property: &str) -> bool {
+        self.lpg_store().get_vector_index(label, property).is_some()
+    }
+
+    /// Returns the durable quantization mode for a registered vector index.
+    ///
+    /// # Semantics
+    ///
+    /// | Return | Meaning |
+    /// |--------|---------|
+    /// | `None` | no vector index registered for the label/property |
+    /// | `Some(QuantizationType::None)` | plain HNSW shell |
+    /// | `Some(Scalar \| Binary \| Product{..})` | quantized shell |
+    ///
+    /// This is the stable inspect surface for reopen/sticky-mode tests.
+    /// Prefer this over env defaults after open.
+    #[cfg(feature = "vector-index")]
+    #[must_use]
+    pub fn vector_index_quantization(
+        &self,
+        label: &str,
+        property: &str,
+    ) -> Option<grafeo_core::index::vector::QuantizationType> {
+        use grafeo_core::index::vector::QuantizationType;
+        let index = self.lpg_store().get_vector_index(label, property)?;
+        Some(index.quantization_type().unwrap_or(QuantizationType::None))
+    }
+
+    /// Estimated heap memory for a registered vector index (topology + payloads).
+    ///
+    /// Returns `None` if the index is not registered. Not process RSS.
+    #[cfg(feature = "vector-index")]
+    #[must_use]
+    pub fn vector_index_heap_memory_bytes(&self, label: &str, property: &str) -> Option<usize> {
+        self.lpg_store()
+            .get_vector_index(label, property)
+            .map(|idx| idx.heap_memory_bytes())
+    }
+
     /// Drops and recreates a vector index, rescanning all matching nodes.
     ///
     /// In normal usage you do **not** need to call this. Vector indexes

--- a/crates/grafeo-engine/src/database/index.rs
+++ b/crates/grafeo-engine/src/database/index.rs
@@ -316,6 +316,18 @@ impl super::GrafeoDB {
         self.lpg_store().get_vector_index(label, property).is_some()
     }
 
+    /// Returns the configured dimensions for a registered vector index.
+    ///
+    /// This remains available when the authoritative property column is
+    /// ForceDisk-spilled and cannot be dimension-probed through graph reads.
+    #[cfg(feature = "vector-index")]
+    #[must_use]
+    pub fn vector_index_dimensions(&self, label: &str, property: &str) -> Option<usize> {
+        self.lpg_store()
+            .get_vector_index(label, property)
+            .map(|index| index.config().dimensions)
+    }
+
     /// Returns the durable quantization mode for a registered vector index.
     ///
     /// # Semantics

--- a/crates/grafeo-engine/src/database/index.rs
+++ b/crates/grafeo-engine/src/database/index.rs
@@ -213,8 +213,20 @@ impl super::GrafeoDB {
                     }
                 }
                 VectorIndexKind::Quantized(q_idx) => {
+                    let graph = self.graph_store();
+                    let accessor =
+                        grafeo_core::index::vector::PropertyVectorAccessor::new(&*graph, property);
                     for (node_id, vec) in &vectors {
-                        q_idx.insert(*node_id, vec);
+                        q_idx.insert(*node_id, vec, &accessor);
+                    }
+                    // Scalar search currently uses LPG accessor distances, not the
+                    // u8 code map. Dropping codes after build avoids pure RSS cost
+                    // while Catalog mode remains Scalar (sticky durability).
+                    if matches!(
+                        quantization_type,
+                        grafeo_core::index::vector::QuantizationType::Scalar
+                    ) {
+                        q_idx.release_quantized_payloads();
                     }
                 }
             }

--- a/crates/grafeo-engine/src/database/mod.rs
+++ b/crates/grafeo-engine/src/database/mod.rs
@@ -1562,16 +1562,17 @@ impl GrafeoDB {
     /// Rehydrate quantized vector index payloads after open.
     ///
     /// Catalog restore creates empty `VectorIndexKind` shells; VectorStore
-    /// applies topology only. Quantized indexes also need full-precision
-    /// vectors + codes, which live in-process (not in GVST). Scan embeddings
-    /// via [`graph_store()`] so CompactStore base + overlay are both visible.
+    /// applies topology only. Quantized indexes need in-process **codes** (not
+    /// a second full-f32 copy of LPG embeddings). Two-pass scan:
+    /// 1) train quantizer parameters without retaining every vector
+    /// 2) write codes only, rescoring uses [`PropertyVectorAccessor`] at search
     ///
     /// Sequencing (required): Catalog shells → LPG load → VectorStore topology
     /// → WAL → wire_layered_after_load → **this step** → spill restore.
     #[cfg(all(feature = "lpg", feature = "vector-index"))]
     fn rehydrate_quantized_vector_indexes(&self) -> Result<()> {
         use grafeo_common::types::{PropertyKey, Value};
-        use grafeo_core::index::vector::QuantizationType;
+        use grafeo_core::index::vector::{BinaryQuantizer, QuantizationType};
 
         let entries = self.lpg_store().vector_index_entries();
         if entries.is_empty() {
@@ -1587,27 +1588,123 @@ impl GrafeoDB {
                 continue;
             };
             let prop_key = PropertyKey::new(property);
-            let mut vectors = Vec::new();
-            for node_id in graph.nodes_by_label(label) {
-                if let Some(Value::Vector(v)) = graph.get_node_property(node_id, &prop_key) {
-                    vectors.push((node_id, v.to_vec()));
+            let dimensions = q_idx.config().dimensions;
+            if dimensions == 0 {
+                return Err(grafeo_common::utils::error::Error::Serialization(format!(
+                    "Cannot rehydrate vector index {key}: catalog dimensions are zero"
+                )));
+            }
+
+            match q_idx.quantization_type() {
+                QuantizationType::None => {
+                    // Exact quantized-shell path: keep legacy full-vector rehydrate.
+                    let mut vectors = Vec::new();
+                    for node_id in graph.nodes_by_label(label) {
+                        if let Some(Value::Vector(v)) = graph.get_node_property(node_id, &prop_key)
+                        {
+                            if v.len() != dimensions {
+                                return Err(grafeo_common::utils::error::Error::Serialization(
+                                    format!(
+                                        "Cannot rehydrate vector index {key}: stored vectors do not match catalog dimensions {dimensions}"
+                                    ),
+                                ));
+                            }
+                            vectors.push((node_id, v.to_vec()));
+                        }
+                    }
+                    q_idx.rehydrate_payloads_from_vectors(vectors);
+                }
+                QuantizationType::Scalar => {
+                    // Topology is already restored from VectorStore. Today's
+                    // scalar search walk/rescore uses the LPG property accessor
+                    // (full precision), not the u8 code map — see
+                    // `search_scalar_quantized`. Materializing 1 byte/dim codes
+                    // for every embedding is pure RSS overhead on reopen and
+                    // prevented the Layer 4 "scalar < plain" bar.
+                    //
+                    // Keep mode sticky via Catalog; leave codes empty so search
+                    // falls through to accessor-backed exact distances (same
+                    // memory model as plain HNSW). When HNSW gains quantized
+                    // distance scoring, rehydrate codes here again.
+                    let mut count = 0usize;
+                    for node_id in graph.nodes_by_label(label) {
+                        if let Some(Value::Vector(v)) = graph.get_node_property(node_id, &prop_key)
+                        {
+                            if v.len() != dimensions {
+                                return Err(grafeo_common::utils::error::Error::Serialization(
+                                    format!(
+                                        "Cannot rehydrate vector index {key}: stored vectors do not match catalog dimensions {dimensions}"
+                                    ),
+                                ));
+                            }
+                            count += 1;
+                        }
+                    }
+                    let _ = count; // validates dim match; empty → probe ready=false
+                    q_idx.release_quantized_payloads();
+                }
+                QuantizationType::Binary => {
+                    let mut codes = Vec::new();
+                    for node_id in graph.nodes_by_label(label) {
+                        if let Some(Value::Vector(v)) = graph.get_node_property(node_id, &prop_key)
+                        {
+                            if v.len() != dimensions {
+                                return Err(grafeo_common::utils::error::Error::Serialization(
+                                    format!(
+                                        "Cannot rehydrate vector index {key}: stored vectors do not match catalog dimensions {dimensions}"
+                                    ),
+                                ));
+                            }
+                            codes.push((node_id, BinaryQuantizer::quantize(v.as_ref())));
+                        }
+                    }
+                    if codes.is_empty() {
+                        continue;
+                    }
+                    q_idx.rehydrate_binary_codes_only(codes);
+                }
+                QuantizationType::Product { num_subvectors } => {
+                    if num_subvectors == 0 || !dimensions.is_multiple_of(num_subvectors) {
+                        return Err(grafeo_common::utils::error::Error::Serialization(format!(
+                            "Cannot rehydrate product vector index {key}: dimensions {dimensions} are not divisible by {num_subvectors} subvectors"
+                        )));
+                    }
+                    // Product training still needs a temporary sample batch; drop after codes.
+                    let mut vectors = Vec::new();
+                    for node_id in graph.nodes_by_label(label) {
+                        if let Some(Value::Vector(v)) = graph.get_node_property(node_id, &prop_key)
+                        {
+                            if v.len() != dimensions {
+                                return Err(grafeo_common::utils::error::Error::Serialization(
+                                    format!(
+                                        "Cannot rehydrate vector index {key}: stored vectors do not match catalog dimensions {dimensions}"
+                                    ),
+                                ));
+                            }
+                            vectors.push((node_id, v.to_vec()));
+                        }
+                    }
+                    q_idx.rehydrate_payloads_from_vectors(vectors);
+                }
+                _ => {
+                    // Forward-compatible: unknown quant modes keep legacy path.
+                    let mut vectors = Vec::new();
+                    for node_id in graph.nodes_by_label(label) {
+                        if let Some(Value::Vector(v)) = graph.get_node_property(node_id, &prop_key)
+                        {
+                            if v.len() != dimensions {
+                                return Err(grafeo_common::utils::error::Error::Serialization(
+                                    format!(
+                                        "Cannot rehydrate vector index {key}: stored vectors do not match catalog dimensions {dimensions}"
+                                    ),
+                                ));
+                            }
+                            vectors.push((node_id, v.to_vec()));
+                        }
+                    }
+                    q_idx.rehydrate_payloads_from_vectors(vectors);
                 }
             }
-            let dimensions = q_idx.config().dimensions;
-            if dimensions == 0 || vectors.iter().any(|(_, vector)| vector.len() != dimensions) {
-                return Err(grafeo_common::utils::error::Error::Serialization(format!(
-                    "Cannot rehydrate vector index {key}: stored vectors do not match catalog dimensions {dimensions}"
-                )));
-            }
-            if let QuantizationType::Product { num_subvectors } = q_idx.quantization_type()
-                && (num_subvectors == 0 || !dimensions.is_multiple_of(num_subvectors))
-            {
-                return Err(grafeo_common::utils::error::Error::Serialization(format!(
-                    "Cannot rehydrate product vector index {key}: dimensions {dimensions} are not divisible by {num_subvectors} subvectors"
-                )));
-            }
-            // Empty scan leaves mode-correct empty shell (readiness false).
-            q_idx.rehydrate_payloads_from_vectors(vectors);
         }
         Ok(())
     }

--- a/crates/grafeo-engine/src/database/mod.rs
+++ b/crates/grafeo-engine/src/database/mod.rs
@@ -667,6 +667,13 @@ impl GrafeoDB {
             db.wire_layered_after_load(compact_base, loaded_overlay_deletions)?;
         }
 
+        // After Catalog shells + VectorStore topology + WAL + layered wiring,
+        // rehydrate Quantized payloads from LPG embeddings via graph_store().
+        // Must not run inside CatalogSection::deserialize (misses CompactStore
+        // base embeddings). Topology is reused; no full HNSW rebuild.
+        #[cfg(all(feature = "lpg", feature = "vector-index"))]
+        db.rehydrate_quantized_vector_indexes()?;
+
         // Start periodic checkpoint timer if configured
         #[cfg(all(feature = "grafeo-file", feature = "lpg"))]
         if let (Some(interval), Some(fm)) = (checkpoint_interval, &db.file_manager)
@@ -1550,6 +1557,59 @@ impl GrafeoDB {
             grafeo_core::graph::compact::deletions_section::OverlayDeletionsSection::empty();
         section.deserialize(&data)?;
         Ok(Some(section.take()))
+    }
+
+    /// Rehydrate quantized vector index payloads after open.
+    ///
+    /// Catalog restore creates empty `VectorIndexKind` shells; VectorStore
+    /// applies topology only. Quantized indexes also need full-precision
+    /// vectors + codes, which live in-process (not in GVST). Scan embeddings
+    /// via [`graph_store()`] so CompactStore base + overlay are both visible.
+    ///
+    /// Sequencing (required): Catalog shells → LPG load → VectorStore topology
+    /// → WAL → wire_layered_after_load → **this step** → spill restore.
+    #[cfg(all(feature = "lpg", feature = "vector-index"))]
+    fn rehydrate_quantized_vector_indexes(&self) -> Result<()> {
+        use grafeo_common::types::{PropertyKey, Value};
+        use grafeo_core::index::vector::QuantizationType;
+
+        let entries = self.lpg_store().vector_index_entries();
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        let graph = self.graph_store();
+        for (key, index) in entries {
+            let Some(q_idx) = index.as_quantized() else {
+                continue;
+            };
+            let Some((label, property)) = key.split_once(':') else {
+                continue;
+            };
+            let prop_key = PropertyKey::new(property);
+            let mut vectors = Vec::new();
+            for node_id in graph.nodes_by_label(label) {
+                if let Some(Value::Vector(v)) = graph.get_node_property(node_id, &prop_key) {
+                    vectors.push((node_id, v.to_vec()));
+                }
+            }
+            let dimensions = q_idx.config().dimensions;
+            if dimensions == 0 || vectors.iter().any(|(_, vector)| vector.len() != dimensions) {
+                return Err(grafeo_common::utils::error::Error::Serialization(format!(
+                    "Cannot rehydrate vector index {key}: stored vectors do not match catalog dimensions {dimensions}"
+                )));
+            }
+            if let QuantizationType::Product { num_subvectors } = q_idx.quantization_type()
+                && (num_subvectors == 0 || !dimensions.is_multiple_of(num_subvectors))
+            {
+                return Err(grafeo_common::utils::error::Error::Serialization(format!(
+                    "Cannot rehydrate product vector index {key}: dimensions {dimensions} are not divisible by {num_subvectors} subvectors"
+                )));
+            }
+            // Empty scan leaves mode-correct empty shell (readiness false).
+            q_idx.rehydrate_payloads_from_vectors(vectors);
+        }
+        Ok(())
     }
 
     /// Loads from a section-based `.grafeo` file (v2 format).

--- a/crates/grafeo-engine/src/database/mod.rs
+++ b/crates/grafeo-engine/src/database/mod.rs
@@ -7,6 +7,8 @@
 //! - `crud` - Node/edge CRUD operations
 //! - `index` - Property, vector, and text index management
 //! - `search` - Vector, text, and hybrid search
+//! - `vector_access` - Shared spill-aware vector accessor construction
+//! - `vector_read` - Exact spill-aware vector reads by NodeId
 //! - `embed` - Embedding model management
 //! - `persistence` - Save, load, snapshots, iteration
 //! - `admin` - Stats, introspection, diagnostics, CDC
@@ -47,8 +49,15 @@ mod rdf_ops;
 #[cfg(feature = "lpg")]
 mod search;
 pub(crate) mod section_consumer;
+#[cfg(all(feature = "lpg", feature = "vector-index"))]
+mod vector_access;
+#[cfg(all(feature = "lpg", feature = "vector-index"))]
+mod vector_read;
 #[cfg(all(feature = "wal", feature = "lpg"))]
 pub(crate) mod wal_store;
+
+#[cfg(all(feature = "lpg", feature = "vector-index"))]
+pub use vector_read::IndexedVectorRead;
 
 use grafeo_common::{grafeo_error, grafeo_warn};
 #[cfg(feature = "wal")]

--- a/crates/grafeo-engine/src/database/mod.rs
+++ b/crates/grafeo-engine/src/database/mod.rs
@@ -692,16 +692,17 @@ impl GrafeoDB {
             ));
         }
 
-        // Discover existing spill files from a previous session.
-        // If vectors were spilled before close, the spill files persist on disk
-        // and need to be re-mapped so search can read from them.
+        // Spill sidecars are ephemeral mmap snapshots, never durability
+        // authority. The complete vector property column is restored from the
+        // .grafeo container (plus WAL) above; discard old sidecars before
+        // applying this session's ForceDisk policy.
         #[cfg(all(
             feature = "lpg",
             feature = "vector-index",
             feature = "mmap",
             not(feature = "temporal")
         ))]
-        db.restore_spill_files();
+        db.discard_stale_vector_spill_files();
 
         // Phase 8a: apply per-section ForceDisk overrides. Each section
         // type configured as ForceDisk triggers a targeted spill of its
@@ -2657,6 +2658,30 @@ impl GrafeoDB {
         self.buffer_manager.reload_eligible(target_fraction)
     }
 
+    /// Materializes spill-backed vectors before a mutation that may update an
+    /// existing HNSW topology.
+    ///
+    /// HNSW insertion reads neighboring vectors through the mutable property
+    /// accessor. Call this before vector-bearing GQL writes so those reads see
+    /// the complete graph rather than only the post-spill delta. The next
+    /// checkpoint reapplies ForceDisk when configured.
+    #[cfg(all(
+        feature = "lpg",
+        feature = "vector-index",
+        feature = "mmap",
+        not(feature = "temporal")
+    ))]
+    pub fn prepare_vector_mutation(&self) -> Result<()> {
+        self.buffer_manager
+            .reload_consumer_by_name("section:VectorStore")
+            .map(|_| ())
+            .map_err(|error| {
+                Error::Internal(format!(
+                    "failed to reload spilled vectors before mutation: {error}"
+                ))
+            })
+    }
+
     /// Returns the current [`StorageTier`] of every registered section consumer.
     ///
     /// The map keys are the [`SectionType`]s parsed from each consumer's name
@@ -2699,93 +2724,33 @@ impl GrafeoDB {
         out
     }
 
-    /// Discovers and re-opens spill files from a previous session.
+    /// Removes vector spill sidecars left by a prior process.
     ///
-    /// When the database was closed with spilled vector embeddings, the
-    /// `vectors_*.bin` files persist in the spill directory. This method
-    /// scans for them, opens each as `MmapStorage`, and registers them
-    /// in the `vector_spill_storages` map so search can read from them.
+    /// Spill files are ephemeral mmap snapshots. The `.grafeo` container plus
+    /// WAL is the durable authority, so reopen always rebuilds ForceDisk state
+    /// from the freshly loaded property column instead of trusting a sidecar
+    /// that may predate later Auto-tier mutations.
     #[cfg(all(
         feature = "lpg",
         feature = "vector-index",
         feature = "mmap",
         not(feature = "temporal")
     ))]
-    fn restore_spill_files(&mut self) {
-        use grafeo_core::index::vector::MmapStorage;
-
-        let spill_dir = match self.buffer_manager.config().spill_path {
-            Some(ref path) => path.clone(),
-            None => return,
-        };
-
-        if !spill_dir.exists() {
-            return;
-        }
-
-        let spill_map = match self.vector_spill_storages {
-            Some(ref map) => Arc::clone(map),
-            None => return,
-        };
-
-        let Ok(entries) = std::fs::read_dir(&spill_dir) else {
+    fn discard_stale_vector_spill_files(&self) {
+        let Some(spill_dir) = self.buffer_manager.config().spill_path.as_ref() else {
             return;
         };
-
-        let Some(ref store) = self.store else {
+        let Ok(entries) = std::fs::read_dir(spill_dir) else {
             return;
         };
-
         for entry in entries.flatten() {
             let path = entry.path();
-            let file_name = match path.file_name().and_then(|n| n.to_str()) {
-                Some(name) => name.to_string(),
-                None => continue,
-            };
-
-            // Match pattern: vectors_{key}.bin where key is percent-encoded
-            if !file_name.starts_with("vectors_")
-                || !std::path::Path::new(&file_name)
-                    .extension()
-                    .is_some_and(|ext| ext.eq_ignore_ascii_case("bin"))
-            {
-                continue;
-            }
-
-            // Extract and decode key: "vectors_Label%3Aembedding.bin" -> "Label:embedding"
-            let key_part = &file_name["vectors_".len()..file_name.len() - ".bin".len()];
-
-            // Percent-decode: %3A -> ':', %25 -> '%'
-            let key = key_part.replace("%3A", ":").replace("%25", "%");
-
-            // Key must contain ':' (label:property format)
-            if !key.contains(':') {
-                // Legacy file with old encoding, skip (will be re-created on next spill)
-                continue;
-            }
-
-            // Only restore if the corresponding vector index exists
-            if store.get_vector_index_by_key(&key).is_none() {
-                // Stale spill file (index was dropped), clean it up
-                let _ = std::fs::remove_file(&path);
-                continue;
-            }
-
-            // Open the MmapStorage
-            match MmapStorage::open(&path) {
-                Ok(mmap_storage) => {
-                    // Mark the property column as spilled so get() returns None
-                    let property = key.split(':').nth(1).unwrap_or("");
-                    let prop_key = grafeo_common::types::PropertyKey::new(property);
-                    store.node_properties_mark_spilled(&prop_key);
-
-                    spill_map.write().insert(key, Arc::new(mmap_storage));
-                }
-                Err(e) => {
-                    eprintln!("failed to restore spill file {}: {e}", path.display());
-                    // Remove corrupt spill file
-                    let _ = std::fs::remove_file(&path);
-                }
+            let is_vector_spill = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("vectors_") && name.ends_with(".bin"));
+            if is_vector_spill {
+                let _ = std::fs::remove_file(path);
             }
         }
     }
@@ -2986,6 +2951,47 @@ impl GrafeoDB {
         fm: &GrafeoFileManager,
         reason: flush::FlushReason,
     ) -> Result<flush::FlushResult> {
+        #[cfg(all(
+            feature = "lpg",
+            feature = "vector-index",
+            feature = "mmap",
+            not(feature = "temporal")
+        ))]
+        let vector_was_on_disk =
+            self.buffer_manager
+                .snapshot_consumer_tiers()
+                .iter()
+                .any(|(name, tier)| {
+                    name == "section:VectorStore"
+                        && *tier == grafeo_common::memory::StorageTier::OnDisk
+                });
+        #[cfg(all(
+            feature = "lpg",
+            feature = "vector-index",
+            feature = "mmap",
+            not(feature = "temporal")
+        ))]
+        let vector_force_disk = self
+            .config
+            .section_configs
+            .get(&grafeo_common::storage::SectionType::VectorStore)
+            .is_some_and(|config| config.tier == grafeo_common::storage::TierOverride::ForceDisk);
+        #[cfg(all(
+            feature = "lpg",
+            feature = "vector-index",
+            feature = "mmap",
+            not(feature = "temporal")
+        ))]
+        if vector_was_on_disk {
+            self.buffer_manager
+                .reload_consumer_by_name("section:VectorStore")
+                .map_err(|error| {
+                    Error::Internal(format!(
+                        "failed to reload spilled vectors before checkpoint: {error}"
+                    ))
+                })?;
+        }
+
         let sections = self.build_sections();
         let section_refs: Vec<&dyn grafeo_common::storage::Section> =
             sections.iter().map(|s| s.as_ref()).collect();
@@ -2994,14 +3000,31 @@ impl GrafeoDB {
         #[cfg(not(feature = "lpg"))]
         let context = flush::build_context_minimal(&self.transaction_manager);
 
-        flush::flush(
+        let result = flush::flush(
             fm,
             &section_refs,
             &context,
             reason,
             #[cfg(feature = "wal")]
             self.wal.as_deref(),
-        )
+        );
+
+        // Spill sidecars are derived state. Recreate them only after the
+        // authoritative container snapshot has serialized the complete merged
+        // property column. Preserve an existing OnDisk tier, and enforce
+        // ForceDisk for indexes created after database open.
+        #[cfg(all(
+            feature = "lpg",
+            feature = "vector-index",
+            feature = "mmap",
+            not(feature = "temporal")
+        ))]
+        if vector_was_on_disk || vector_force_disk {
+            self.buffer_manager
+                .spill_consumer_by_name("section:VectorStore");
+        }
+
+        result
     }
 
     /// Returns the file manager if using single-file format.

--- a/crates/grafeo-engine/src/database/mod.rs
+++ b/crates/grafeo-engine/src/database/mod.rs
@@ -3239,11 +3239,13 @@ mod tests {
         {
             let db = GrafeoDB::open(&db_path).unwrap();
 
-            let alix = db.create_node(&["Person"]);
-            db.set_node_property(alix, "name", Value::from("Alix"));
+            let alix = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(alix, "name", Value::from("Alix"))
+                .unwrap();
 
-            let gus = db.create_node(&["Person"]);
-            db.set_node_property(gus, "name", Value::from("Gus"));
+            let gus = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(gus, "name", Value::from("Gus"))
+                .unwrap();
 
             let _edge = db.create_edge(alix, gus, "KNOWS");
 
@@ -3278,8 +3280,8 @@ mod tests {
         let db = GrafeoDB::open(&db_path).unwrap();
 
         // Create some data
-        let node = db.create_node(&["Test"]);
-        db.delete_node(node);
+        let node = db.create_node(&["Test"]).unwrap();
+        db.delete_node(node).unwrap();
 
         // WAL should have records
         if let Some(wal) = db.wal() {
@@ -3302,8 +3304,9 @@ mod tests {
         // Session 1: Create initial data
         {
             let db = GrafeoDB::open(&db_path).unwrap();
-            let alix = db.create_node(&["Person"]);
-            db.set_node_property(alix, "name", Value::from("Alix"));
+            let alix = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(alix, "name", Value::from("Alix"))
+                .unwrap();
             db.close().unwrap();
         }
 
@@ -3311,8 +3314,9 @@ mod tests {
         {
             let db = GrafeoDB::open(&db_path).unwrap();
             assert_eq!(db.node_count(), 1); // Previous data recovered
-            let gus = db.create_node(&["Person"]);
-            db.set_node_property(gus, "name", Value::from("Gus"));
+            let gus = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(gus, "name", Value::from("Gus"))
+                .unwrap();
             db.close().unwrap();
         }
 
@@ -3344,9 +3348,9 @@ mod tests {
             let db = GrafeoDB::open(&db_path).unwrap();
 
             // Create nodes
-            let a = db.create_node(&["Node"]);
-            let b = db.create_node(&["Node"]);
-            let c = db.create_node(&["Node"]);
+            let a = db.create_node(&["Node"]).unwrap();
+            let b = db.create_node(&["Node"]).unwrap();
+            let c = db.create_node(&["Node"]).unwrap();
 
             // Create edges
             let e1 = db.create_edge(a, b, "LINKS");
@@ -3354,11 +3358,11 @@ mod tests {
 
             // Delete middle node and its edge
             db.delete_edge(e1);
-            db.delete_node(b);
+            db.delete_node(b).unwrap();
 
             // Set properties on remaining nodes
-            db.set_node_property(a, "value", Value::Int64(1));
-            db.set_node_property(c, "value", Value::Int64(3));
+            db.set_node_property(a, "value", Value::Int64(1)).unwrap();
+            db.set_node_property(c, "value", Value::Int64(3)).unwrap();
 
             db.close().unwrap();
         }
@@ -3392,7 +3396,7 @@ mod tests {
         let db_path = dir.path().join("close_test_db");
 
         let db = GrafeoDB::open(&db_path).unwrap();
-        db.create_node(&["Test"]);
+        db.create_node(&["Test"]).unwrap();
 
         // First close should succeed
         assert!(db.close().is_ok());
@@ -3442,8 +3446,8 @@ mod tests {
         let db = GrafeoDB::new_in_memory();
 
         // Perform some operations
-        db.create_node(&["Person"]);
-        db.create_node(&["Person"]);
+        db.create_node(&["Person"]).unwrap();
+        db.create_node(&["Person"]).unwrap();
 
         // Check that metrics snapshot returns data
         let snap = db.metrics();
@@ -3455,8 +3459,8 @@ mod tests {
     fn test_query_result_has_metrics() {
         // Verifies that query results include execution metrics
         let db = GrafeoDB::new_in_memory();
-        db.create_node(&["Person"]);
-        db.create_node(&["Person"]);
+        db.create_node(&["Person"]).unwrap();
+        db.create_node(&["Person"]).unwrap();
 
         #[cfg(feature = "gql")]
         {
@@ -3474,7 +3478,7 @@ mod tests {
     fn test_empty_query_result_metrics() {
         // Verifies metrics are correct for queries returning no results
         let db = GrafeoDB::new_in_memory();
-        db.create_node(&["Person"]);
+        db.create_node(&["Person"]).unwrap();
 
         #[cfg(feature = "gql")]
         {
@@ -3501,12 +3505,12 @@ mod tests {
             let db = cdc_db();
 
             // Create
-            let id = db.create_node(&["Person"]);
+            let id = db.create_node(&["Person"]).unwrap();
             // Update
-            db.set_node_property(id, "name", "Alix".into());
-            db.set_node_property(id, "name", "Gus".into());
+            db.set_node_property(id, "name", "Alix".into()).unwrap();
+            db.set_node_property(id, "name", "Gus".into()).unwrap();
             // Delete
-            db.delete_node(id);
+            db.delete_node(id).unwrap();
 
             let history = db.history(id).unwrap();
             assert_eq!(history.len(), 4); // create + 2 updates + delete
@@ -3522,8 +3526,8 @@ mod tests {
         fn test_edge_lifecycle_history() {
             let db = cdc_db();
 
-            let alix = db.create_node(&["Person"]);
-            let gus = db.create_node(&["Person"]);
+            let alix = db.create_node(&["Person"]).unwrap();
+            let gus = db.create_node(&["Person"]).unwrap();
             let edge = db.create_edge(alix, gus, "KNOWS");
             db.set_edge_property(edge, "since", 2024i64.into());
             db.delete_edge(edge);
@@ -3539,13 +3543,15 @@ mod tests {
         fn test_create_node_with_props_cdc() {
             let db = cdc_db();
 
-            let id = db.create_node_with_props(
-                &["Person"],
-                vec![
-                    ("name", grafeo_common::types::Value::from("Alix")),
-                    ("age", grafeo_common::types::Value::from(30i64)),
-                ],
-            );
+            let id = db
+                .create_node_with_props(
+                    &["Person"],
+                    vec![
+                        ("name", grafeo_common::types::Value::from("Alix")),
+                        ("age", grafeo_common::types::Value::from(30i64)),
+                    ],
+                )
+                .unwrap();
 
             let history = db.history(id).unwrap();
             assert_eq!(history.len(), 1);
@@ -3559,9 +3565,9 @@ mod tests {
         fn test_changes_between() {
             let db = cdc_db();
 
-            let id1 = db.create_node(&["A"]);
-            let _id2 = db.create_node(&["B"]);
-            db.set_node_property(id1, "x", 1i64.into());
+            let id1 = db.create_node(&["A"]).unwrap();
+            let _id2 = db.create_node(&["B"]).unwrap();
+            db.set_node_property(id1, "x", 1i64.into()).unwrap();
 
             // All events should be at the same epoch (in-memory, epoch doesn't advance without tx)
             let changes = db
@@ -3578,8 +3584,8 @@ mod tests {
             let db = GrafeoDB::new_in_memory();
             assert!(!db.is_cdc_enabled());
 
-            let id = db.create_node(&["Person"]);
-            db.set_node_property(id, "name", "Alix".into());
+            let id = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(id, "name", "Alix".into()).unwrap();
 
             let history = db.history(id).unwrap();
             assert!(history.is_empty(), "CDC off by default: no events recorded");
@@ -3631,13 +3637,13 @@ mod tests {
             db.set_cdc_enabled(true);
             assert!(db.is_cdc_enabled());
 
-            let id = db.create_node(&["Person"]);
+            let id = db.create_node(&["Person"]).unwrap();
             let history = db.history(id).unwrap();
             assert_eq!(history.len(), 1, "CDC enabled at runtime records events");
 
             // Disable again
             db.set_cdc_enabled(false);
-            let id2 = db.create_node(&["Person"]);
+            let id2 = db.create_node(&["Person"]).unwrap();
             let history2 = db.history(id2).unwrap();
             assert!(
                 history2.is_empty(),
@@ -3913,7 +3919,7 @@ mod tests {
     #[test]
     fn test_database_gc() {
         let db = GrafeoDB::new_in_memory();
-        db.create_node(&["Person"]);
+        db.create_node(&["Person"]).unwrap();
         db.gc();
         // Verify no panic, node still accessible
         assert_eq!(db.node_count(), 1);
@@ -4025,7 +4031,7 @@ mod tests {
     #[test]
     fn test_graph_store_returns_lpg_by_default() {
         let db = GrafeoDB::new_in_memory();
-        db.create_node(&["Person"]);
+        db.create_node(&["Person"]).unwrap();
         let store = db.graph_store();
         assert_eq!(store.node_count(), 1);
     }
@@ -4080,7 +4086,7 @@ mod tests {
     #[allow(deprecated)]
     fn test_session_read_only() {
         let db = GrafeoDB::new_in_memory();
-        db.create_node(&["Person"]);
+        db.create_node(&["Person"]).unwrap();
 
         let session = db.session_read_only();
         // Read queries should work
@@ -4098,7 +4104,7 @@ mod tests {
     #[test]
     fn test_close_in_memory_database() {
         let db = GrafeoDB::new_in_memory();
-        db.create_node(&["Person"]);
+        db.create_node(&["Person"]).unwrap();
         assert!(db.close().is_ok());
         // Second close should also be fine (idempotent)
         assert!(db.close().is_ok());

--- a/crates/grafeo-engine/src/database/persistence.rs
+++ b/crates/grafeo-engine/src/database/persistence.rs
@@ -1277,10 +1277,10 @@ mod tests {
     #[test]
     fn test_to_memory_copies_edges_and_properties() {
         let db = GrafeoDB::new_in_memory();
-        let a = db.create_node(&["Person"]);
-        db.set_node_property(a, "name", "Alix".into());
-        let b = db.create_node(&["Person"]);
-        db.set_node_property(b, "name", "Gus".into());
+        let a = db.create_node(&["Person"]).unwrap();
+        db.set_node_property(a, "name", "Alix".into()).unwrap();
+        let b = db.create_node(&["Person"]).unwrap();
+        db.set_node_property(b, "name", "Gus".into()).unwrap();
         let edge = db.create_edge(a, b, "KNOWS");
         db.set_edge_property(edge, "since", Value::Int64(2020));
 
@@ -1318,10 +1318,10 @@ mod tests {
     #[test]
     fn test_iter_nodes_returns_all() {
         let db = GrafeoDB::new_in_memory();
-        let id1 = db.create_node(&["Person"]);
-        db.set_node_property(id1, "name", "Alix".into());
-        let id2 = db.create_node(&["Animal"]);
-        db.set_node_property(id2, "name", "Fido".into());
+        let id1 = db.create_node(&["Person"]).unwrap();
+        db.set_node_property(id1, "name", "Alix".into()).unwrap();
+        let id2 = db.create_node(&["Animal"]).unwrap();
+        db.set_node_property(id2, "name", "Fido".into()).unwrap();
 
         let nodes: Vec<_> = db.iter_nodes().collect();
         assert_eq!(nodes.len(), 2);
@@ -1344,9 +1344,9 @@ mod tests {
     #[test]
     fn test_iter_edges_returns_all() {
         let db = GrafeoDB::new_in_memory();
-        let a = db.create_node(&["A"]);
-        let b = db.create_node(&["B"]);
-        let c = db.create_node(&["C"]);
+        let a = db.create_node(&["A"]).unwrap();
+        let b = db.create_node(&["B"]).unwrap();
+        let c = db.create_node(&["C"]).unwrap();
         db.create_edge(a, b, "R1");
         db.create_edge(b, c, "R2");
 
@@ -1546,18 +1546,20 @@ mod tests {
 
         let db = GrafeoDB::new_in_memory();
 
-        let n1 = db.create_node(&["Doc"]);
+        let n1 = db.create_node(&["Doc"]).unwrap();
         db.set_node_property(
             n1,
             "embedding",
             Value::Vector(Arc::from([1.0_f32, 0.0, 0.0])),
-        );
-        let n2 = db.create_node(&["Doc"]);
+        )
+        .unwrap();
+        let n2 = db.create_node(&["Doc"]).unwrap();
         db.set_node_property(
             n2,
             "embedding",
             Value::Vector(Arc::from([0.0_f32, 1.0, 0.0])),
-        );
+        )
+        .unwrap();
 
         db.create_vector_index(
             "Doc",
@@ -1587,10 +1589,12 @@ mod tests {
     fn test_snapshot_roundtrip_text_index() {
         let db = GrafeoDB::new_in_memory();
 
-        let n1 = db.create_node(&["Article"]);
-        db.set_node_property(n1, "body", Value::String("rust graph database".into()));
-        let n2 = db.create_node(&["Article"]);
-        db.set_node_property(n2, "body", Value::String("python web framework".into()));
+        let n1 = db.create_node(&["Article"]).unwrap();
+        db.set_node_property(n1, "body", Value::String("rust graph database".into()))
+            .unwrap();
+        let n2 = db.create_node(&["Article"]).unwrap();
+        db.set_node_property(n2, "body", Value::String("python web framework".into()))
+            .unwrap();
 
         db.create_text_index("Article", "body").unwrap();
 

--- a/crates/grafeo-engine/src/database/search.rs
+++ b/crates/grafeo-engine/src/database/search.rs
@@ -18,52 +18,6 @@ use grafeo_common::utils::error::Error;
 use grafeo_common::utils::error::Result;
 
 impl super::GrafeoDB {
-    /// Creates a vector accessor for the given label/property, using spilled
-    /// MmapStorage if the index has been spilled to disk.
-    #[cfg(all(feature = "vector-index", feature = "mmap", not(feature = "temporal")))]
-    fn make_vector_accessor<'a>(
-        &'a self,
-        label: &str,
-        property: &str,
-    ) -> grafeo_core::index::vector::VectorAccessorKind<'a> {
-        let key = format!("{label}:{property}");
-        if let Some(ref spill_map) = self.vector_spill_storages {
-            let map = spill_map.read();
-            if let Some(storage) = map.get(&key) {
-                return grafeo_core::index::vector::VectorAccessorKind::Spilled(
-                    grafeo_core::index::vector::SpillableVectorAccessor::new(
-                        self.graph_store_ref(),
-                        property,
-                        std::sync::Arc::clone(storage)
-                            as std::sync::Arc<dyn grafeo_core::index::vector::VectorStorage>,
-                    ),
-                );
-            }
-        }
-        grafeo_core::index::vector::VectorAccessorKind::Property(
-            grafeo_core::index::vector::PropertyVectorAccessor::new(
-                self.graph_store_ref(),
-                property,
-            ),
-        )
-    }
-
-    /// Creates a vector accessor (no spill support when mmap or temporal unavailable).
-    #[cfg(not(all(feature = "vector-index", feature = "mmap", not(feature = "temporal"))))]
-    #[cfg(feature = "vector-index")]
-    fn make_vector_accessor<'a>(
-        &'a self,
-        _label: &str,
-        property: &str,
-    ) -> grafeo_core::index::vector::VectorAccessorKind<'a> {
-        grafeo_core::index::vector::VectorAccessorKind::Property(
-            grafeo_core::index::vector::PropertyVectorAccessor::new(
-                self.graph_store_ref(),
-                property,
-            ),
-        )
-    }
-
     /// Computes a node allowlist from property filters.
     ///
     /// Supports equality filters (scalar values) and operator filters (Map values

--- a/crates/grafeo-engine/src/database/section_consumer.rs
+++ b/crates/grafeo-engine/src/database/section_consumer.rs
@@ -31,7 +31,7 @@ use grafeo_common::storage::Section;
     feature = "mmap",
     not(feature = "temporal")
 ))]
-use grafeo_common::types::{PropertyKey, Value};
+use grafeo_common::types::{NodeId, PropertyKey, Value};
 #[cfg(all(
     feature = "lpg",
     feature = "vector-index",
@@ -52,7 +52,7 @@ use parking_lot::RwLock;
     feature = "mmap",
     not(feature = "temporal")
 ))]
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Wraps a [`Section`] as a [`MemoryConsumer`] for the BufferManager.
 ///
@@ -296,66 +296,38 @@ impl VectorIndexConsumer {
         &self.spilled
     }
 
-    /// Spills a single vector index's embeddings to disk.
-    ///
-    /// Returns bytes freed, or an error.
+    /// Writes one label-scoped vector index payload to disk.
     fn spill_index(
         &self,
-        store: &grafeo_core::graph::lpg::LpgStore,
         key: &str,
         dimensions: usize,
-    ) -> Result<usize, SpillError> {
+        vectors: &[(NodeId, Arc<[f32]>)],
+    ) -> Result<(), SpillError> {
         let spill_dir = self
             .spill_path
             .as_ref()
             .ok_or(SpillError::NoSpillDirectory)?;
-
-        // Extract property name from key ("label:property" -> "property")
-        let property = key
-            .split(':')
-            .nth(1)
-            .ok_or_else(|| SpillError::IoError(format!("invalid index key: {key}")))?;
-        let prop_key = PropertyKey::new(property);
-
-        // Drain vector values from the property column
-        let drained = store.drain_node_property_column(&prop_key);
-        if drained.is_empty() {
-            return Ok(0);
-        }
-
-        // Create spill directory if needed
         std::fs::create_dir_all(spill_dir).map_err(|e| SpillError::IoError(e.to_string()))?;
 
         // Sanitize key for filename ("Label:property" -> "Label%3Aproperty")
-        // Percent-encodes ':' to preserve label case, underscores, and avoid
-        // ambiguity with any separator character.
+        // while preserving label case and underscores.
         let safe_key = key.replace('%', "%25").replace(':', "%3A");
         let spill_file = spill_dir.join(format!("vectors_{safe_key}.bin"));
-
-        // Create MmapStorage and write all vectors
         let mmap_storage = grafeo_core::index::vector::MmapStorage::create(&spill_file, dimensions)
             .map_err(|e| SpillError::IoError(e.to_string()))?;
 
-        let mut freed_bytes = 0;
-        for (id, value) in &drained {
-            if let Value::Vector(vec_data) = value {
-                freed_bytes += vec_data.len() * 4 + std::mem::size_of::<Arc<[f32]>>();
-                mmap_storage
-                    .insert(*id, vec_data)
-                    .map_err(|e| SpillError::IoError(e.to_string()))?;
-            }
+        for (id, vector) in vectors {
+            mmap_storage
+                .insert(*id, vector)
+                .map_err(|e| SpillError::IoError(e.to_string()))?;
         }
-
         mmap_storage
             .flush()
             .map_err(|e| SpillError::IoError(e.to_string()))?;
-
-        // Register the spill storage
         self.spilled
             .write()
             .insert(key.to_string(), Arc::new(mmap_storage));
-
-        Ok(freed_bytes)
+        Ok(())
     }
 }
 
@@ -418,26 +390,71 @@ impl MemoryConsumer for VectorIndexConsumer {
             .upgrade()
             .ok_or(SpillError::IoError("store dropped".to_string()))?;
 
-        let indexes = store.vector_index_entries();
-        let mut total_freed = 0;
+        // Property columns are global by property name while vector indexes are
+        // label-scoped. Drain each shared property exactly once, then partition
+        // its vectors by the labels registered for each index. The previous
+        // per-index drain made the first HashMap entry consume every label's
+        // vectors and left later indexes with empty spill stores.
+        let already_spilled: HashSet<String> = self.spilled.read().keys().cloned().collect();
+        let mut indexes_by_property: HashMap<String, Vec<(String, usize, HashSet<NodeId>)>> =
+            HashMap::new();
+        for (key, index) in store.vector_index_entries() {
+            if already_spilled.contains(&key) {
+                continue;
+            }
+            let Some((label, property)) = key.split_once(':') else {
+                eprintln!("failed to spill vector index {key}: invalid index key");
+                continue;
+            };
+            let label = label.to_string();
+            let property = property.to_string();
+            indexes_by_property.entry(property).or_default().push((
+                key,
+                index.config().dimensions,
+                store.nodes_by_label(&label).into_iter().collect(),
+            ));
+        }
 
-        for (key, index) in &indexes {
-            // Skip already-spilled indexes
-            if self.spilled.read().contains_key(key) {
+        let mut total_freed = 0;
+        for (property, indexes) in indexes_by_property {
+            let prop_key = PropertyKey::new(&property);
+            let drained = store.drain_node_property_column(&prop_key);
+            if drained.is_empty() {
                 continue;
             }
 
-            let dimensions = index.config().dimensions;
-            match self.spill_index(&store, key, dimensions) {
-                Ok(freed) => total_freed += freed,
-                Err(e) => {
-                    // Log but continue: earlier indexes may have already been
-                    // drained and persisted. Returning Err would discard the
-                    // freed bytes from those, leaving BufferManager with
-                    // incorrect pressure tracking.
-                    eprintln!("failed to spill vector index {key}: {e}");
+            let mut consumed = HashSet::new();
+            for (key, dimensions, label_nodes) in indexes {
+                let vectors: Vec<(NodeId, Arc<[f32]>)> = drained
+                    .iter()
+                    .filter_map(|(id, value)| match value {
+                        Value::Vector(vector)
+                            if label_nodes.contains(id) && vector.len() == dimensions =>
+                        {
+                            Some((*id, Arc::clone(vector)))
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                if vectors.is_empty() {
+                    continue;
+                }
+                match self.spill_index(&key, dimensions, &vectors) {
+                    Ok(()) => consumed.extend(vectors.iter().map(|(id, _)| *id)),
+                    Err(error) => eprintln!("failed to spill vector index {key}: {error}"),
                 }
             }
+
+            for (id, value) in &drained {
+                if consumed.contains(id) {
+                    if let Value::Vector(vector) = value {
+                        total_freed += vector.len() * std::mem::size_of::<f32>()
+                            + std::mem::size_of::<Arc<[f32]>>();
+                    }
+                }
+            }
+            let unconsumed = drained.into_iter().filter(|(id, _)| !consumed.contains(id));
+            store.restore_node_property_column(&prop_key, unconsumed);
         }
 
         Ok(total_freed)

--- a/crates/grafeo-engine/src/database/vector_access.rs
+++ b/crates/grafeo-engine/src/database/vector_access.rs
@@ -1,0 +1,52 @@
+//! Spill-aware vector accessor construction for GrafeoDB.
+//!
+//! Shared by ANN search and exact indexed vector reads so both paths use the
+//! same committed inline/ForceDisk accessor seam.
+
+#[cfg(feature = "vector-index")]
+impl super::GrafeoDB {
+    /// Creates a vector accessor for the given label/property, using spilled
+    /// MmapStorage if the index has been spilled to disk.
+    #[cfg(all(feature = "mmap", not(feature = "temporal")))]
+    pub(super) fn make_vector_accessor<'a>(
+        &'a self,
+        label: &str,
+        property: &str,
+    ) -> grafeo_core::index::vector::VectorAccessorKind<'a> {
+        let key = format!("{label}:{property}");
+        if let Some(ref spill_map) = self.vector_spill_storages {
+            let map = spill_map.read();
+            if let Some(storage) = map.get(&key) {
+                return grafeo_core::index::vector::VectorAccessorKind::Spilled(
+                    grafeo_core::index::vector::SpillableVectorAccessor::new(
+                        self.graph_store_ref(),
+                        property,
+                        std::sync::Arc::clone(storage)
+                            as std::sync::Arc<dyn grafeo_core::index::vector::VectorStorage>,
+                    ),
+                );
+            }
+        }
+        grafeo_core::index::vector::VectorAccessorKind::Property(
+            grafeo_core::index::vector::PropertyVectorAccessor::new(
+                self.graph_store_ref(),
+                property,
+            ),
+        )
+    }
+
+    /// Creates a vector accessor (no spill support when mmap or temporal unavailable).
+    #[cfg(not(all(feature = "mmap", not(feature = "temporal"))))]
+    pub(super) fn make_vector_accessor<'a>(
+        &'a self,
+        _label: &str,
+        property: &str,
+    ) -> grafeo_core::index::vector::VectorAccessorKind<'a> {
+        grafeo_core::index::vector::VectorAccessorKind::Property(
+            grafeo_core::index::vector::PropertyVectorAccessor::new(
+                self.graph_store_ref(),
+                property,
+            ),
+        )
+    }
+}

--- a/crates/grafeo-engine/src/database/vector_read.rs
+++ b/crates/grafeo-engine/src/database/vector_read.rs
@@ -1,0 +1,83 @@
+//! Exact spill-aware vector reads for GrafeoDB.
+//!
+//! Provides [`GrafeoDB::read_indexed_node_vector`], which returns an owned copy
+//! of the indexed vector for a `(label, property, NodeId)` using the same
+//! spill-aware accessor as ANN search. This is the authority when ForceDisk
+//! has drained the inline property column.
+
+use grafeo_common::types::NodeId;
+use grafeo_common::utils::error::Result;
+use grafeo_core::index::vector::VectorAccessor;
+
+/// Outcome of an exact indexed vector read by `(label, property, NodeId)`.
+///
+/// Normal control-flow outcomes (missing node/vector, unregistered index) are
+/// machine-typed variants. Dimension corruption remains a typed [`Result::Err`].
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum IndexedVectorRead {
+    /// Indexed vector present for a visible node under the requested label.
+    Found(Vec<f32>),
+    /// Node absent, lacks the label, or has no vector for the property.
+    Absent,
+    /// No vector index is registered for the label/property pair.
+    IndexNotRegistered,
+}
+
+impl super::GrafeoDB {
+    /// Reads the exact indexed vector for `node_id` under `(label, property)`.
+    ///
+    /// Uses the same committed, spill-aware accessor as
+    /// [`vector_search`](Self::vector_search). Returns an owned vector copy that
+    /// remains valid after the source node is purged. Does not perform
+    /// approximate nearest-neighbor search or mutate the graph.
+    ///
+    /// # Returns
+    ///
+    /// - [`IndexedVectorRead::Found`] when the node is visible under `label`
+    ///   and an indexed vector of the registered width is available (inline or
+    ///   spilled)
+    /// - [`IndexedVectorRead::Absent`] when the node is absent, lacks `label`,
+    ///   or has no vector for `property` in the index-backed storage
+    /// - [`IndexedVectorRead::IndexNotRegistered`] when no vector index exists
+    ///   for `label`/`property`
+    ///
+    /// # Errors
+    ///
+    /// Returns [`grafeo_common::utils::error::Error::InvalidValue`] if a
+    /// recovered vector's width does not match the index dimensions.
+    pub fn read_indexed_node_vector(
+        &self,
+        label: &str,
+        property: &str,
+        node_id: NodeId,
+    ) -> Result<IndexedVectorRead> {
+        let Some(index) = self.lpg_store().get_vector_index(label, property) else {
+            return Ok(IndexedVectorRead::IndexNotRegistered);
+        };
+        let expected_dims = index.config().dimensions;
+
+        // Index registration is label-scoped; do not return a cross-label
+        // property hit from the shared property column or a sibling spill file.
+        let has_label = self
+            .lpg_store()
+            .get_node(node_id)
+            .is_some_and(|node| node.labels.iter().any(|l| l.as_str() == label));
+        if !has_label {
+            return Ok(IndexedVectorRead::Absent);
+        }
+
+        let accessor = self.make_vector_accessor(label, property);
+        let Some(vector) = accessor.get_vector(node_id) else {
+            return Ok(IndexedVectorRead::Absent);
+        };
+        if vector.len() != expected_dims {
+            return Err(grafeo_common::utils::error::Error::InvalidValue(format!(
+                "Indexed vector for :{label}({property}) node {} has width {}, expected {expected_dims}",
+                node_id.as_u64(),
+                vector.len()
+            )));
+        }
+        Ok(IndexedVectorRead::Found(vector.as_ref().to_vec()))
+    }
+}

--- a/crates/grafeo-engine/src/lib.rs
+++ b/crates/grafeo-engine/src/lib.rs
@@ -52,6 +52,8 @@ pub use auth::{Grant, Identity, Role, StatementKind};
 pub use catalog::{Catalog, CatalogError, IndexDefinition, IndexType};
 pub use config::{AccessMode, Config, ConfigError, DurabilityMode, GraphModel};
 pub use database::GrafeoDB;
+#[cfg(all(feature = "lpg", feature = "vector-index"))]
+pub use database::IndexedVectorRead;
 pub use grafeo_core::graph::{GraphStore, GraphStoreMut, ProjectionSpec};
 pub use memory_usage::MemoryUsage;
 #[cfg(feature = "metrics")]

--- a/crates/grafeo-engine/src/memory_usage.rs
+++ b/crates/grafeo-engine/src/memory_usage.rs
@@ -5,7 +5,8 @@
 //! types (`CacheMemory`, `BufferManagerMemory`, `RdfMemory`, `CdcMemory`).
 
 pub use grafeo_common::memory::usage::{
-    IndexMemory, MvccMemory, NamedMemory, StoreMemory, StringPoolMemory,
+    AdjacencyCapacityMemory, IndexMemory, LpgResidencyMemory, MvccMemory, NamedMemory,
+    PropertyColumnMemory, PropertyStorageMemory, StoreMemory, StringPoolMemory,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/grafeo-engine/src/session/mod.rs
+++ b/crates/grafeo-engine/src/session/mod.rs
@@ -177,6 +177,12 @@ pub struct Session {
     /// Flushed to `cdc_log` on commit, discarded on rollback.
     #[cfg(feature = "cdc")]
     cdc_pending_events: Option<Arc<parking_lot::Mutex<Vec<crate::cdc::ChangeEvent>>>>,
+    /// Transaction-local vector index intents.
+    ///
+    /// HNSW is not MVCC-aware, so direct session writes defer vector index
+    /// synchronization until commit has made graph changes visible.
+    #[cfg(all(feature = "lpg", feature = "vector-index"))]
+    vector_index_intents: parking_lot::Mutex<Vec<VectorIndexIntent>>,
     /// Current graph name (for multi-graph USE GRAPH support). None = default graph.
     current_graph: parking_lot::Mutex<Option<String>>,
     /// Current schema name (ISO/IEC 39075 Section 4.7.3: independent from session graph).
@@ -241,6 +247,21 @@ struct GraphSavepoint {
     undo_log_position: usize,
 }
 
+/// Deferred HNSW update captured by direct session writes inside a transaction.
+#[cfg(all(feature = "lpg", feature = "vector-index"))]
+#[derive(Clone)]
+enum VectorIndexIntent {
+    Upsert {
+        graph_name: Option<String>,
+        node_id: NodeId,
+        property: String,
+    },
+    Delete {
+        graph_name: Option<String>,
+        node_id: NodeId,
+    },
+}
+
 /// Savepoint state: name + per-graph snapshots + the graph that was active.
 #[derive(Clone)]
 struct SavepointState {
@@ -254,6 +275,9 @@ struct SavepointState {
     /// On rollback-to-savepoint, the buffer is truncated to this position.
     #[cfg(feature = "cdc")]
     cdc_event_position: usize,
+    /// Vector intent buffer position at savepoint creation.
+    #[cfg(all(feature = "lpg", feature = "vector-index"))]
+    vector_intent_position: usize,
 }
 
 impl Session {
@@ -296,6 +320,8 @@ impl Session {
             cdc_log: Arc::new(crate::cdc::CdcLog::new()),
             #[cfg(feature = "cdc")]
             cdc_pending_events: None,
+            #[cfg(all(feature = "lpg", feature = "vector-index"))]
+            vector_index_intents: parking_lot::Mutex::new(Vec::new()),
             current_graph: parking_lot::Mutex::new(None),
             current_schema: parking_lot::Mutex::new(None),
             time_zone: parking_lot::Mutex::new(None),
@@ -441,6 +467,8 @@ impl Session {
             cdc_log: Arc::new(crate::cdc::CdcLog::new()),
             #[cfg(feature = "cdc")]
             cdc_pending_events: None,
+            #[cfg(all(feature = "lpg", feature = "vector-index"))]
+            vector_index_intents: parking_lot::Mutex::new(Vec::new()),
             current_graph: parking_lot::Mutex::new(None),
             current_schema: parking_lot::Mutex::new(None),
             time_zone: parking_lot::Mutex::new(None),
@@ -4023,6 +4051,8 @@ impl Session {
                 if let Some(ref pending) = self.cdc_pending_events {
                     pending.lock().clear();
                 }
+                #[cfg(all(feature = "lpg", feature = "vector-index"))]
+                self.clear_vector_intents();
                 *self.read_only_tx.lock() = self.db_read_only;
                 self.savepoints.lock().clear();
                 self.touched_graphs.lock().clear();
@@ -4095,6 +4125,9 @@ impl Session {
             let store = self.resolve_store(graph_name);
             store.sync_epoch(current_epoch);
         }
+
+        #[cfg(all(feature = "lpg", feature = "vector-index"))]
+        self.apply_buffered_vector_intents()?;
 
         // Reset read-only flag and clear savepoints.
         // touched_graphs was already emptied by mem::take above.
@@ -4216,6 +4249,8 @@ impl Session {
         if let Some(ref pending) = self.cdc_pending_events {
             pending.lock().clear();
         }
+        #[cfg(all(feature = "lpg", feature = "vector-index"))]
+        self.clear_vector_intents();
 
         // Clear savepoints and touched graphs
         self.savepoints.lock().clear();
@@ -4294,6 +4329,8 @@ impl Session {
                 .cdc_pending_events
                 .as_ref()
                 .map_or(0, |p| p.lock().len()),
+            #[cfg(all(feature = "lpg", feature = "vector-index"))]
+            vector_intent_position: self.vector_index_intents.lock().len(),
         });
         Ok(())
     }
@@ -4379,6 +4416,8 @@ impl Session {
         if let Some(ref pending) = self.cdc_pending_events {
             pending.lock().truncate(sp_state.cdc_event_position);
         }
+        #[cfg(all(feature = "lpg", feature = "vector-index"))]
+        self.truncate_vector_intents(sp_state.vector_intent_position);
 
         // Restore touched_graphs to only the graphs that were known at savepoint time.
         let mut touched = self.touched_graphs.lock();
@@ -4730,6 +4769,92 @@ impl Session {
         }
     }
 
+    #[cfg(all(feature = "lpg", feature = "vector-index"))]
+    fn push_vector_intent(&self, intent: VectorIndexIntent) -> Result<()> {
+        if self.current_transaction.lock().is_some() {
+            self.vector_index_intents.lock().push(intent);
+            Ok(())
+        } else {
+            self.apply_vector_intent(&intent)
+        }
+    }
+
+    #[cfg(all(feature = "lpg", feature = "vector-index"))]
+    fn clear_vector_intents(&self) {
+        self.vector_index_intents.lock().clear();
+    }
+
+    #[cfg(all(feature = "lpg", feature = "vector-index"))]
+    fn truncate_vector_intents(&self, position: usize) {
+        self.vector_index_intents.lock().truncate(position);
+    }
+
+    #[cfg(all(feature = "lpg", feature = "vector-index"))]
+    fn apply_buffered_vector_intents(&self) -> Result<()> {
+        let intents: Vec<VectorIndexIntent> = self.vector_index_intents.lock().drain(..).collect();
+        for intent in intents {
+            self.apply_vector_intent(&intent)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(all(feature = "lpg", feature = "vector-index"))]
+    fn apply_vector_intent(&self, intent: &VectorIndexIntent) -> Result<()> {
+        match intent {
+            VectorIndexIntent::Upsert {
+                graph_name,
+                node_id,
+                property,
+            } => {
+                let store = self.resolve_store(graph_name);
+                let Some(node) = store.get_node(*node_id) else {
+                    return Ok(());
+                };
+                let prop_key = grafeo_common::types::PropertyKey::new(property);
+                let vector = node
+                    .properties
+                    .get(&prop_key)
+                    .and_then(|value| match value {
+                        Value::Vector(vector) => Some(vector),
+                        _ => None,
+                    });
+                for label in &node.labels {
+                    if let Some(index) = store.get_vector_index(label.as_str(), property) {
+                        index.remove(*node_id);
+                        let Some(vector) = vector else {
+                            continue;
+                        };
+                        if vector.len() != index.config().dimensions {
+                            return Err(grafeo_common::utils::error::Error::Internal(format!(
+                                "Vector dimension mismatch for :{}({}): expected {}, found {} on node {}",
+                                label,
+                                property,
+                                index.config().dimensions,
+                                vector.len(),
+                                node_id.0
+                            )));
+                        }
+                        let accessor = grafeo_core::index::vector::PropertyVectorAccessor::new(
+                            &*store,
+                            property.as_str(),
+                        );
+                        index.insert(*node_id, vector, &accessor);
+                    }
+                }
+            }
+            VectorIndexIntent::Delete {
+                graph_name,
+                node_id,
+            } => {
+                let store = self.resolve_store(graph_name);
+                for (_key, index) in store.vector_index_entries() {
+                    index.remove(*node_id);
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Creates a planner with transaction context and constraint validator.
     ///
     /// The `store` parameter is the graph store to plan against (use
@@ -4900,14 +5025,26 @@ impl Session {
             .iter()
             .map(|(k, v)| ((*k).to_string(), v.clone()))
             .collect();
+        #[cfg(feature = "vector-index")]
+        let vector_props: Vec<String> = props
+            .iter()
+            .filter_map(|(key, value)| match value {
+                Value::Vector(_) => Some((*key).to_string()),
+                _ => None,
+            })
+            .collect();
 
         let (epoch, transaction_id) = self.get_transaction_context();
+        let graph_name = self.active_graph_storage_key();
         let id = self.active_lpg_store().create_node_with_props_versioned(
             labels,
             props,
             epoch,
             transaction_id.unwrap_or(TransactionId::SYSTEM),
         );
+        if let Some(tid) = transaction_id {
+            self.transaction_manager.record_write(tid, id)?;
+        }
 
         #[cfg(feature = "wal")]
         {
@@ -4922,6 +5059,15 @@ impl Session {
                     value,
                 });
             }
+        }
+
+        #[cfg(feature = "vector-index")]
+        for property in vector_props {
+            self.push_vector_intent(VectorIndexIntent::Upsert {
+                graph_name: graph_name.clone(),
+                node_id: id,
+                property,
+            })?;
         }
 
         Ok(id)
@@ -5015,8 +5161,11 @@ impl Session {
 
         #[cfg(feature = "wal")]
         let value_for_wal = value.clone();
+        #[cfg(feature = "vector-index")]
+        let vector_intent = self.active_graph_storage_key();
 
         if let Some(tid) = transaction_id {
+            self.transaction_manager.record_write(tid, id)?;
             self.active_lpg_store()
                 .set_node_property_versioned(id, key, value, tid);
         } else {
@@ -5029,6 +5178,13 @@ impl Session {
             key: key.to_string(),
             value: value_for_wal,
         });
+
+        #[cfg(feature = "vector-index")]
+        self.push_vector_intent(VectorIndexIntent::Upsert {
+            graph_name: vector_intent,
+            node_id: id,
+            property: key.to_string(),
+        })?;
 
         Ok(())
     }
@@ -5082,6 +5238,14 @@ impl Session {
         #[cfg(feature = "wal")]
         if deleted {
             self.log_wal_record(&grafeo_storage::wal::WalRecord::DeleteNode { id });
+        }
+
+        #[cfg(feature = "vector-index")]
+        if deleted {
+            let _ = self.push_vector_intent(VectorIndexIntent::Delete {
+                graph_name: self.active_graph_storage_key(),
+                node_id: id,
+            });
         }
 
         deleted
@@ -5577,7 +5741,7 @@ mod tests {
         let db = GrafeoDB::new_in_memory();
 
         // Create a node outside of any transaction
-        let node_before = db.create_node(&["Person"]);
+        let node_before = db.create_node(&["Person"]).unwrap();
         assert!(node_before.is_valid());
         assert_eq!(db.node_count(), 1, "Should have 1 node before transaction");
 
@@ -5624,7 +5788,7 @@ mod tests {
         let db = GrafeoDB::new_in_memory();
 
         // Create a node outside of any transaction
-        db.create_node(&["Person"]);
+        db.create_node(&["Person"]).unwrap();
         assert_eq!(db.node_count(), 1, "Should have 1 node before transaction");
 
         // Start a transaction and create a node with properties
@@ -6847,6 +7011,115 @@ mod tests {
             let result = session.execute("SHOW GRAPH TYPE social").unwrap();
             assert_eq!(result.rows.len(), 1);
             assert_eq!(result.rows[0][0], Value::from("social"));
+        }
+
+        #[cfg(feature = "vector-index")]
+        fn vector_hits(db: &GrafeoDB, query: &[f32]) -> Vec<grafeo_common::types::NodeId> {
+            db.vector_search("Doc", "embedding", query, 10, None, None)
+                .unwrap()
+                .into_iter()
+                .map(|(id, _)| id)
+                .collect()
+        }
+
+        #[cfg(feature = "vector-index")]
+        #[test]
+        fn test_transaction_vector_create_rolls_back_without_hnsw_insert() {
+            let db = GrafeoDB::new_in_memory();
+            db.create_vector_index("Doc", "embedding", Some(2), None, None, None, None)
+                .unwrap();
+
+            let mut session = db.session();
+            session.begin_transaction().unwrap();
+            let node = session
+                .create_node_with_props(
+                    &["Doc"],
+                    [("embedding", Value::Vector(vec![1.0, 0.0].into()))],
+                )
+                .unwrap();
+            session.rollback().unwrap();
+
+            assert!(!vector_hits(&db, &[1.0, 0.0]).contains(&node));
+        }
+
+        #[cfg(feature = "vector-index")]
+        #[test]
+        fn test_transaction_vector_create_commit_updates_hnsw() {
+            let db = GrafeoDB::new_in_memory();
+            db.create_vector_index("Doc", "embedding", Some(2), None, None, None, None)
+                .unwrap();
+
+            let mut session = db.session();
+            session.begin_transaction().unwrap();
+            let node = session
+                .create_node_with_props(
+                    &["Doc"],
+                    [("embedding", Value::Vector(vec![1.0, 0.0].into()))],
+                )
+                .unwrap();
+            session.commit().unwrap();
+
+            assert!(vector_hits(&db, &[1.0, 0.0]).contains(&node));
+        }
+
+        #[cfg(feature = "vector-index")]
+        #[test]
+        fn test_transaction_vector_update_commit_replaces_hnsw_entry() {
+            let db = GrafeoDB::new_in_memory();
+            let node = db.create_node(&["Doc"]).unwrap();
+            db.set_node_property(node, "embedding", Value::Vector(vec![1.0, 0.0].into()))
+                .unwrap();
+            db.create_vector_index("Doc", "embedding", Some(2), None, None, None, None)
+                .unwrap();
+
+            let mut session = db.session();
+            session.begin_transaction().unwrap();
+            session
+                .set_node_property(node, "embedding", Value::Vector(vec![0.0, 1.0].into()))
+                .unwrap();
+            session.commit().unwrap();
+
+            assert_eq!(vector_hits(&db, &[0.0, 1.0]).first().copied(), Some(node));
+        }
+
+        #[cfg(feature = "vector-index")]
+        #[test]
+        fn test_transaction_vector_delete_commit_removes_hnsw_entry() {
+            let db = GrafeoDB::new_in_memory();
+            let node = db.create_node(&["Doc"]).unwrap();
+            db.set_node_property(node, "embedding", Value::Vector(vec![1.0, 0.0].into()))
+                .unwrap();
+            db.create_vector_index("Doc", "embedding", Some(2), None, None, None, None)
+                .unwrap();
+
+            let mut session = db.session();
+            session.begin_transaction().unwrap();
+            assert!(session.delete_node(node));
+            session.commit().unwrap();
+
+            assert!(!vector_hits(&db, &[1.0, 0.0]).contains(&node));
+        }
+
+        #[cfg(feature = "vector-index")]
+        #[test]
+        fn test_savepoint_rollback_discards_later_vector_intents() {
+            let db = GrafeoDB::new_in_memory();
+            db.create_vector_index("Doc", "embedding", Some(2), None, None, None, None)
+                .unwrap();
+
+            let mut session = db.session();
+            session.begin_transaction().unwrap();
+            session.savepoint("before_vector").unwrap();
+            let node = session
+                .create_node_with_props(
+                    &["Doc"],
+                    [("embedding", Value::Vector(vec![1.0, 0.0].into()))],
+                )
+                .unwrap();
+            session.rollback_to_savepoint("before_vector").unwrap();
+            session.commit().unwrap();
+
+            assert!(!vector_hits(&db, &[1.0, 0.0]).contains(&node));
         }
     }
 }

--- a/crates/grafeo-engine/src/session/mod.rs
+++ b/crates/grafeo-engine/src/session/mod.rs
@@ -6,6 +6,10 @@
 
 #[cfg(feature = "triple-store")]
 mod rdf;
+#[cfg(feature = "lpg")]
+mod transactional_batch;
+#[cfg(feature = "lpg")]
+pub use transactional_batch::{TransactionalEdgeCreate, TransactionalNodeCreate};
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;

--- a/crates/grafeo-engine/src/session/mod.rs
+++ b/crates/grafeo-engine/src/session/mod.rs
@@ -4552,7 +4552,13 @@ impl Session {
     /// Auto-commit kicks in when: the session is in auto-commit mode,
     /// no explicit transaction is active, and the query mutates data.
     fn needs_auto_commit(&self, has_mutations: bool) -> bool {
-        self.auto_commit && has_mutations && self.current_transaction.lock().is_none()
+        let result = self.auto_commit && has_mutations && self.current_transaction.lock().is_none();
+        eprintln!(
+            "[epoch-debug] needs_auto_commit: auto_commit={} has_mutations={has_mutations} has_active_tx={} result={result}",
+            self.auto_commit,
+            self.current_transaction.lock().is_some()
+        );
+        result
     }
 
     /// Wraps `body` in an automatic begin/commit when [`needs_auto_commit`]
@@ -4563,18 +4569,22 @@ impl Session {
         F: FnOnce() -> Result<QueryResult>,
     {
         if self.needs_auto_commit(has_mutations) {
+            eprintln!("[epoch-debug] with_auto_commit: entering auto-commit path (has_mutations={has_mutations})");
             self.begin_transaction_inner(false, None)?;
             match body() {
                 Ok(result) => {
+                    eprintln!("[epoch-debug] with_auto_commit: body succeeded, calling commit_inner");
                     self.commit_inner()?;
                     Ok(result)
                 }
                 Err(e) => {
+                    eprintln!("[epoch-debug] with_auto_commit: body failed, rolling back");
                     let _ = self.rollback_inner();
                     Err(e)
                 }
             }
         } else {
+            eprintln!("[epoch-debug] with_auto_commit: skipping auto-commit (has_mutations={has_mutations})");
             body()
         }
     }

--- a/crates/grafeo-engine/src/session/mod.rs
+++ b/crates/grafeo-engine/src/session/mod.rs
@@ -4552,13 +4552,7 @@ impl Session {
     /// Auto-commit kicks in when: the session is in auto-commit mode,
     /// no explicit transaction is active, and the query mutates data.
     fn needs_auto_commit(&self, has_mutations: bool) -> bool {
-        let result = self.auto_commit && has_mutations && self.current_transaction.lock().is_none();
-        eprintln!(
-            "[epoch-debug] needs_auto_commit: auto_commit={} has_mutations={has_mutations} has_active_tx={} result={result}",
-            self.auto_commit,
-            self.current_transaction.lock().is_some()
-        );
-        result
+        self.auto_commit && has_mutations && self.current_transaction.lock().is_none()
     }
 
     /// Wraps `body` in an automatic begin/commit when [`needs_auto_commit`]
@@ -4569,22 +4563,18 @@ impl Session {
         F: FnOnce() -> Result<QueryResult>,
     {
         if self.needs_auto_commit(has_mutations) {
-            eprintln!("[epoch-debug] with_auto_commit: entering auto-commit path (has_mutations={has_mutations})");
             self.begin_transaction_inner(false, None)?;
             match body() {
                 Ok(result) => {
-                    eprintln!("[epoch-debug] with_auto_commit: body succeeded, calling commit_inner");
                     self.commit_inner()?;
                     Ok(result)
                 }
                 Err(e) => {
-                    eprintln!("[epoch-debug] with_auto_commit: body failed, rolling back");
                     let _ = self.rollback_inner();
                     Err(e)
                 }
             }
         } else {
-            eprintln!("[epoch-debug] with_auto_commit: skipping auto-commit (has_mutations={has_mutations})");
             body()
         }
     }

--- a/crates/grafeo-engine/src/session/transactional_batch.rs
+++ b/crates/grafeo-engine/src/session/transactional_batch.rs
@@ -1,0 +1,271 @@
+//! Transaction-aware storage-level batch node/edge creation.
+//!
+//! Public contract (W1-GRAFEO-BATCH, plan §3.4): provider-neutral,
+//! explicit-transaction-required batch mutation on [`Session`]. These methods
+//! are **not** a loop over the row-oriented `create_node_with_props` /
+//! `create_edge_with_props`; they delegate to a single storage-level batch
+//! primitive ([`LpgStore::create_nodes_batch_versioned`] /
+//! [`create_edges_batch_versioned`]) that hoists every per-row lock to once per
+//! batch and allocates the ID range with one atomic.
+//!
+//! Locked contracts honored here:
+//! - fail if no explicit transaction is active;
+//! - prevalidate every property size before the first mutation;
+//! - version every row under the active transaction ID (PENDING visibility);
+//! - register every node and edge write with transaction management;
+//! - preserve WAL records (identical record stream to the row path);
+//! - buffer vector-index intents until commit;
+//! - preserve returned ID order;
+//! - never call the offline/unindexed bulk loaders.
+//!
+//! Commit/rollback need no batch-specific logic: rows are versioned identically
+//! to the row path, so the transaction-wide `finalize_version_epochs` (commit)
+//! and `discard_uncommitted_versions` (rollback) scans make the whole batch
+//! visible or remove it atomically — including secondary structures published
+//! eagerly by the create path (label/property indexes, adjacency, type counts).
+
+use grafeo_common::types::{EdgeId, NodeId, PropertyKey, Value};
+use grafeo_common::utils::error::{Error, Result, TransactionError};
+use grafeo_core::graph::lpg::{BatchEdgeCreate, BatchNodeCreate};
+
+use super::Session;
+#[cfg(all(feature = "lpg", feature = "vector-index"))]
+use super::VectorIndexIntent;
+
+/// A node to create within a transactional batch.
+///
+/// Provider-neutral DTO. Properties are owned so the batch can prevalidate sizes
+/// and then hand them to the storage layer in one shot.
+#[derive(Debug, Clone)]
+pub struct TransactionalNodeCreate {
+    /// Labels applied to the node.
+    pub labels: Vec<String>,
+    /// Property key/value pairs, written in order.
+    pub properties: Vec<(String, Value)>,
+}
+
+impl TransactionalNodeCreate {
+    /// Creates a node spec with labels and no properties.
+    #[must_use]
+    pub fn new(labels: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            labels: labels.into_iter().map(Into::into).collect(),
+            properties: Vec::new(),
+        }
+    }
+
+    /// Adds a property, returning self for chaining.
+    #[must_use]
+    pub fn with_property(mut self, key: impl Into<String>, value: impl Into<Value>) -> Self {
+        self.properties.push((key.into(), value.into()));
+        self
+    }
+}
+
+/// An edge to create within a transactional batch.
+#[derive(Debug, Clone)]
+pub struct TransactionalEdgeCreate {
+    /// Source node.
+    pub source: NodeId,
+    /// Target node.
+    pub target: NodeId,
+    /// Edge type name.
+    pub edge_type: String,
+    /// Property key/value pairs, written in order.
+    pub properties: Vec<(String, Value)>,
+}
+
+impl TransactionalEdgeCreate {
+    /// Creates an edge spec with no properties.
+    #[must_use]
+    pub fn new(source: NodeId, target: NodeId, edge_type: impl Into<String>) -> Self {
+        Self {
+            source,
+            target,
+            edge_type: edge_type.into(),
+            properties: Vec::new(),
+        }
+    }
+
+    /// Adds a property, returning self for chaining.
+    #[must_use]
+    pub fn with_property(mut self, key: impl Into<String>, value: impl Into<Value>) -> Self {
+        self.properties.push((key.into(), value.into()));
+        self
+    }
+}
+
+impl Session {
+    /// Batch-creates nodes inside the active transaction using one storage-level
+    /// batch operation, returning the new IDs in input order.
+    ///
+    /// # Errors
+    ///
+    /// - if no explicit transaction is active;
+    /// - if any property value exceeds the configured `max_property_size`
+    ///   (checked for the whole batch before any mutation);
+    /// - on a write-write conflict registering the batch with the transaction.
+    #[cfg(feature = "lpg")]
+    pub fn create_nodes_with_props_transactional(
+        &self,
+        nodes: &[TransactionalNodeCreate],
+    ) -> Result<Vec<NodeId>> {
+        let transaction_id = self.require_active_transaction()?;
+
+        // Preflight: validate every property size before the first mutation.
+        for node in nodes {
+            for (key, value) in &node.properties {
+                self.check_property_size(key, value)?;
+            }
+        }
+
+        let (epoch, _) = self.get_transaction_context();
+        #[cfg(feature = "vector-index")]
+        let graph_name = self.active_graph_storage_key();
+
+        // Labels are borrowed `&[&str]` in the storage DTO; build per-node label
+        // slices that reference the caller's owned strings, then the storage DTOs.
+        let label_slices: Vec<Vec<&str>> = nodes
+            .iter()
+            .map(|n| n.labels.iter().map(String::as_str).collect())
+            .collect();
+        let storage_nodes: Vec<BatchNodeCreate<'_>> = nodes
+            .iter()
+            .zip(label_slices.iter())
+            .map(|(n, labels)| BatchNodeCreate {
+                labels,
+                properties: n
+                    .properties
+                    .iter()
+                    .map(|(k, v)| (PropertyKey::new(k.clone()), v.clone()))
+                    .collect(),
+            })
+            .collect();
+
+        let store = self.active_lpg_store();
+        let ids = store.create_nodes_batch_versioned(&storage_nodes, epoch, transaction_id);
+
+        // Register every node write with transaction management (one lock).
+        let entities: Vec<crate::transaction::EntityId> = ids
+            .iter()
+            .copied()
+            .map(crate::transaction::EntityId::Node)
+            .collect();
+        self.transaction_manager
+            .record_writes(transaction_id, &entities)?;
+
+        // WAL: identical record stream to the row path (CreateNode + SetNodeProperty*).
+        #[cfg(feature = "wal")]
+        for (node, &id) in nodes.iter().zip(ids.iter()) {
+            self.log_wal_record(&grafeo_storage::wal::WalRecord::CreateNode {
+                id,
+                labels: node.labels.clone(),
+            });
+            for (key, value) in &node.properties {
+                self.log_wal_record(&grafeo_storage::wal::WalRecord::SetNodeProperty {
+                    id,
+                    key: key.clone(),
+                    value: value.clone(),
+                });
+            }
+        }
+
+        // Vector intents: buffer until commit, exactly like the row path.
+        #[cfg(feature = "vector-index")]
+        for (node, &id) in nodes.iter().zip(ids.iter()) {
+            for (key, value) in &node.properties {
+                if matches!(value, Value::Vector(_)) {
+                    self.push_vector_intent(VectorIndexIntent::Upsert {
+                        graph_name: graph_name.clone(),
+                        node_id: id,
+                        property: key.clone(),
+                    })?;
+                }
+            }
+        }
+
+        Ok(ids)
+    }
+
+    /// Batch-creates edges inside the active transaction using one storage-level
+    /// batch operation, returning the new IDs in input order.
+    ///
+    /// # Errors
+    ///
+    /// - if no explicit transaction is active;
+    /// - if any property value exceeds the configured `max_property_size`
+    ///   (checked for the whole batch before any mutation);
+    /// - on a write-write conflict registering the batch with the transaction.
+    #[cfg(feature = "lpg")]
+    pub fn create_edges_with_props_transactional(
+        &self,
+        edges: &[TransactionalEdgeCreate],
+    ) -> Result<Vec<EdgeId>> {
+        let transaction_id = self.require_active_transaction()?;
+
+        for edge in edges {
+            for (key, value) in &edge.properties {
+                self.check_property_size(key, value)?;
+            }
+        }
+
+        let (epoch, _) = self.get_transaction_context();
+
+        let storage_edges: Vec<BatchEdgeCreate<'_>> = edges
+            .iter()
+            .map(|e| BatchEdgeCreate {
+                source: e.source,
+                target: e.target,
+                edge_type: e.edge_type.as_str(),
+                properties: e
+                    .properties
+                    .iter()
+                    .map(|(k, v)| (PropertyKey::new(k.clone()), v.clone()))
+                    .collect(),
+            })
+            .collect();
+
+        let store = self.active_lpg_store();
+        let ids = store.create_edges_batch_versioned(&storage_edges, epoch, transaction_id);
+
+        let entities: Vec<crate::transaction::EntityId> = ids
+            .iter()
+            .copied()
+            .map(crate::transaction::EntityId::Edge)
+            .collect();
+        self.transaction_manager
+            .record_writes(transaction_id, &entities)?;
+
+        #[cfg(feature = "wal")]
+        for (edge, &id) in edges.iter().zip(ids.iter()) {
+            self.log_wal_record(&grafeo_storage::wal::WalRecord::CreateEdge {
+                id,
+                src: edge.source,
+                dst: edge.target,
+                edge_type: edge.edge_type.clone(),
+            });
+            for (key, value) in &edge.properties {
+                self.log_wal_record(&grafeo_storage::wal::WalRecord::SetEdgeProperty {
+                    id,
+                    key: key.clone(),
+                    value: value.clone(),
+                });
+            }
+        }
+
+        Ok(ids)
+    }
+
+    /// Returns the active transaction ID or fails closed if none is active.
+    ///
+    /// The batch APIs are explicit-transaction-required by contract; unlike the
+    /// row methods they never fall back to `TransactionId::SYSTEM` auto-commit.
+    #[cfg(feature = "lpg")]
+    fn require_active_transaction(&self) -> Result<grafeo_common::types::TransactionId> {
+        self.current_transaction.lock().ok_or_else(|| {
+            Error::Transaction(TransactionError::InvalidState(
+                "transactional batch mutation requires an active explicit transaction".to_string(),
+            ))
+        })
+    }
+}

--- a/crates/grafeo-engine/src/transaction/manager.rs
+++ b/crates/grafeo-engine/src/transaction/manager.rs
@@ -342,7 +342,13 @@ impl TransactionManager {
 
         // Commit successful: advance epoch atomically.
         // SeqCst ensures all threads see commits in a consistent total order.
+        let old_epoch = self.current_epoch.load(Ordering::SeqCst);
         let commit_epoch = EpochId::new(self.current_epoch.fetch_add(1, Ordering::SeqCst) + 1);
+        eprintln!(
+            "[epoch-debug] TM::commit: tx={transaction_id:?} old_epoch={old_epoch} commit_epoch={} tm_ptr={:p}",
+            commit_epoch.as_u64(),
+            self
+        );
 
         // Update state and record commit epoch atomically (both write locks held).
         if let Some(info) = txns.get_mut(&transaction_id) {
@@ -449,7 +455,9 @@ impl TransactionManager {
     /// Returns the current epoch.
     #[must_use]
     pub fn current_epoch(&self) -> EpochId {
-        EpochId::new(self.current_epoch.load(Ordering::Acquire))
+        let epoch = self.current_epoch.load(Ordering::Acquire);
+        eprintln!("[epoch-debug] TM::current_epoch: epoch={epoch} tm_ptr={:p}", self);
+        EpochId::new(epoch)
     }
 
     /// Synchronizes the epoch counter to at least the given value.

--- a/crates/grafeo-engine/src/transaction/manager.rs
+++ b/crates/grafeo-engine/src/transaction/manager.rs
@@ -217,6 +217,60 @@ impl TransactionManager {
         Ok(())
     }
 
+    /// Records many write operations for a transaction under a single
+    /// `transactions` write-lock acquisition.
+    ///
+    /// Storage-level batch node/edge creation writes hundreds or thousands of
+    /// entities at once; calling [`record_write`](Self::record_write) per row
+    /// would re-acquire the lock and re-scan for conflicts every time. This
+    /// performs the same first-writer-wins conflict detection as `record_write`
+    /// but amortizes both over the whole batch.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on a write-write conflict with another active
+    /// transaction, or if the transaction is missing/inactive. On conflict the
+    /// write set is left partially extended, which is harmless: the caller rolls
+    /// the transaction back.
+    pub fn record_writes(
+        &self,
+        transaction_id: TransactionId,
+        entities: &[EntityId],
+    ) -> Result<()> {
+        if entities.is_empty() {
+            return Ok(());
+        }
+        let mut txns = self.transactions.write();
+
+        if self.active_count.load(Ordering::Relaxed) > 1 {
+            for &entity in entities {
+                for (other_tx, other_info) in txns.iter() {
+                    if *other_tx != transaction_id
+                        && other_info.state == TransactionState::Active
+                        && other_info.write_set.contains(&entity)
+                    {
+                        return Err(Error::Transaction(TransactionError::WriteConflict(
+                            format!("Write-write conflict on entity {entity:?}"),
+                        )));
+                    }
+                }
+            }
+        }
+
+        let info = txns.get_mut(&transaction_id).ok_or_else(|| {
+            Error::Transaction(TransactionError::InvalidState(
+                "Transaction not found".to_string(),
+            ))
+        })?;
+        if info.state != TransactionState::Active {
+            return Err(Error::Transaction(TransactionError::InvalidState(
+                "Transaction not active".to_string(),
+            )));
+        }
+        info.write_set.extend(entities.iter().copied());
+        Ok(())
+    }
+
     /// Records a read operation for the transaction (for serializable isolation).
     ///
     /// # Errors
@@ -456,7 +510,10 @@ impl TransactionManager {
     #[must_use]
     pub fn current_epoch(&self) -> EpochId {
         let epoch = self.current_epoch.load(Ordering::Acquire);
-        eprintln!("[epoch-debug] TM::current_epoch: epoch={epoch} tm_ptr={:p}", self);
+        eprintln!(
+            "[epoch-debug] TM::current_epoch: epoch={epoch} tm_ptr={:p}",
+            self
+        );
         EpochId::new(epoch)
     }
 

--- a/crates/grafeo-engine/src/transaction/manager.rs
+++ b/crates/grafeo-engine/src/transaction/manager.rs
@@ -342,10 +342,10 @@ impl TransactionManager {
 
         // Commit successful: advance epoch atomically.
         // SeqCst ensures all threads see commits in a consistent total order.
-        let old_epoch = self.current_epoch.load(Ordering::SeqCst);
         let commit_epoch = EpochId::new(self.current_epoch.fetch_add(1, Ordering::SeqCst) + 1);
+        #[cfg(debug_assertions)]
         eprintln!(
-            "[epoch-debug] TM::commit: tx={transaction_id:?} old_epoch={old_epoch} commit_epoch={} tm_ptr={:p}",
+            "[epoch-debug] TM::commit: tx={transaction_id:?} commit_epoch={} tm_ptr={:p}",
             commit_epoch.as_u64(),
             self
         );

--- a/crates/grafeo-engine/src/transaction/mvcc.rs
+++ b/crates/grafeo-engine/src/transaction/mvcc.rs
@@ -100,12 +100,12 @@ mod tests {
     #[test]
     fn test_version_chain_rollback() {
         let mut chain = VersionChain::with_initial("v1", EpochId::new(1), TransactionId::new(1));
-        chain.add_version("v2", EpochId::new(5), TransactionId::new(2));
-        chain.add_version("v3", EpochId::new(6), TransactionId::new(2));
+        chain.add_version("v2", EpochId::PENDING, TransactionId::new(2));
+        chain.add_version("v3", EpochId::PENDING, TransactionId::new(2));
 
         assert_eq!(chain.version_count(), 3);
 
-        // Rollback tx 2's changes
+        // Rollback tx 2's PENDING changes
         chain.remove_versions_by(TransactionId::new(2));
 
         assert_eq!(chain.version_count(), 1);

--- a/crates/grafeo-engine/tests/agent_memory_migration.rs
+++ b/crates/grafeo-engine/tests/agent_memory_migration.rs
@@ -92,15 +92,19 @@ fn test_incremental_growth_with_persistence() {
     {
         let db = GrafeoDB::with_config(Config::persistent(&path)).unwrap();
         for i in 0..batch_size {
-            let node = db.create_node(&["Memory"]);
-            db.set_node_property(node, "text", Value::String(format!("fact_{i}").into()));
-            db.set_node_property(node, "timestamp", Value::Int64(1_700_000_000 + i));
-            db.set_node_property(node, "confidence", Value::Float64(0.5 + (i as f64) * 0.001));
+            let node = db.create_node(&["Memory"]).unwrap();
+            db.set_node_property(node, "text", Value::String(format!("fact_{i}").into()))
+                .unwrap();
+            db.set_node_property(node, "timestamp", Value::Int64(1_700_000_000 + i))
+                .unwrap();
+            db.set_node_property(node, "confidence", Value::Float64(0.5 + (i as f64) * 0.001))
+                .unwrap();
             db.set_node_property(
                 node,
                 "embedding",
                 Value::Vector(random_384d_vector(i as u64).into()),
-            );
+            )
+            .unwrap();
         }
         inserted += batch_size as u64;
 
@@ -144,15 +148,19 @@ fn test_incremental_growth_with_persistence() {
 
         let batch_end = (inserted + reopen_every as u64).min(total_nodes as u64);
         for i in inserted..batch_end {
-            let node = db.create_node(&["Memory"]);
-            db.set_node_property(node, "text", Value::String(format!("fact_{i}").into()));
-            db.set_node_property(node, "timestamp", Value::Int64(1_700_000_000 + i as i64));
-            db.set_node_property(node, "confidence", Value::Float64(0.5 + (i as f64) * 0.001));
+            let node = db.create_node(&["Memory"]).unwrap();
+            db.set_node_property(node, "text", Value::String(format!("fact_{i}").into()))
+                .unwrap();
+            db.set_node_property(node, "timestamp", Value::Int64(1_700_000_000 + i as i64))
+                .unwrap();
+            db.set_node_property(node, "confidence", Value::Float64(0.5 + (i as f64) * 0.001))
+                .unwrap();
             db.set_node_property(
                 node,
                 "embedding",
                 Value::Vector(random_384d_vector(i).into()),
-            );
+            )
+            .unwrap();
         }
         inserted = batch_end;
 
@@ -196,12 +204,13 @@ fn bench_hnsw_at_20k() {
 
     // Insert first 100, then create index
     for i in 0..100u64 {
-        let node = db.create_node(&["Memory"]);
+        let node = db.create_node(&["Memory"]).unwrap();
         db.set_node_property(
             node,
             "embedding",
             Value::Vector(random_384d_vector(i).into()),
-        );
+        )
+        .unwrap();
     }
     db.create_vector_index(
         "Memory",
@@ -216,12 +225,13 @@ fn bench_hnsw_at_20k() {
 
     // Insert remaining incrementally
     for i in 100..total as u64 {
-        let node = db.create_node(&["Memory"]);
+        let node = db.create_node(&["Memory"]).unwrap();
         db.set_node_property(
             node,
             "embedding",
             Value::Vector(random_384d_vector(i).into()),
-        );
+        )
+        .unwrap();
 
         // Measure at milestones
         let count = (i + 1) as usize;
@@ -267,8 +277,9 @@ fn test_hnsw_recall_at_2k() {
     let mut id_to_index: std::collections::HashMap<u64, usize> = std::collections::HashMap::new();
     for i in 0..count as u64 {
         let vec = random_384d_vector(i);
-        let node = db.create_node(&["Memory"]);
-        db.set_node_property(node, "embedding", Value::Vector(vec.clone().into()));
+        let node = db.create_node(&["Memory"]).unwrap();
+        db.set_node_property(node, "embedding", Value::Vector(vec.clone().into()))
+            .unwrap();
         id_to_index.insert(node.as_u64(), i as usize);
         all_vectors.push(vec);
     }
@@ -340,12 +351,13 @@ fn test_concurrent_vector_search_during_writes() {
 
     // Seed 500 nodes with vectors
     for i in 0..500u64 {
-        let node = db.create_node(&["Memory"]);
+        let node = db.create_node(&["Memory"]).unwrap();
         db.set_node_property(
             node,
             "embedding",
             Value::Vector(random_384d_vector(i).into()),
-        );
+        )
+        .unwrap();
     }
     db.create_vector_index(
         "Memory",
@@ -377,12 +389,13 @@ fn test_concurrent_vector_search_during_writes() {
         handles.push(std::thread::spawn(move || {
             barrier.wait();
             for i in 0..writes {
-                let node = db.create_node(&["Memory"]);
+                let node = db.create_node(&["Memory"]).unwrap();
                 db.set_node_property(
                     node,
                     "embedding",
                     Value::Vector(random_384d_vector(10_000 + i as u64).into()),
-                );
+                )
+                .unwrap();
                 write_success.fetch_add(1, Ordering::Relaxed);
             }
         }));
@@ -468,8 +481,9 @@ fn test_close_reopen_preserves_data() {
         let mut node_ids = Vec::with_capacity(100);
         for i in 0..100 {
             let label = ENTITY_LABELS[i % ENTITY_LABELS.len()];
-            let node = db.create_node(&[label]);
-            db.set_node_property(node, "name", Value::String(format!("entity_{i}").into()));
+            let node = db.create_node(&[label]).unwrap();
+            db.set_node_property(node, "name", Value::String(format!("entity_{i}").into()))
+                .unwrap();
             node_ids.push(node);
         }
         // Create some edges via direct API
@@ -529,12 +543,13 @@ fn test_storage_size_100_entities() {
                 ("confidence", Value::Float64(0.5 + (i as f64) * 0.005)),
                 ("source", Value::String(format!("agent_{}", i % 5).into())),
             ],
-        );
+        ).unwrap();
         db.set_node_property(
             node,
             "embedding",
             Value::Vector(random_384d_vector(i).into()),
-        );
+        )
+        .unwrap();
         node_ids.push(node);
     }
     // Create 150 edges via direct API
@@ -605,20 +620,23 @@ fn bench_storage_size_5400_entities() {
 
         let timestamp = base_ts + (i as i64 * six_months_secs / num_nodes as i64);
 
-        let node = db.create_node_with_props(
-            &[label],
-            vec![
-                ("text", Value::String(text.into())),
-                ("timestamp", Value::Int64(timestamp)),
-                ("confidence", Value::Float64(0.3 + (i as f64 % 70.0) * 0.01)),
-                ("source", Value::String(format!("agent_{}", i % 5).into())),
-            ],
-        );
+        let node = db
+            .create_node_with_props(
+                &[label],
+                vec![
+                    ("text", Value::String(text.into())),
+                    ("timestamp", Value::Int64(timestamp)),
+                    ("confidence", Value::Float64(0.3 + (i as f64 % 70.0) * 0.01)),
+                    ("source", Value::String(format!("agent_{}", i % 5).into())),
+                ],
+            )
+            .unwrap();
         db.set_node_property(
             node,
             "embedding",
             Value::Vector(random_384d_vector(i).into()),
-        );
+        )
+        .unwrap();
         node_ids.push(node);
     }
 
@@ -689,18 +707,21 @@ fn bench_vector_index_rebuild_5k() {
         let db = GrafeoDB::with_config(Config::persistent(&path)).unwrap();
 
         for i in 0..num_nodes as u64 {
-            let node = db.create_node_with_props(
-                &["Memory"],
-                vec![
-                    ("text", Value::String(format!("fact_{i}").into())),
-                    ("confidence", Value::Float64(0.5 + (i as f64) * 0.0001)),
-                ],
-            );
+            let node = db
+                .create_node_with_props(
+                    &["Memory"],
+                    vec![
+                        ("text", Value::String(format!("fact_{i}").into())),
+                        ("confidence", Value::Float64(0.5 + (i as f64) * 0.0001)),
+                    ],
+                )
+                .unwrap();
             db.set_node_property(
                 node,
                 "embedding",
                 Value::Vector(random_384d_vector(i).into()),
-            );
+            )
+            .unwrap();
         }
 
         // Create index before close (so it gets persisted in snapshot v4)
@@ -803,12 +824,13 @@ fn test_byov_384_cosine() {
 
     // Insert 50 nodes with 384-dim vectors
     for i in 0..50u64 {
-        let node = db.create_node(&["Memory"]);
+        let node = db.create_node(&["Memory"]).unwrap();
         db.set_node_property(
             node,
             "embedding",
             Value::Vector(random_384d_vector(i).into()),
-        );
+        )
+        .unwrap();
     }
 
     db.create_vector_index(
@@ -854,12 +876,13 @@ fn test_byov_all_metrics() {
         let db = GrafeoDB::new_in_memory();
 
         for i in 0..20u64 {
-            let node = db.create_node(&["Memory"]);
+            let node = db.create_node(&["Memory"]).unwrap();
             db.set_node_property(
                 node,
                 "embedding",
                 Value::Vector(random_384d_vector(i).into()),
-            );
+            )
+            .unwrap();
         }
 
         db.create_vector_index(
@@ -894,12 +917,13 @@ fn test_byov_incremental_after_index() {
     let db = GrafeoDB::new_in_memory();
 
     // Create index on empty set with declared dimension
-    let sentinel = db.create_node(&["Memory"]);
+    let sentinel = db.create_node(&["Memory"]).unwrap();
     db.set_node_property(
         sentinel,
         "embedding",
         Value::Vector(random_384d_vector(9999).into()),
-    );
+    )
+    .unwrap();
     db.create_vector_index(
         "Memory",
         "embedding",
@@ -913,12 +937,13 @@ fn test_byov_incremental_after_index() {
 
     // Insert 100 nodes incrementally
     for i in 0..100u64 {
-        let node = db.create_node(&["Memory"]);
+        let node = db.create_node(&["Memory"]).unwrap();
         db.set_node_property(
             node,
             "embedding",
             Value::Vector(random_384d_vector(i).into()),
-        );
+        )
+        .unwrap();
 
         if (i + 1) % 25 == 0 {
             let results = db
@@ -960,14 +985,16 @@ fn test_bulk_import_single_transaction() {
     let mut node_ids = Vec::with_capacity(num_nodes);
     for i in 0..num_nodes as u64 {
         let label = ENTITY_LABELS[i as usize % ENTITY_LABELS.len()];
-        let id = db.create_node_with_props(
-            &[label],
-            vec![
-                ("name", Value::String(format!("entity_{i}").into())),
-                ("timestamp", Value::Int64(1_700_000_000 + i as i64)),
-                ("confidence", Value::Float64(0.5 + (i as f64) * 0.0003)),
-            ],
-        );
+        let id = db
+            .create_node_with_props(
+                &[label],
+                vec![
+                    ("name", Value::String(format!("entity_{i}").into())),
+                    ("timestamp", Value::Int64(1_700_000_000 + i as i64)),
+                    ("confidence", Value::Float64(0.5 + (i as f64) * 0.0003)),
+                ],
+            )
+            .unwrap();
         node_ids.push(id);
     }
 
@@ -1012,13 +1039,15 @@ fn bench_bulk_import_15k() {
         let mut node_ids = Vec::with_capacity(num_nodes);
         for i in 0..num_nodes as u64 {
             let label = ENTITY_LABELS[i as usize % ENTITY_LABELS.len()];
-            let id = db.create_node_with_props(
-                &[label],
-                vec![
-                    ("name", Value::String(format!("entity_{i}").into())),
-                    ("timestamp", Value::Int64(1_700_000_000 + i as i64)),
-                ],
-            );
+            let id = db
+                .create_node_with_props(
+                    &[label],
+                    vec![
+                        ("name", Value::String(format!("entity_{i}").into())),
+                        ("timestamp", Value::Int64(1_700_000_000 + i as i64)),
+                    ],
+                )
+                .unwrap();
             node_ids.push(id);
         }
 

--- a/crates/grafeo-engine/tests/backup_restore.rs
+++ b/crates/grafeo-engine/tests/backup_restore.rs
@@ -149,7 +149,7 @@ fn backup_manifest_tracks_segments() {
     let backup_dir = dir.path().join("backups");
 
     let db = GrafeoDB::open(&db_path).expect("open");
-    db.create_node(&["Test"]);
+    db.create_node(&["Test"]).unwrap();
 
     let segment = db.backup_full(&backup_dir).expect("full backup");
 
@@ -172,7 +172,7 @@ fn incremental_without_full_fails() {
     let backup_dir = dir.path().join("backups");
 
     let db = GrafeoDB::open(&db_path).expect("open");
-    db.create_node(&["Test"]);
+    db.create_node(&["Test"]).unwrap();
 
     let result = db.backup_incremental(&backup_dir);
     assert!(result.is_err(), "incremental without full should fail");

--- a/crates/grafeo-engine/tests/call_procedures.rs
+++ b/crates/grafeo-engine/tests/call_procedures.rs
@@ -10,13 +10,16 @@ use grafeo_engine::GrafeoDB;
 /// Creates 3 Person nodes (Alix, Gus, Harm) with 2 KNOWS edges.
 fn setup_graph() -> GrafeoDB {
     let db = GrafeoDB::new_in_memory();
-    let alix = db.create_node(&["Person"]);
-    let gus = db.create_node(&["Person"]);
-    let harm = db.create_node(&["Person"]);
+    let alix = db.create_node(&["Person"]).unwrap();
+    let gus = db.create_node(&["Person"]).unwrap();
+    let harm = db.create_node(&["Person"]).unwrap();
 
-    db.set_node_property(alix, "name", Value::from("Alix"));
-    db.set_node_property(gus, "name", Value::from("Gus"));
-    db.set_node_property(harm, "name", Value::from("Harm"));
+    db.set_node_property(alix, "name", Value::from("Alix"))
+        .unwrap();
+    db.set_node_property(gus, "name", Value::from("Gus"))
+        .unwrap();
+    db.set_node_property(harm, "name", Value::from("Harm"))
+        .unwrap();
 
     db.create_edge(alix, gus, "KNOWS");
     db.create_edge(gus, harm, "KNOWS");
@@ -400,10 +403,10 @@ fn test_call_bfs_with_invalid_source() {
 fn test_call_shortest_path_disconnected() {
     let db = GrafeoDB::new_in_memory();
     // Create two disconnected components
-    let a = db.create_node(&["Node"]);
-    let b = db.create_node(&["Node"]);
-    db.set_node_property(a, "name", Value::from("A"));
-    db.set_node_property(b, "name", Value::from("B"));
+    let a = db.create_node(&["Node"]).unwrap();
+    let b = db.create_node(&["Node"]).unwrap();
+    db.set_node_property(a, "name", Value::from("A")).unwrap();
+    db.set_node_property(b, "name", Value::from("B")).unwrap();
     // No edge between them
 
     let session = db.session();
@@ -422,7 +425,7 @@ fn test_call_shortest_path_disconnected() {
 #[test]
 fn test_call_pagerank_single_node() {
     let db = GrafeoDB::new_in_memory();
-    db.create_node(&["Isolated"]);
+    db.create_node(&["Isolated"]).unwrap();
 
     let session = db.session();
     let result = session.execute("CALL grafeo.pagerank()").unwrap();

--- a/crates/grafeo-engine/tests/cdc_crud_api.rs
+++ b/crates/grafeo-engine/tests/cdc_crud_api.rs
@@ -24,10 +24,12 @@ fn db() -> GrafeoDB {
 #[test]
 fn create_node_with_props_generates_cdc() {
     let db = db();
-    let id = db.create_node_with_props(
-        &["Person"],
-        vec![("name", Value::from("Alix")), ("age", Value::Int64(30))],
-    );
+    let id = db
+        .create_node_with_props(
+            &["Person"],
+            vec![("name", Value::from("Alix")), ("age", Value::Int64(30))],
+        )
+        .unwrap();
 
     let history = db.history(id).unwrap();
     assert!(!history.is_empty(), "Should have CDC events");
@@ -48,11 +50,13 @@ fn create_node_with_props_generates_cdc() {
 #[test]
 fn delete_node_generates_cdc_with_before_snapshot() {
     let db = db();
-    let id = db.create_node(&["Person"]);
-    db.set_node_property(id, "name", Value::from("Alix"));
-    db.set_node_property(id, "city", Value::from("Amsterdam"));
+    let id = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(id, "name", Value::from("Alix"))
+        .unwrap();
+    db.set_node_property(id, "city", Value::from("Amsterdam"))
+        .unwrap();
 
-    let deleted = db.delete_node(id);
+    let deleted = db.delete_node(id).unwrap();
     assert!(deleted);
 
     let history = db.history(id).unwrap();
@@ -72,9 +76,11 @@ fn delete_node_generates_cdc_with_before_snapshot() {
 #[test]
 fn set_node_property_records_old_and_new_values() {
     let db = db();
-    let id = db.create_node(&["Person"]);
-    db.set_node_property(id, "name", Value::from("Alix"));
-    db.set_node_property(id, "name", Value::from("Gus"));
+    let id = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(id, "name", Value::from("Alix"))
+        .unwrap();
+    db.set_node_property(id, "name", Value::from("Gus"))
+        .unwrap();
 
     let history = db.history(id).unwrap();
     let updates: Vec<_> = history
@@ -102,8 +108,8 @@ fn set_node_property_records_old_and_new_values() {
 #[test]
 fn create_edge_generates_cdc() {
     let db = db();
-    let a = db.create_node(&["Person"]);
-    let b = db.create_node(&["Person"]);
+    let a = db.create_node(&["Person"]).unwrap();
+    let b = db.create_node(&["Person"]).unwrap();
     let eid = db.create_edge(a, b, "KNOWS");
 
     let changes = db
@@ -128,8 +134,8 @@ fn create_edge_generates_cdc() {
 #[test]
 fn create_edge_with_props_generates_cdc() {
     let db = db();
-    let a = db.create_node(&["Person"]);
-    let b = db.create_node(&["Person"]);
+    let a = db.create_node(&["Person"]).unwrap();
+    let b = db.create_node(&["Person"]).unwrap();
     let eid = db.create_edge_with_props(
         a,
         b,
@@ -163,8 +169,8 @@ fn create_edge_with_props_generates_cdc() {
 #[test]
 fn delete_edge_generates_cdc_with_before_snapshot() {
     let db = db();
-    let a = db.create_node(&["Person"]);
-    let b = db.create_node(&["Person"]);
+    let a = db.create_node(&["Person"]).unwrap();
+    let b = db.create_node(&["Person"]).unwrap();
     let eid = db.create_edge(a, b, "KNOWS");
     db.set_edge_property(eid, "since", Value::Int64(2020));
 
@@ -193,8 +199,8 @@ fn delete_edge_generates_cdc_with_before_snapshot() {
 #[test]
 fn set_edge_property_records_old_and_new_values() {
     let db = db();
-    let a = db.create_node(&["Person"]);
-    let b = db.create_node(&["Person"]);
+    let a = db.create_node(&["Person"]).unwrap();
+    let b = db.create_node(&["Person"]).unwrap();
     let eid = db.create_edge(a, b, "KNOWS");
     db.set_edge_property(eid, "weight", Value::Float64(0.5));
     db.set_edge_property(eid, "weight", Value::Float64(0.9));
@@ -237,7 +243,8 @@ fn database_gc_prunes_cdc_events() {
 
     // Create 10 nodes via the CRUD API (each generates a CDC Create event)
     for i in 0..10 {
-        db.create_node_with_props(&["Person"], vec![("idx", Value::Int64(i))]);
+        db.create_node_with_props(&["Person"], vec![("idx", Value::Int64(i))])
+            .unwrap();
     }
 
     let before_gc = db

--- a/crates/grafeo-engine/tests/compact_roundtrip_proptest.rs
+++ b/crates/grafeo-engine/tests/compact_roundtrip_proptest.rs
@@ -91,12 +91,13 @@ fn graph_spec_strategy() -> impl Strategy<Value = GraphSpec> {
 fn apply_spec(spec: &GraphSpec, db: &GrafeoDB) {
     let mut ids: Vec<NodeId> = Vec::with_capacity(spec.nodes.len());
     for n in &spec.nodes {
-        let id = db.create_node(&[n.label]);
+        let id = db.create_node(&[n.label]).unwrap();
         if let Some(num) = n.num {
-            db.set_node_property(id, "num", Value::Int64(num));
+            db.set_node_property(id, "num", Value::Int64(num)).unwrap();
         }
         if let Some(s) = &n.name {
-            db.set_node_property(id, "name", Value::String(s.clone().into()));
+            db.set_node_property(id, "name", Value::String(s.clone().into()))
+                .unwrap();
         }
         ids.push(id);
     }

--- a/crates/grafeo-engine/tests/coverage_session.rs
+++ b/crates/grafeo-engine/tests/coverage_session.rs
@@ -598,8 +598,9 @@ mod cdc_tests {
     #[test]
     fn test_cdc_history_records_create() {
         let db = cdc_db();
-        let node_id = db.create_node(&["Person"]);
-        db.set_node_property(node_id, "name", Value::String("Alix".into()));
+        let node_id = db.create_node(&["Person"]).unwrap();
+        db.set_node_property(node_id, "name", Value::String("Alix".into()))
+            .unwrap();
 
         let session = db.session();
         let history = session.history(node_id).unwrap();
@@ -619,9 +620,11 @@ mod cdc_tests {
     #[test]
     fn test_cdc_history_records_update() {
         let db = cdc_db();
-        let node_id = db.create_node(&["Person"]);
-        db.set_node_property(node_id, "name", Value::String("Alix".into()));
-        db.set_node_property(node_id, "name", Value::String("Gus".into()));
+        let node_id = db.create_node(&["Person"]).unwrap();
+        db.set_node_property(node_id, "name", Value::String("Alix".into()))
+            .unwrap();
+        db.set_node_property(node_id, "name", Value::String("Gus".into()))
+            .unwrap();
 
         let session = db.session();
         let history = session.history(node_id).unwrap();
@@ -638,8 +641,9 @@ mod cdc_tests {
     #[test]
     fn test_cdc_history_since_filters_by_epoch() {
         let db = cdc_db();
-        let node_id = db.create_node(&["Person"]);
-        db.set_node_property(node_id, "name", Value::String("Alix".into()));
+        let node_id = db.create_node(&["Person"]).unwrap();
+        db.set_node_property(node_id, "name", Value::String("Alix".into()))
+            .unwrap();
 
         let session = db.session();
         // history_since with a very high epoch should return nothing
@@ -662,8 +666,8 @@ mod cdc_tests {
     #[test]
     fn test_cdc_changes_between_epoch_range() {
         let db = cdc_db();
-        db.create_node(&["Person"]);
-        db.create_node(&["Person"]);
+        db.create_node(&["Person"]).unwrap();
+        db.create_node(&["Person"]).unwrap();
 
         let session = db.session();
         // Get all changes from epoch 0 to a large epoch

--- a/crates/grafeo-engine/tests/database_api.rs
+++ b/crates/grafeo-engine/tests/database_api.rs
@@ -12,8 +12,8 @@ use grafeo_engine::GrafeoDB;
 #[test]
 fn test_create_edge_with_props() {
     let db = GrafeoDB::new_in_memory();
-    let alix = db.create_node(&["Person"]);
-    let gus = db.create_node(&["Person"]);
+    let alix = db.create_node(&["Person"]).unwrap();
+    let gus = db.create_node(&["Person"]).unwrap();
 
     let eid = db.create_edge_with_props(
         alix,
@@ -43,8 +43,8 @@ fn test_get_edge_returns_none_for_invalid_id() {
 #[test]
 fn test_set_and_remove_edge_property() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["N"]);
-    let b = db.create_node(&["N"]);
+    let a = db.create_node(&["N"]).unwrap();
+    let b = db.create_node(&["N"]).unwrap();
     let eid = db.create_edge(a, b, "R");
 
     db.set_edge_property(eid, "weight", Value::Float64(1.5));
@@ -71,8 +71,8 @@ fn test_set_and_remove_edge_property() {
 #[test]
 fn test_delete_edge() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["N"]);
-    let b = db.create_node(&["N"]);
+    let a = db.create_node(&["N"]).unwrap();
+    let b = db.create_node(&["N"]).unwrap();
     let eid = db.create_edge(a, b, "R");
 
     assert_eq!(db.edge_count(), 1);
@@ -86,7 +86,7 @@ fn test_delete_edge() {
 #[test]
 fn test_add_and_remove_node_label() {
     let db = GrafeoDB::new_in_memory();
-    let n = db.create_node(&["Person"]);
+    let n = db.create_node(&["Person"]).unwrap();
 
     // Add label
     assert!(db.add_node_label(n, "Employee"));
@@ -121,8 +121,9 @@ fn test_get_node_labels_returns_none_for_invalid_id() {
 #[test]
 fn test_remove_node_property() {
     let db = GrafeoDB::new_in_memory();
-    let n = db.create_node(&["Person"]);
-    db.set_node_property(n, "name", Value::String("Alix".into()));
+    let n = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(n, "name", Value::String("Alix".into()))
+        .unwrap();
 
     assert!(db.remove_node_property(n, "name"));
     let node = db.get_node(n).unwrap();
@@ -150,12 +151,15 @@ fn test_property_index_lifecycle() {
     assert!(db.has_property_index("name"));
 
     // Create nodes with the property
-    let n1 = db.create_node(&["Person"]);
-    db.set_node_property(n1, "name", Value::String("Alix".into()));
-    let n2 = db.create_node(&["Person"]);
-    db.set_node_property(n2, "name", Value::String("Gus".into()));
-    let n3 = db.create_node(&["Person"]);
-    db.set_node_property(n3, "name", Value::String("Alix".into()));
+    let n1 = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(n1, "name", Value::String("Alix".into()))
+        .unwrap();
+    let n2 = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(n2, "name", Value::String("Gus".into()))
+        .unwrap();
+    let n3 = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(n3, "name", Value::String("Alix".into()))
+        .unwrap();
 
     // Find by property
     let results = db.find_nodes_by_property("name", &Value::String("Alix".into()));
@@ -182,9 +186,9 @@ fn test_property_index_lifecycle() {
 #[test]
 fn test_iter_nodes() {
     let db = GrafeoDB::new_in_memory();
-    let _n1 = db.create_node(&["Person"]);
-    let _n2 = db.create_node(&["Company"]);
-    let _n3 = db.create_node(&["Person"]);
+    let _n1 = db.create_node(&["Person"]).unwrap();
+    let _n2 = db.create_node(&["Company"]).unwrap();
+    let _n3 = db.create_node(&["Person"]).unwrap();
 
     let nodes: Vec<_> = db.iter_nodes().collect();
     assert_eq!(nodes.len(), 3);
@@ -193,9 +197,9 @@ fn test_iter_nodes() {
 #[test]
 fn test_iter_edges() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["N"]);
-    let b = db.create_node(&["N"]);
-    let c = db.create_node(&["N"]);
+    let a = db.create_node(&["N"]).unwrap();
+    let b = db.create_node(&["N"]).unwrap();
+    let c = db.create_node(&["N"]).unwrap();
 
     let _e1 = db.create_edge(a, b, "R");
     let _e2 = db.create_edge(b, c, "S");
@@ -216,8 +220,8 @@ fn test_iter_empty_database() {
 #[test]
 fn test_validate_healthy_database() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["Person"]);
-    let b = db.create_node(&["Person"]);
+    let a = db.create_node(&["Person"]).unwrap();
+    let b = db.create_node(&["Person"]).unwrap();
     db.create_edge(a, b, "KNOWS");
 
     let result = db.validate();
@@ -236,8 +240,9 @@ fn test_validate_empty_database() {
 #[test]
 fn test_info() {
     let db = GrafeoDB::new_in_memory();
-    let _n = db.create_node(&["Person"]);
-    db.set_node_property(_n, "name", Value::String("Alix".into()));
+    let _n = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(_n, "name", Value::String("Alix".into()))
+        .unwrap();
 
     let info = db.info();
     assert_eq!(info.node_count, 1);
@@ -249,10 +254,12 @@ fn test_info() {
 #[test]
 fn test_detailed_stats() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["Person"]);
-    db.set_node_property(a, "name", Value::String("Alix".into()));
-    let b = db.create_node(&["Company"]);
-    db.set_node_property(b, "name", Value::String("Acme".into()));
+    let a = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(a, "name", Value::String("Alix".into()))
+        .unwrap();
+    let b = db.create_node(&["Company"]).unwrap();
+    db.set_node_property(b, "name", Value::String("Acme".into()))
+        .unwrap();
     db.create_edge(a, b, "WORKS_AT");
 
     let stats = db.detailed_stats();
@@ -282,10 +289,12 @@ fn test_graph_model_default() {
 #[test]
 fn test_to_memory_clones_data() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["Person"]);
-    db.set_node_property(a, "name", Value::String("Alix".into()));
-    let b = db.create_node(&["Person"]);
-    db.set_node_property(b, "name", Value::String("Gus".into()));
+    let a = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(a, "name", Value::String("Alix".into()))
+        .unwrap();
+    let b = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(b, "name", Value::String("Gus".into()))
+        .unwrap();
     db.create_edge(a, b, "KNOWS");
 
     let clone = db.to_memory().expect("to_memory should succeed");
@@ -303,11 +312,13 @@ fn test_to_memory_clones_data() {
 #[test]
 fn test_snapshot_export_import_roundtrip() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["Person"]);
-    db.set_node_property(a, "name", Value::String("Alix".into()));
-    db.set_node_property(a, "age", Value::Int64(30));
-    let b = db.create_node(&["Person"]);
-    db.set_node_property(b, "name", Value::String("Gus".into()));
+    let a = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(a, "name", Value::String("Alix".into()))
+        .unwrap();
+    db.set_node_property(a, "age", Value::Int64(30)).unwrap();
+    let b = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(b, "name", Value::String("Gus".into()))
+        .unwrap();
     db.create_edge(a, b, "KNOWS");
 
     // Export
@@ -341,11 +352,13 @@ fn test_schema_returns_labels_and_edge_types() {
     use grafeo_engine::SchemaInfo;
 
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["Person"]);
-    db.set_node_property(a, "name", Value::String("Alix".into()));
-    db.set_node_property(a, "age", Value::Int64(30));
-    let b = db.create_node(&["Company"]);
-    db.set_node_property(b, "name", Value::String("Acme".into()));
+    let a = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(a, "name", Value::String("Alix".into()))
+        .unwrap();
+    db.set_node_property(a, "age", Value::Int64(30)).unwrap();
+    let b = db.create_node(&["Company"]).unwrap();
+    db.set_node_property(b, "name", Value::String("Acme".into()))
+        .unwrap();
     db.create_edge(a, b, "WORKS_AT");
     db.create_edge(a, b, "LIKES");
 
@@ -372,8 +385,8 @@ fn test_schema_returns_labels_and_edge_types() {
 #[test]
 fn test_label_and_type_counts() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["Person"]);
-    let b = db.create_node(&["Company"]);
+    let a = db.create_node(&["Person"]).unwrap();
+    let b = db.create_node(&["Company"]).unwrap();
     db.create_edge(a, b, "WORKS_AT");
 
     assert!(db.label_count() >= 2);
@@ -405,8 +418,8 @@ fn test_wal_status_in_memory() {
 #[test]
 fn test_close_in_memory_database() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["N"]);
-    db.set_node_property(a, "x", Value::Int64(1));
+    let a = db.create_node(&["N"]).unwrap();
+    db.set_node_property(a, "x", Value::Int64(1)).unwrap();
 
     // Close should succeed (no-op for in-memory)
     db.close().expect("close should succeed for in-memory db");
@@ -457,8 +470,8 @@ fn test_info_updates_after_operations() {
     assert_eq!(info0.node_count, 0);
     assert_eq!(info0.edge_count, 0);
 
-    let a = db.create_node(&["Person"]);
-    let b = db.create_node(&["Company"]);
+    let a = db.create_node(&["Person"]).unwrap();
+    let b = db.create_node(&["Company"]).unwrap();
     db.create_edge(a, b, "WORKS_AT");
 
     let info1 = db.info();
@@ -471,14 +484,17 @@ fn test_info_updates_after_operations() {
 #[test]
 fn test_complex_graph_with_multiple_edge_types() {
     let db = GrafeoDB::new_in_memory();
-    let alix = db.create_node(&["Person"]);
-    db.set_node_property(alix, "name", Value::String("Alix".into()));
+    let alix = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(alix, "name", Value::String("Alix".into()))
+        .unwrap();
 
-    let gus = db.create_node(&["Person"]);
-    db.set_node_property(gus, "name", Value::String("Gus".into()));
+    let gus = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(gus, "name", Value::String("Gus".into()))
+        .unwrap();
 
-    let acme = db.create_node(&["Company"]);
-    db.set_node_property(acme, "name", Value::String("Acme".into()));
+    let acme = db.create_node(&["Company"]).unwrap();
+    db.set_node_property(acme, "name", Value::String("Acme".into()))
+        .unwrap();
 
     db.create_edge(alix, gus, "KNOWS");
     db.create_edge(alix, acme, "WORKS_AT");

--- a/crates/grafeo-engine/tests/error_paths.rs
+++ b/crates/grafeo-engine/tests/error_paths.rs
@@ -27,7 +27,8 @@ fn test_get_nonexistent_edge() {
 fn test_set_property_on_nonexistent_node() {
     let db = GrafeoDB::new_in_memory();
     // Setting a property on a missing node should not panic
-    db.set_node_property(NodeId::new(999), "key", Value::Int64(1));
+    db.set_node_property(NodeId::new(999), "key", Value::Int64(1))
+        .unwrap();
     // Node still doesn't exist
     assert!(db.get_node(NodeId::new(999)).is_none());
 }
@@ -35,7 +36,7 @@ fn test_set_property_on_nonexistent_node() {
 #[test]
 fn test_delete_nonexistent_node() {
     let db = GrafeoDB::new_in_memory();
-    assert!(!db.delete_node(NodeId::new(999)));
+    assert!(!db.delete_node(NodeId::new(999)).unwrap());
 }
 
 #[test]
@@ -249,8 +250,8 @@ fn test_info_empty_database() {
 #[test]
 fn test_property_with_null_value() {
     let db = GrafeoDB::new_in_memory();
-    let n = db.create_node(&["Test"]);
-    db.set_node_property(n, "key", Value::Null);
+    let n = db.create_node(&["Test"]).unwrap();
+    db.set_node_property(n, "key", Value::Null).unwrap();
 
     // In temporal mode, Null acts as a tombstone and is filtered out.
     // In non-temporal mode, Null is stored and returned.
@@ -272,8 +273,9 @@ fn test_property_with_null_value() {
 #[test]
 fn test_property_with_empty_string() {
     let db = GrafeoDB::new_in_memory();
-    let n = db.create_node(&["Test"]);
-    db.set_node_property(n, "key", Value::String("".into()));
+    let n = db.create_node(&["Test"]).unwrap();
+    db.set_node_property(n, "key", Value::String("".into()))
+        .unwrap();
 
     let node = db.get_node(n).unwrap();
     assert_eq!(
@@ -286,7 +288,7 @@ fn test_property_with_empty_string() {
 #[test]
 fn test_node_with_no_labels() {
     let db = GrafeoDB::new_in_memory();
-    let n = db.create_node(&[]);
+    let n = db.create_node(&[]).unwrap();
 
     let node = db.get_node(n);
     assert!(node.is_some(), "Node with no labels should exist");
@@ -310,7 +312,7 @@ fn test_node_with_many_labels() {
             _ => "J",
         })
         .collect();
-    let n = db.create_node(&labels);
+    let n = db.create_node(&labels).unwrap();
 
     let stored_labels = db.get_node_labels(n).unwrap();
     assert_eq!(stored_labels.len(), 10);
@@ -319,7 +321,7 @@ fn test_node_with_many_labels() {
 #[test]
 fn test_self_referencing_edge() {
     let db = GrafeoDB::new_in_memory();
-    let n = db.create_node(&["Node"]);
+    let n = db.create_node(&["Node"]).unwrap();
     let e = db.create_edge(n, n, "SELF");
 
     let edge = db.get_edge(e).unwrap();
@@ -430,9 +432,11 @@ fn test_graphql_range_filter_end_to_end() {
     let db = GrafeoDB::new_in_memory();
     // Create test data
     for i in 0..5 {
-        let n = db.create_node(&["Person"]);
-        db.set_node_property(n, "name", Value::String(format!("Person{}", i).into()));
-        db.set_node_property(n, "age", Value::Int64(20 + i * 10)); // 20, 30, 40, 50, 60
+        let n = db.create_node(&["Person"]).unwrap();
+        db.set_node_property(n, "name", Value::String(format!("Person{}", i).into()))
+            .unwrap();
+        db.set_node_property(n, "age", Value::Int64(20 + i * 10))
+            .unwrap(); // 20, 30, 40, 50, 60
     }
 
     let session = db.session();
@@ -472,8 +476,9 @@ fn test_insert_and_match_special_characters_in_properties() {
 #[test]
 fn test_match_with_multiple_labels() {
     let db = GrafeoDB::new_in_memory();
-    let n = db.create_node(&["Person", "Employee"]);
-    db.set_node_property(n, "name", Value::String("Alix".into()));
+    let n = db.create_node(&["Person", "Employee"]).unwrap();
+    db.set_node_property(n, "name", Value::String("Alix".into()))
+        .unwrap();
 
     let session = db.session();
     let result = session.execute("MATCH (n:Person) RETURN n.name").unwrap();
@@ -485,7 +490,7 @@ fn test_in_operator_with_empty_list() {
     let db = GrafeoDB::new_in_memory();
     let session = db.session();
 
-    db.create_node(&["Person"]);
+    db.create_node(&["Person"]).unwrap();
 
     let result = session
         .execute("MATCH (n:Person) WHERE n.name IN [] RETURN n")

--- a/crates/grafeo-engine/tests/exact_vector_read/helpers.rs
+++ b/crates/grafeo-engine/tests/exact_vector_read/helpers.rs
@@ -1,0 +1,38 @@
+//! Shared helpers for `exact_vector_read` integration tests.
+
+use grafeo_common::storage::{SectionType, TierOverride};
+use grafeo_common::types::{NodeId, PropertyKey, Value};
+use grafeo_engine::{Config, GrafeoDB};
+
+pub fn force_disk_config(db_path: &std::path::Path, spill_path: &std::path::Path) -> Config {
+    Config::persistent(db_path)
+        .with_spill_path(spill_path)
+        .with_section_tier(SectionType::VectorStore, TierOverride::ForceDisk)
+}
+
+pub fn make_embedding(seed: u64, dim: usize) -> Vec<f32> {
+    (0..dim)
+        .map(|i| ((seed * 7 + i as u64) % 100) as f32 / 100.0)
+        .collect()
+}
+
+pub fn seed_indexed_node(db: &GrafeoDB, label: &str, property: &str, vector: &[f32]) -> NodeId {
+    let id = db.create_node(&[label]).unwrap();
+    db.set_node_property(id, property, Value::Vector(vector.to_vec().into()))
+        .unwrap();
+    db.create_vector_index(label, property, Some(vector.len()), None, None, None, None)
+        .unwrap();
+    id
+}
+
+/// Returns the embedding from the inline node property column, if present.
+///
+/// After ForceDisk spill this is expected to be `None` even when the
+/// spill-aware exact read API still returns the vector.
+pub fn inline_embedding(db: &GrafeoDB, node: NodeId, property: &str) -> Option<Vec<f32>> {
+    let prop_key = PropertyKey::new(property);
+    match db.get_node(node)?.properties.get(&prop_key)? {
+        Value::Vector(v) => Some(v.as_ref().to_vec()),
+        _ => None,
+    }
+}

--- a/crates/grafeo-engine/tests/exact_vector_read/main.rs
+++ b/crates/grafeo-engine/tests/exact_vector_read/main.rs
@@ -1,0 +1,211 @@
+//! Exact spill-aware vector read by `(label, property, NodeId)`.
+//!
+//! Proves `GrafeoDB::read_indexed_node_vector` against inline storage and the
+//! ForceDisk checkpoint/reopen lifecycle where the inline property path is empty.
+//!
+//! ```bash
+//! cargo test -p grafeo-engine --test exact_vector_read \
+//!   --features "vector-index,mmap,grafeo-file"
+//! ```
+
+mod helpers;
+
+use grafeo_common::memory::StorageTier;
+use grafeo_common::storage::SectionType;
+use grafeo_common::types::{NodeId, PropertyKey, Value};
+use grafeo_engine::{GrafeoDB, IndexedVectorRead};
+use helpers::{force_disk_config, inline_embedding, make_embedding, seed_indexed_node};
+
+#[test]
+fn inline_exact_read_returns_owned_floats() {
+    let db = GrafeoDB::new_in_memory();
+    let expected = vec![0.25, 0.5, 0.75, 1.0];
+    let node = seed_indexed_node(&db, "Item", "embedding", &expected);
+
+    let IndexedVectorRead::Found(got) = db
+        .read_indexed_node_vector("Item", "embedding", node)
+        .expect("exact read")
+    else {
+        panic!("expected Found");
+    };
+    assert_eq!(got, expected);
+    // Owned copy: mutating the returned vec must not affect a second read.
+    let mut owned = got;
+    owned[0] = -1.0;
+    let IndexedVectorRead::Found(again) = db
+        .read_indexed_node_vector("Item", "embedding", node)
+        .expect("second exact read")
+    else {
+        panic!("expected Found");
+    };
+    assert_eq!(again[0], 0.25);
+}
+
+#[test]
+fn missing_node_and_missing_vector_return_absent() {
+    let db = GrafeoDB::new_in_memory();
+    db.create_vector_index("Item", "embedding", Some(4), None, None, None, None)
+        .unwrap();
+
+    let absent = NodeId::new(9_999);
+    assert!(matches!(
+        db.read_indexed_node_vector("Item", "embedding", absent)
+            .unwrap(),
+        IndexedVectorRead::Absent
+    ));
+
+    let node = db.create_node(&["Item"]).unwrap();
+    db.set_node_property(node, "name", Value::from("no-vector"))
+        .unwrap();
+    assert!(matches!(
+        db.read_indexed_node_vector("Item", "embedding", node)
+            .unwrap(),
+        IndexedVectorRead::Absent
+    ));
+}
+
+#[test]
+fn unregistered_or_wrong_label_property_is_typed() {
+    let db = GrafeoDB::new_in_memory();
+    let expected = make_embedding(3, 4);
+    let node = seed_indexed_node(&db, "Item", "embedding", &expected);
+
+    assert!(matches!(
+        db.read_indexed_node_vector("Item", "missing_prop", node)
+            .unwrap(),
+        IndexedVectorRead::IndexNotRegistered
+    ));
+
+    assert!(matches!(
+        db.read_indexed_node_vector("Other", "embedding", node)
+            .unwrap(),
+        IndexedVectorRead::IndexNotRegistered
+    ));
+
+    // Same property name on a different label: index exists for Item only, so
+    // reading under a registered-but-mismatched label is already covered above.
+    // A node lacking the indexed label returns Absent once an index exists for it.
+    db.create_vector_index("Other", "embedding", Some(4), None, None, None, None)
+        .unwrap();
+    assert!(
+        matches!(
+            db.read_indexed_node_vector("Other", "embedding", node)
+                .unwrap(),
+            IndexedVectorRead::Absent
+        ),
+        "Item node must not satisfy Other-label index"
+    );
+}
+
+#[test]
+fn dimension_fidelity_matches_registered_width() {
+    let db = GrafeoDB::new_in_memory();
+    let dim = 16;
+    let expected = make_embedding(11, dim);
+    let node = seed_indexed_node(&db, "Doc", "emb", &expected);
+    assert_eq!(db.vector_index_dimensions("Doc", "emb"), Some(dim));
+
+    let IndexedVectorRead::Found(got) = db
+        .read_indexed_node_vector("Doc", "emb", node)
+        .expect("exact read")
+    else {
+        panic!("expected Found");
+    };
+    assert_eq!(got.len(), dim);
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn uncommitted_session_vector_not_visible_on_database_api() {
+    let db = GrafeoDB::new_in_memory();
+    db.create_vector_index("Doc", "emb", Some(3), None, None, None, None)
+        .unwrap();
+
+    let mut session = db.session();
+    session.begin_transaction().unwrap();
+    let node = session
+        .create_node_with_props(
+            &["Doc"],
+            [("emb", Value::Vector(vec![1.0, 0.0, 0.0].into()))],
+        )
+        .unwrap();
+
+    assert!(
+        matches!(
+            db.read_indexed_node_vector("Doc", "emb", node).unwrap(),
+            IndexedVectorRead::Absent
+        ),
+        "uncommitted vector must not be visible via GrafeoDB"
+    );
+
+    session.commit().unwrap();
+    assert!(matches!(
+        db.read_indexed_node_vector("Doc", "emb", node).unwrap(),
+        IndexedVectorRead::Found(ref v) if v.as_slice() == [1.0, 0.0, 0.0]
+    ));
+}
+
+#[test]
+#[cfg(not(feature = "temporal"))]
+fn force_disk_checkpoint_reopen_exact_read_without_inline_property() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("exact_read.grafeo");
+    let spill_path = dir.path().join("exact_read.spill");
+    let expected = vec![0.125, 0.25, 0.375, 0.5];
+    let node;
+
+    {
+        let db = GrafeoDB::with_config(force_disk_config(&db_path, &spill_path)).unwrap();
+        node = seed_indexed_node(&db, "Item", "embedding", &expected);
+        assert!(matches!(
+            db.read_indexed_node_vector("Item", "embedding", node)
+                .unwrap(),
+            IndexedVectorRead::Found(ref v) if v.as_slice() == expected.as_slice()
+        ));
+
+        db.wal_checkpoint().unwrap();
+        assert_eq!(
+            db.storage_tiers().get(&SectionType::VectorStore),
+            Some(&StorageTier::OnDisk)
+        );
+
+        // After ForceDisk spill, the inline property column must not supply
+        // the vector — only the spill-aware exact API remains authoritative.
+        assert!(
+            inline_embedding(&db, node, "embedding").is_none(),
+            "inline property path must be empty after ForceDisk checkpoint"
+        );
+        assert!(matches!(
+            db.read_indexed_node_vector("Item", "embedding", node)
+                .unwrap(),
+            IndexedVectorRead::Found(ref v) if v.as_slice() == expected.as_slice()
+        ));
+        db.close().unwrap();
+    }
+
+    {
+        let db = GrafeoDB::with_config(force_disk_config(&db_path, &spill_path)).unwrap();
+        assert_eq!(
+            db.storage_tiers().get(&SectionType::VectorStore),
+            Some(&StorageTier::OnDisk)
+        );
+        assert!(
+            inline_embedding(&db, node, "embedding").is_none(),
+            "inline property path must stay empty after ForceDisk reopen"
+        );
+        let IndexedVectorRead::Found(got) = db
+            .read_indexed_node_vector("Item", "embedding", node)
+            .expect("exact read after reopen")
+        else {
+            panic!("spilled vector must be present");
+        };
+        assert_eq!(got, expected);
+        // Property-key probe via the store must also miss (same as get_node).
+        let prop_key = PropertyKey::new("embedding");
+        assert!(db
+            .get_node(node)
+            .and_then(|n| n.properties.get(&prop_key).cloned())
+            .is_none());
+        db.close().unwrap();
+    }
+}

--- a/crates/grafeo-engine/tests/generate_fixture.rs
+++ b/crates/grafeo-engine/tests/generate_fixture.rs
@@ -17,16 +17,19 @@ pub fn build_fixture_db() -> GrafeoDB {
     let db = GrafeoDB::new_in_memory();
 
     // 3 nodes with different labels and properties
-    let alix = db.create_node(&["Person"]);
-    db.set_node_property(alix, "name", Value::String("Alix".into()));
-    db.set_node_property(alix, "age", Value::Int64(30));
+    let alix = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(alix, "name", Value::String("Alix".into()))
+        .unwrap();
+    db.set_node_property(alix, "age", Value::Int64(30)).unwrap();
 
-    let gus = db.create_node(&["Person", "Employee"]);
-    db.set_node_property(gus, "name", Value::String("Gus".into()));
-    db.set_node_property(gus, "age", Value::Int64(25));
+    let gus = db.create_node(&["Person", "Employee"]).unwrap();
+    db.set_node_property(gus, "name", Value::String("Gus".into()))
+        .unwrap();
+    db.set_node_property(gus, "age", Value::Int64(25)).unwrap();
 
-    let acme = db.create_node(&["Company"]);
-    db.set_node_property(acme, "name", Value::String("Acme Corp".into()));
+    let acme = db.create_node(&["Company"]).unwrap();
+    db.set_node_property(acme, "name", Value::String("Acme Corp".into()))
+        .unwrap();
 
     // 2 edges with properties
     let knows = db.create_edge(alix, gus, "KNOWS");

--- a/crates/grafeo-engine/tests/hybrid_pushdown_coverage.rs
+++ b/crates/grafeo-engine/tests/hybrid_pushdown_coverage.rs
@@ -62,11 +62,15 @@ fn article_fixture(text_index: bool, vector_index: bool) -> GrafeoDB {
         ),
     ];
     for (title, body, emb, published) in rows {
-        let n = db.create_node(&["Article"]);
-        db.set_node_property(n, "title", Value::String(title.into()));
-        db.set_node_property(n, "body", Value::String(body.into()));
-        db.set_node_property(n, "embedding", Value::Vector(emb.into()));
-        db.set_node_property(n, "published", Value::Bool(published));
+        let n = db.create_node(&["Article"]).unwrap();
+        db.set_node_property(n, "title", Value::String(title.into()))
+            .unwrap();
+        db.set_node_property(n, "body", Value::String(body.into()))
+            .unwrap();
+        db.set_node_property(n, "embedding", Value::Vector(emb.into()))
+            .unwrap();
+        db.set_node_property(n, "published", Value::Bool(published))
+            .unwrap();
     }
 
     if vector_index {
@@ -340,10 +344,13 @@ fn test_text_pushdown_with_remaining() {
         ("graph", "property graphs and queries", true),
     ];
     for (title, body, published) in rows {
-        let n = db.create_node(&["Article"]);
-        db.set_node_property(n, "title", Value::String(title.into()));
-        db.set_node_property(n, "body", Value::String(body.into()));
-        db.set_node_property(n, "published", Value::Bool(published));
+        let n = db.create_node(&["Article"]).unwrap();
+        db.set_node_property(n, "title", Value::String(title.into()))
+            .unwrap();
+        db.set_node_property(n, "body", Value::String(body.into()))
+            .unwrap();
+        db.set_node_property(n, "published", Value::Bool(published))
+            .unwrap();
     }
     db.create_text_index("Article", "body").unwrap();
 
@@ -376,10 +383,13 @@ fn test_text_pushdown_with_remaining_reversed() {
         ("draft", "rust draft", false),
     ];
     for (title, body, published) in rows {
-        let n = db.create_node(&["Article"]);
-        db.set_node_property(n, "title", Value::String(title.into()));
-        db.set_node_property(n, "body", Value::String(body.into()));
-        db.set_node_property(n, "published", Value::Bool(published));
+        let n = db.create_node(&["Article"]).unwrap();
+        db.set_node_property(n, "title", Value::String(title.into()))
+            .unwrap();
+        db.set_node_property(n, "body", Value::String(body.into()))
+            .unwrap();
+        db.set_node_property(n, "published", Value::Bool(published))
+            .unwrap();
     }
     db.create_text_index("Article", "body").unwrap();
 
@@ -411,10 +421,13 @@ fn test_vector_pushdown_with_remaining() {
         ("far-published", vec![0.0f32, 1.0, 0.0], true),
     ];
     for (title, emb, published) in rows {
-        let n = db.create_node(&["Doc"]);
-        db.set_node_property(n, "title", Value::String(title.into()));
-        db.set_node_property(n, "embedding", Value::Vector(emb.into()));
-        db.set_node_property(n, "published", Value::Bool(published));
+        let n = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n, "title", Value::String(title.into()))
+            .unwrap();
+        db.set_node_property(n, "embedding", Value::Vector(emb.into()))
+            .unwrap();
+        db.set_node_property(n, "published", Value::Bool(published))
+            .unwrap();
     }
     db.create_vector_index(
         "Doc",
@@ -458,9 +471,11 @@ fn test_vector_scan_with_similarity_and_distance() {
         ("far", vec![0.0, 1.0, 0.0]),
     ];
     for (title, emb) in rows {
-        let n = db.create_node(&["Doc"]);
-        db.set_node_property(n, "title", Value::String(title.into()));
-        db.set_node_property(n, "embedding", Value::Vector(emb.into()));
+        let n = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n, "title", Value::String(title.into()))
+            .unwrap();
+        db.set_node_property(n, "embedding", Value::Vector(emb.into()))
+            .unwrap();
     }
     db.create_vector_index(
         "Doc",
@@ -511,9 +526,11 @@ fn test_plan_text_scan_threshold_only_no_limit() {
         ("brief", "rust brief"),
         ("unrelated", "graphs and queries"),
     ] {
-        let n = db.create_node(&["Article"]);
-        db.set_node_property(n, "title", Value::String(title.into()));
-        db.set_node_property(n, "body", Value::String(body.into()));
+        let n = db.create_node(&["Article"]).unwrap();
+        db.set_node_property(n, "title", Value::String(title.into()))
+            .unwrap();
+        db.set_node_property(n, "body", Value::String(body.into()))
+            .unwrap();
     }
     db.create_text_index("Article", "body").unwrap();
 
@@ -543,9 +560,11 @@ fn test_plan_text_scan_threshold_only_no_limit() {
 #[test]
 fn test_resolve_vector_literal_string_element_falls_through() {
     let db = GrafeoDB::new_in_memory();
-    let n = db.create_node(&["Doc"]);
-    db.set_node_property(n, "title", Value::String("only".into()));
-    db.set_node_property(n, "embedding", Value::Vector(vec![0.9f32, 0.1, 0.0].into()));
+    let n = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n, "title", Value::String("only".into()))
+        .unwrap();
+    db.set_node_property(n, "embedding", Value::Vector(vec![0.9f32, 0.1, 0.0].into()))
+        .unwrap();
     db.create_vector_index(
         "Doc",
         "embedding",

--- a/crates/grafeo-engine/tests/hybrid_query.rs
+++ b/crates/grafeo-engine/tests/hybrid_query.rs
@@ -23,56 +23,67 @@ fn setup_article_db() -> GrafeoDB {
     let db = GrafeoDB::new_in_memory();
 
     // Create articles with embeddings and text
-    let a1 = db.create_node(&["Article"]);
-    db.set_node_property(a1, "title", Value::String("Graph Neural Networks".into()));
+    let a1 = db.create_node(&["Article"]).unwrap();
+    db.set_node_property(a1, "title", Value::String("Graph Neural Networks".into()))
+        .unwrap();
     db.set_node_property(
         a1,
         "body",
         Value::String(
             "attention mechanisms in graph neural networks for node classification".into(),
         ),
-    );
+    )
+    .unwrap();
     db.set_node_property(
         a1,
         "embedding",
         Value::Vector(vec![0.9f32, 0.1, 0.0].into()),
-    );
+    )
+    .unwrap();
 
-    let a2 = db.create_node(&["Article"]);
-    db.set_node_property(a2, "title", Value::String("Rust Database Internals".into()));
+    let a2 = db.create_node(&["Article"]).unwrap();
+    db.set_node_property(a2, "title", Value::String("Rust Database Internals".into()))
+        .unwrap();
     db.set_node_property(
         a2,
         "body",
         Value::String("building a database engine in rust with MVCC transactions".into()),
-    );
+    )
+    .unwrap();
     db.set_node_property(
         a2,
         "embedding",
         Value::Vector(vec![0.1f32, 0.9, 0.0].into()),
-    );
+    )
+    .unwrap();
 
-    let a3 = db.create_node(&["Article"]);
+    let a3 = db.create_node(&["Article"]).unwrap();
     db.set_node_property(
         a3,
         "title",
         Value::String("Transformer Architectures".into()),
-    );
+    )
+    .unwrap();
     db.set_node_property(
         a3,
         "body",
         Value::String("attention mechanisms and transformer models for natural language".into()),
-    );
+    )
+    .unwrap();
     db.set_node_property(
         a3,
         "embedding",
         Value::Vector(vec![0.8f32, 0.2, 0.1].into()),
-    );
+    )
+    .unwrap();
 
     // Create user + friend with relationships
-    let user = db.create_node(&["User"]);
-    db.set_node_property(user, "name", Value::String("Alix".into()));
-    let friend = db.create_node(&["User"]);
-    db.set_node_property(friend, "name", Value::String("Vincent".into()));
+    let user = db.create_node(&["User"]).unwrap();
+    db.set_node_property(user, "name", Value::String("Alix".into()))
+        .unwrap();
+    let friend = db.create_node(&["User"]).unwrap();
+    db.set_node_property(friend, "name", Value::String("Vincent".into()))
+        .unwrap();
     db.create_edge(user, friend, "FOLLOWS");
     db.create_edge(friend, a1, "WROTE");
     db.create_edge(friend, a2, "WROTE");
@@ -208,8 +219,9 @@ fn test_vector_where_with_pushdown() {
 fn test_text_score_without_index_fallthrough() {
     let db = GrafeoDB::new_in_memory();
     // Create nodes but NO text index
-    let n = db.create_node(&["Article"]);
-    db.set_node_property(n, "body", Value::String("some body text about rust".into()));
+    let n = db.create_node(&["Article"]).unwrap();
+    db.set_node_property(n, "body", Value::String("some body text about rust".into()))
+        .unwrap();
 
     let session = db.session();
     let result = session
@@ -232,21 +244,25 @@ fn test_text_score_without_index_fallthrough() {
 fn test_vector_without_index_brute_force() {
     let db = GrafeoDB::new_in_memory();
     // Create articles WITHOUT a vector index
-    let a1 = db.create_node(&["Article"]);
-    db.set_node_property(a1, "title", Value::String("Graph Neural Networks".into()));
+    let a1 = db.create_node(&["Article"]).unwrap();
+    db.set_node_property(a1, "title", Value::String("Graph Neural Networks".into()))
+        .unwrap();
     db.set_node_property(
         a1,
         "embedding",
         Value::Vector(vec![0.9f32, 0.1, 0.0].into()),
-    );
+    )
+    .unwrap();
 
-    let a2 = db.create_node(&["Article"]);
-    db.set_node_property(a2, "title", Value::String("Rust Database Internals".into()));
+    let a2 = db.create_node(&["Article"]).unwrap();
+    db.set_node_property(a2, "title", Value::String("Rust Database Internals".into()))
+        .unwrap();
     db.set_node_property(
         a2,
         "embedding",
         Value::Vector(vec![0.1f32, 0.9, 0.0].into()),
-    );
+    )
+    .unwrap();
 
     // NO vector index created — should fall back to brute-force per-row evaluation
     let session = db.session();
@@ -793,25 +809,33 @@ fn test_text_score_with_int_threshold() {
 #[test]
 fn test_compound_with_scalar_remainder() {
     let db = GrafeoDB::new_in_memory();
-    let a1 = db.create_node(&["Article"]);
-    db.set_node_property(a1, "title", Value::String("A1".into()));
-    db.set_node_property(a1, "body", Value::String("attention mechanisms".into()));
+    let a1 = db.create_node(&["Article"]).unwrap();
+    db.set_node_property(a1, "title", Value::String("A1".into()))
+        .unwrap();
+    db.set_node_property(a1, "body", Value::String("attention mechanisms".into()))
+        .unwrap();
     db.set_node_property(
         a1,
         "embedding",
         Value::Vector(vec![0.9_f32, 0.1, 0.0].into()),
-    );
-    db.set_node_property(a1, "published", Value::Bool(true));
+    )
+    .unwrap();
+    db.set_node_property(a1, "published", Value::Bool(true))
+        .unwrap();
 
-    let a2 = db.create_node(&["Article"]);
-    db.set_node_property(a2, "title", Value::String("A2".into()));
-    db.set_node_property(a2, "body", Value::String("attention mechanisms".into()));
+    let a2 = db.create_node(&["Article"]).unwrap();
+    db.set_node_property(a2, "title", Value::String("A2".into()))
+        .unwrap();
+    db.set_node_property(a2, "body", Value::String("attention mechanisms".into()))
+        .unwrap();
     db.set_node_property(
         a2,
         "embedding",
         Value::Vector(vec![0.9_f32, 0.1, 0.0].into()),
-    );
-    db.set_node_property(a2, "published", Value::Bool(false));
+    )
+    .unwrap();
+    db.set_node_property(a2, "published", Value::Bool(false))
+        .unwrap();
 
     db.create_vector_index(
         "Article",
@@ -850,13 +874,15 @@ fn test_compound_with_scalar_remainder() {
 #[test]
 fn test_compound_or_with_missing_text_index_falls_through() {
     let db = GrafeoDB::new_in_memory();
-    let a1 = db.create_node(&["Article"]);
-    db.set_node_property(a1, "body", Value::String("rust".into()));
+    let a1 = db.create_node(&["Article"]).unwrap();
+    db.set_node_property(a1, "body", Value::String("rust".into()))
+        .unwrap();
     db.set_node_property(
         a1,
         "embedding",
         Value::Vector(vec![1.0_f32, 0.0, 0.0].into()),
-    );
+    )
+    .unwrap();
 
     db.create_vector_index(
         "Article",
@@ -902,9 +928,11 @@ fn test_order_by_euclidean_distance_ascending() {
         ("Orthogonal", vec![0.0_f32, 0.0, 1.0]),
     ];
     for (title, emb) in &docs {
-        let n = db.create_node(&["Doc"]);
-        db.set_node_property(n, "title", Value::String((*title).into()));
-        db.set_node_property(n, "embedding", Value::Vector(emb.clone().into()));
+        let n = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n, "title", Value::String((*title).into()))
+            .unwrap();
+        db.set_node_property(n, "embedding", Value::Vector(emb.clone().into()))
+            .unwrap();
     }
 
     let session = db.session();
@@ -1085,13 +1113,17 @@ fn test_text_score_two_properties_same_variable_and_query() {
     // They differ on title: only a1.title contains 'rust'.
     //   a1: title "rust guide",   body "rust tutorial"
     //   a2: title "other stuff",  body "rust tutorial"
-    let a1 = db.create_node(&["Article"]);
-    db.set_node_property(a1, "title", Value::String("rust guide".into()));
-    db.set_node_property(a1, "body", Value::String("rust tutorial".into()));
+    let a1 = db.create_node(&["Article"]).unwrap();
+    db.set_node_property(a1, "title", Value::String("rust guide".into()))
+        .unwrap();
+    db.set_node_property(a1, "body", Value::String("rust tutorial".into()))
+        .unwrap();
 
-    let a2 = db.create_node(&["Article"]);
-    db.set_node_property(a2, "title", Value::String("other stuff".into()));
-    db.set_node_property(a2, "body", Value::String("rust tutorial".into()));
+    let a2 = db.create_node(&["Article"]).unwrap();
+    db.set_node_property(a2, "title", Value::String("other stuff".into()))
+        .unwrap();
+    db.set_node_property(a2, "body", Value::String("rust tutorial".into()))
+        .unwrap();
 
     db.create_text_index("Article", "body").unwrap();
     db.create_text_index("Article", "title").unwrap();

--- a/crates/grafeo-engine/tests/mmr_search.rs
+++ b/crates/grafeo-engine/tests/mmr_search.rs
@@ -15,20 +15,25 @@ fn setup_db() -> GrafeoDB {
     let db = GrafeoDB::new_in_memory();
 
     // Create 5 nodes with varied vectors
-    let n1 = db.create_node(&["Doc"]);
-    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
+    let n1 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+        .unwrap();
 
-    let n2 = db.create_node(&["Doc"]);
-    db.set_node_property(n2, "emb", vec3(0.95, 0.05, 0.0)); // very similar to n1
+    let n2 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n2, "emb", vec3(0.95, 0.05, 0.0))
+        .unwrap(); // very similar to n1
 
-    let n3 = db.create_node(&["Doc"]);
-    db.set_node_property(n3, "emb", vec3(0.0, 1.0, 0.0)); // orthogonal
+    let n3 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n3, "emb", vec3(0.0, 1.0, 0.0))
+        .unwrap(); // orthogonal
 
-    let n4 = db.create_node(&["Doc"]);
-    db.set_node_property(n4, "emb", vec3(0.0, 0.0, 1.0)); // orthogonal
+    let n4 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n4, "emb", vec3(0.0, 0.0, 1.0))
+        .unwrap(); // orthogonal
 
-    let n5 = db.create_node(&["Doc"]);
-    db.set_node_property(n5, "emb", vec3(0.9, 0.1, 0.0)); // similar to n1
+    let n5 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n5, "emb", vec3(0.9, 0.1, 0.0))
+        .unwrap(); // similar to n1
 
     db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
         .expect("create index");

--- a/crates/grafeo-engine/tests/offline_bulk_loader.rs
+++ b/crates/grafeo-engine/tests/offline_bulk_loader.rs
@@ -1,0 +1,46 @@
+use std::collections::HashMap;
+
+use grafeo_common::types::{PropertyKey, Value};
+use grafeo_engine::GrafeoDB;
+
+#[test]
+fn bulk_loader_preserves_rows_and_node_ids_without_secondary_indexes() {
+    let db = GrafeoDB::new_in_memory();
+    let rows = (0..10_000)
+        .map(|index| {
+            HashMap::from([
+                (PropertyKey::new("key"), Value::from(format!("row-{index}"))),
+                (PropertyKey::new("ordinal"), Value::from(i64::from(index))),
+            ])
+        })
+        .collect();
+
+    let ids = db
+        .bulk_load_nodes_with_props_unindexed("BulkRow", rows)
+        .expect("fresh store accepts an offline bulk load");
+
+    assert_eq!(ids.len(), 10_000);
+    assert_eq!(db.graph_store().nodes_by_label("BulkRow").len(), 10_000);
+    assert_eq!(
+        db.graph_store()
+            .get_node_property(ids[9_999], &PropertyKey::new("key")),
+        Some(Value::from("row-9999"))
+    );
+}
+
+#[test]
+fn bulk_loader_rejects_a_store_after_vector_index_creation() {
+    let db = GrafeoDB::new_in_memory();
+    db.create_vector_index("BulkRow", "embedding", Some(2), None, None, None, None)
+        .expect("empty vector index is valid with explicit dimensions");
+
+    let result = db.bulk_load_nodes_with_props_unindexed(
+        "BulkRow",
+        vec![HashMap::from([(
+            PropertyKey::new("key"),
+            Value::from("row"),
+        )])],
+    );
+
+    assert!(result.is_err());
+}

--- a/crates/grafeo-engine/tests/offline_bulk_loader.rs
+++ b/crates/grafeo-engine/tests/offline_bulk_loader.rs
@@ -44,3 +44,25 @@ fn bulk_loader_rejects_a_store_after_vector_index_creation() {
 
     assert!(result.is_err());
 }
+
+#[test]
+fn bulk_edge_loader_writes_adjacency_without_online_mutation_path() {
+    let db = GrafeoDB::new_in_memory();
+    let nodes = db
+        .bulk_load_nodes_with_props_unindexed(
+            "BulkRow",
+            (0..10_000)
+                .map(|index| HashMap::from([(PropertyKey::new("key"), Value::from(index as i64))]))
+                .collect(),
+        )
+        .expect("fresh store accepts nodes");
+    let edges: Vec<_> = nodes
+        .windows(2)
+        .map(|pair| (pair[0], pair[1], "NEXT"))
+        .collect();
+
+    let ids = db.bulk_load_edges_unindexed(&edges);
+
+    assert_eq!(ids.len(), edges.len());
+    assert_eq!(db.graph_store().edge_count(), edges.len());
+}

--- a/crates/grafeo-engine/tests/planner_lpg_coverage.rs
+++ b/crates/grafeo-engine/tests/planner_lpg_coverage.rs
@@ -45,9 +45,11 @@ fn vector_graph(metric: &str, with_index: bool) -> GrafeoDB {
         ("near", vec![0.9f32, 0.1, 0.0]),
         ("far", vec![0.0f32, 1.0, 0.0]),
     ] {
-        let n = db.create_node(&["Doc"]);
-        db.set_node_property(n, "title", Value::String(title.into()));
-        db.set_node_property(n, "embedding", Value::Vector(vec.into()));
+        let n = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n, "title", Value::String(title.into()))
+            .unwrap();
+        db.set_node_property(n, "embedding", Value::Vector(vec.into()))
+            .unwrap();
     }
     if with_index {
         db.create_vector_index("Doc", "embedding", Some(3), Some(metric), None, None, None)
@@ -217,11 +219,14 @@ fn test_topk_negative_no_index() {
 #[test]
 fn test_topk_negative_wrong_variable() {
     let db = GrafeoDB::new_in_memory();
-    let d = db.create_node(&["Doc"]);
-    db.set_node_property(d, "title", Value::String("doc1".into()));
-    db.set_node_property(d, "embedding", Value::Vector(vec![0.9f32, 0.1, 0.0].into()));
-    let o = db.create_node(&["Other"]);
-    db.set_node_property(o, "embedding", Value::Vector(vec![0.5f32, 0.5, 0.0].into()));
+    let d = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(d, "title", Value::String("doc1".into()))
+        .unwrap();
+    db.set_node_property(d, "embedding", Value::Vector(vec![0.9f32, 0.1, 0.0].into()))
+        .unwrap();
+    let o = db.create_node(&["Other"]).unwrap();
+    db.set_node_property(o, "embedding", Value::Vector(vec![0.5f32, 0.5, 0.0].into()))
+        .unwrap();
     db.create_vector_index(
         "Doc",
         "embedding",
@@ -380,9 +385,11 @@ fn test_plan_text_scan_with_threshold() {
         ("Graph Databases", "property graphs and cypher queries"),
         ("ML Systems", "attention mechanisms in neural networks"),
     ] {
-        let n = db.create_node(&["Article"]);
-        db.set_node_property(n, "title", Value::String(title.into()));
-        db.set_node_property(n, "body", Value::String(body.into()));
+        let n = db.create_node(&["Article"]).unwrap();
+        db.set_node_property(n, "title", Value::String(title.into()))
+            .unwrap();
+        db.set_node_property(n, "body", Value::String(body.into()))
+            .unwrap();
     }
     db.create_text_index("Article", "body").unwrap();
 
@@ -445,9 +452,11 @@ fn test_plan_vector_scan_max_distance() {
 #[test]
 fn test_resolve_vector_literal_from_numeric_list() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["Doc"]);
-    db.set_node_property(a, "title", Value::String("target".into()));
-    db.set_node_property(a, "embedding", Value::Vector(vec![1.0f32, 2.0, 3.0].into()));
+    let a = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(a, "title", Value::String("target".into()))
+        .unwrap();
+    db.set_node_property(a, "embedding", Value::Vector(vec![1.0f32, 2.0, 3.0].into()))
+        .unwrap();
     db.create_vector_index(
         "Doc",
         "embedding",
@@ -484,9 +493,11 @@ fn test_resolve_vector_literal_from_numeric_list() {
 #[test]
 fn test_resolve_vector_literal_non_literal_falls_through() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["Doc"]);
-    db.set_node_property(a, "title", Value::String("target".into()));
-    db.set_node_property(a, "embedding", Value::Vector(vec![1.0f32, 2.0, 3.0].into()));
+    let a = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(a, "title", Value::String("target".into()))
+        .unwrap();
+    db.set_node_property(a, "embedding", Value::Vector(vec![1.0f32, 2.0, 3.0].into()))
+        .unwrap();
     db.create_vector_index(
         "Doc",
         "embedding",
@@ -561,9 +572,11 @@ fn test_plan_horizontal_aggregate_edge() {
 #[test]
 fn test_score_reuse_isolates_different_query_vectors() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["Doc"]);
-    db.set_node_property(a, "title", Value::String("x-aligned".into()));
-    db.set_node_property(a, "embedding", Value::Vector(vec![1.0f32, 0.0, 0.0].into()));
+    let a = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(a, "title", Value::String("x-aligned".into()))
+        .unwrap();
+    db.set_node_property(a, "embedding", Value::Vector(vec![1.0f32, 0.0, 0.0].into()))
+        .unwrap();
     db.create_vector_index(
         "Doc",
         "embedding",
@@ -614,16 +627,20 @@ fn test_vector_scan_metric_mismatch_uses_brute_force() {
     let db = GrafeoDB::new_in_memory();
     // A is close to query in Euclidean space (distance ~1.41) but far in cosine.
     // B is far in Euclidean space (distance ~99) but cosine-identical to query.
-    let a = db.create_node(&["Doc"]);
-    db.set_node_property(a, "title", Value::String("near".into()));
-    db.set_node_property(a, "embedding", Value::Vector(vec![1.0f32, 0.0, 0.0].into()));
-    let b = db.create_node(&["Doc"]);
-    db.set_node_property(b, "title", Value::String("far".into()));
+    let a = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(a, "title", Value::String("near".into()))
+        .unwrap();
+    db.set_node_property(a, "embedding", Value::Vector(vec![1.0f32, 0.0, 0.0].into()))
+        .unwrap();
+    let b = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(b, "title", Value::String("far".into()))
+        .unwrap();
     db.set_node_property(
         b,
         "embedding",
         Value::Vector(vec![0.0f32, 100.0, 0.0].into()),
-    );
+    )
+    .unwrap();
     db.create_vector_index(
         "Doc",
         "embedding",

--- a/crates/grafeo-engine/tests/post_compact_index.rs
+++ b/crates/grafeo-engine/tests/post_compact_index.rs
@@ -21,17 +21,23 @@ fn vec3(x: f32, y: f32, z: f32) -> Value {
 fn setup_compacted_vector_db() -> GrafeoDB {
     let mut db = GrafeoDB::new_in_memory();
 
-    let n1 = db.create_node(&["Doc"]);
-    db.set_node_property(n1, "embedding", vec3(1.0, 0.0, 0.0));
-    db.set_node_property(n1, "title", Value::String("alpha".into()));
+    let n1 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n1, "embedding", vec3(1.0, 0.0, 0.0))
+        .unwrap();
+    db.set_node_property(n1, "title", Value::String("alpha".into()))
+        .unwrap();
 
-    let n2 = db.create_node(&["Doc"]);
-    db.set_node_property(n2, "embedding", vec3(0.0, 1.0, 0.0));
-    db.set_node_property(n2, "title", Value::String("beta".into()));
+    let n2 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n2, "embedding", vec3(0.0, 1.0, 0.0))
+        .unwrap();
+    db.set_node_property(n2, "title", Value::String("beta".into()))
+        .unwrap();
 
-    let n3 = db.create_node(&["Doc"]);
-    db.set_node_property(n3, "embedding", vec3(0.0, 0.0, 1.0));
-    db.set_node_property(n3, "title", Value::String("gamma".into()));
+    let n3 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n3, "embedding", vec3(0.0, 0.0, 1.0))
+        .unwrap();
+    db.set_node_property(n3, "title", Value::String("gamma".into()))
+        .unwrap();
 
     db.compact().expect("compact");
     db
@@ -128,17 +134,23 @@ fn rebuild_vector_index_after_compact() {
 fn vector_search_with_filter_after_compact() {
     let mut db = GrafeoDB::new_in_memory();
 
-    let n1 = db.create_node(&["Doc"]);
-    db.set_node_property(n1, "embedding", vec3(1.0, 0.0, 0.0));
-    db.set_node_property(n1, "category", Value::String("science".into()));
+    let n1 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n1, "embedding", vec3(1.0, 0.0, 0.0))
+        .unwrap();
+    db.set_node_property(n1, "category", Value::String("science".into()))
+        .unwrap();
 
-    let n2 = db.create_node(&["Doc"]);
-    db.set_node_property(n2, "embedding", vec3(0.0, 1.0, 0.0));
-    db.set_node_property(n2, "category", Value::String("art".into()));
+    let n2 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n2, "embedding", vec3(0.0, 1.0, 0.0))
+        .unwrap();
+    db.set_node_property(n2, "category", Value::String("art".into()))
+        .unwrap();
 
-    let n3 = db.create_node(&["Doc"]);
-    db.set_node_property(n3, "embedding", vec3(0.0, 0.0, 1.0));
-    db.set_node_property(n3, "category", Value::String("science".into()));
+    let n3 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n3, "embedding", vec3(0.0, 0.0, 1.0))
+        .unwrap();
+    db.set_node_property(n3, "category", Value::String("science".into()))
+        .unwrap();
 
     db.compact().expect("compact");
     db.create_property_index("category");
@@ -177,22 +189,25 @@ fn vector_search_with_filter_after_compact() {
 fn text_index_after_compact() {
     let mut db = GrafeoDB::new_in_memory();
 
-    let n1 = db.create_node(&["Article"]);
+    let n1 = db.create_node(&["Article"]).unwrap();
     db.set_node_property(
         n1,
         "body",
         Value::String("the quick brown fox jumps over the lazy dog".into()),
-    );
+    )
+    .unwrap();
 
-    let n2 = db.create_node(&["Article"]);
+    let n2 = db.create_node(&["Article"]).unwrap();
     db.set_node_property(
         n2,
         "body",
         Value::String("a fast brown fox leaps over a sleepy hound".into()),
-    );
+    )
+    .unwrap();
 
-    let n3 = db.create_node(&["Article"]);
-    db.set_node_property(n3, "body", Value::String("the cat sat on the mat".into()));
+    let n3 = db.create_node(&["Article"]).unwrap();
+    db.set_node_property(n3, "body", Value::String("the cat sat on the mat".into()))
+        .unwrap();
 
     db.compact().expect("compact");
 
@@ -217,12 +232,15 @@ fn snapshot_compact_vector_index_round_trip() {
     // Phase 1: build DB, export snapshot
     let snapshot_bytes = {
         let db = GrafeoDB::new_in_memory();
-        let n1 = db.create_node(&["Doc"]);
-        db.set_node_property(n1, "embedding", vec3(1.0, 0.0, 0.0));
-        let n2 = db.create_node(&["Doc"]);
-        db.set_node_property(n2, "embedding", vec3(0.0, 1.0, 0.0));
-        let n3 = db.create_node(&["Doc"]);
-        db.set_node_property(n3, "embedding", vec3(0.0, 0.0, 1.0));
+        let n1 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n1, "embedding", vec3(1.0, 0.0, 0.0))
+            .unwrap();
+        let n2 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n2, "embedding", vec3(0.0, 1.0, 0.0))
+            .unwrap();
+        let n3 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n3, "embedding", vec3(0.0, 0.0, 1.0))
+            .unwrap();
         db.export_snapshot().expect("export")
     };
 
@@ -255,8 +273,9 @@ fn snapshot_compact_vector_index_round_trip() {
 fn layered_store_has_vector_index_forwards_to_overlay() {
     let mut db = GrafeoDB::new_in_memory();
 
-    let n = db.create_node(&["Doc"]);
-    db.set_node_property(n, "embedding", vec3(1.0, 0.0, 0.0));
+    let n = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n, "embedding", vec3(1.0, 0.0, 0.0))
+        .unwrap();
 
     db.compact().expect("compact");
 
@@ -287,8 +306,9 @@ fn layered_store_has_vector_index_forwards_to_overlay() {
 fn layered_store_has_text_index_forwards_to_overlay() {
     let mut db = GrafeoDB::new_in_memory();
 
-    let n = db.create_node(&["Article"]);
-    db.set_node_property(n, "body", Value::String("hello world".into()));
+    let n = db.create_node(&["Article"]).unwrap();
+    db.set_node_property(n, "body", Value::String("hello world".into()))
+        .unwrap();
 
     db.compact().expect("compact");
 
@@ -308,16 +328,19 @@ fn layered_store_has_text_index_forwards_to_overlay() {
 fn vector_index_after_recompact() {
     let mut db = GrafeoDB::new_in_memory();
 
-    let n1 = db.create_node(&["Doc"]);
-    db.set_node_property(n1, "embedding", vec3(1.0, 0.0, 0.0));
-    let n2 = db.create_node(&["Doc"]);
-    db.set_node_property(n2, "embedding", vec3(0.0, 1.0, 0.0));
+    let n1 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n1, "embedding", vec3(1.0, 0.0, 0.0))
+        .unwrap();
+    let n2 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n2, "embedding", vec3(0.0, 1.0, 0.0))
+        .unwrap();
 
     db.compact().expect("first compact");
 
     // Insert a third node after compact, then recompact to merge all three.
-    let n3 = db.create_node(&["Doc"]);
-    db.set_node_property(n3, "embedding", vec3(0.0, 0.0, 1.0));
+    let n3 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n3, "embedding", vec3(0.0, 0.0, 1.0))
+        .unwrap();
 
     db.recompact().expect("recompact");
 

--- a/crates/grafeo-engine/tests/post_compact_numeric_content.rs
+++ b/crates/grafeo-engine/tests/post_compact_numeric_content.rs
@@ -42,10 +42,10 @@ fn positive_only_sum_returns_int64() {
     // went through BitPacked and round-tripped correctly. Guards against
     // regressions from the RawI64 wiring.
     let mut db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["A"]);
-    let b = db.create_node(&["A"]);
-    db.set_node_property(a, "num", Value::Int64(100));
-    db.set_node_property(b, "num", Value::Int64(200));
+    let a = db.create_node(&["A"]).unwrap();
+    let b = db.create_node(&["A"]).unwrap();
+    db.set_node_property(a, "num", Value::Int64(100)).unwrap();
+    db.set_node_property(b, "num", Value::Int64(200)).unwrap();
 
     let pre = scalar(&db, "MATCH (n) RETURN sum(n.num)");
     db.compact().unwrap();
@@ -61,10 +61,10 @@ fn mixed_signs_sum_returns_int64() {
     // The diagnostic case from GrafeoDB/grafeo#301. Pre-fix this returned
     // Float64(50.0) post-compact.
     let mut db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["A"]);
-    let b = db.create_node(&["A"]);
-    db.set_node_property(a, "num", Value::Int64(100));
-    db.set_node_property(b, "num", Value::Int64(-50));
+    let a = db.create_node(&["A"]).unwrap();
+    let b = db.create_node(&["A"]).unwrap();
+    db.set_node_property(a, "num", Value::Int64(100)).unwrap();
+    db.set_node_property(b, "num", Value::Int64(-50)).unwrap();
 
     let pre = scalar(&db, "MATCH (n) RETURN sum(n.num)");
     db.compact().unwrap();
@@ -79,8 +79,8 @@ fn mixed_signs_sum_returns_int64() {
 fn i64_extremes_roundtrip() {
     let mut db = GrafeoDB::new_in_memory();
     for v in [i64::MIN + 1, -1, 0, 1, i64::MAX] {
-        let n = db.create_node(&["A"]);
-        db.set_node_property(n, "val", Value::Int64(v));
+        let n = db.create_node(&["A"]).unwrap();
+        db.set_node_property(n, "val", Value::Int64(v)).unwrap();
     }
     db.compact().unwrap();
 
@@ -102,10 +102,10 @@ fn i64_extremes_roundtrip() {
 #[test]
 fn where_matches_negative_int() {
     let mut db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["A"]);
-    let b = db.create_node(&["A"]);
-    db.set_node_property(a, "num", Value::Int64(42));
-    db.set_node_property(b, "num", Value::Int64(-17));
+    let a = db.create_node(&["A"]).unwrap();
+    let b = db.create_node(&["A"]).unwrap();
+    db.set_node_property(a, "num", Value::Int64(42)).unwrap();
+    db.set_node_property(b, "num", Value::Int64(-17)).unwrap();
     db.compact().unwrap();
 
     assert_eq!(row_count(&db, "MATCH (n:A) WHERE n.num = 42 RETURN n"), 1);
@@ -117,8 +117,8 @@ fn where_matches_negative_int() {
 fn where_range_matches_across_zero() {
     let mut db = GrafeoDB::new_in_memory();
     for v in [-10i64, -5, 0, 5, 10, -100, 100] {
-        let n = db.create_node(&["A"]);
-        db.set_node_property(n, "val", Value::Int64(v));
+        let n = db.create_node(&["A"]).unwrap();
+        db.set_node_property(n, "val", Value::Int64(v)).unwrap();
     }
     db.compact().unwrap();
 
@@ -143,12 +143,12 @@ fn where_range_matches_across_zero() {
 fn per_label_sum_preserves_int64_across_compact() {
     let mut db = GrafeoDB::new_in_memory();
     for v in [10, -20, 30] {
-        let n = db.create_node(&["A"]);
-        db.set_node_property(n, "num", Value::Int64(v));
+        let n = db.create_node(&["A"]).unwrap();
+        db.set_node_property(n, "num", Value::Int64(v)).unwrap();
     }
     for v in [1, 2] {
-        let n = db.create_node(&["B"]);
-        db.set_node_property(n, "num", Value::Int64(v));
+        let n = db.create_node(&["B"]).unwrap();
+        db.set_node_property(n, "num", Value::Int64(v)).unwrap();
     }
 
     let pre_a = scalar(&db, "MATCH (n:A) RETURN sum(n.num)");

--- a/crates/grafeo-engine/tests/post_compact_overlay_visibility.rs
+++ b/crates/grafeo-engine/tests/post_compact_overlay_visibility.rs
@@ -37,9 +37,9 @@ fn row_count(db: &GrafeoDB, q: &str) -> usize {
 #[test]
 fn node_created_after_compact_is_visible() {
     let mut db = GrafeoDB::new_in_memory();
-    db.create_node(&["X"]);
+    db.create_node(&["X"]).unwrap();
     db.compact().expect("compact");
-    db.create_node(&["Y"]);
+    db.create_node(&["Y"]).unwrap();
 
     assert_eq!(int_scalar(&db, "MATCH (n) RETURN count(n)"), 2);
     assert_eq!(row_count(&db, "MATCH (n:Y) RETURN n"), 1);
@@ -49,10 +49,10 @@ fn node_created_after_compact_is_visible() {
 #[test]
 fn multiple_post_compact_nodes_visible() {
     let mut db = GrafeoDB::new_in_memory();
-    db.create_node(&["Base"]);
+    db.create_node(&["Base"]).unwrap();
     db.compact().expect("compact");
     for _ in 0..5 {
-        db.create_node(&["Overlay"]);
+        db.create_node(&["Overlay"]).unwrap();
     }
 
     assert_eq!(int_scalar(&db, "MATCH (n) RETURN count(n)"), 6);
@@ -63,14 +63,14 @@ fn multiple_post_compact_nodes_visible() {
 #[test]
 fn post_compact_edge_visible() {
     let mut db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["A"]);
-    let b = db.create_node(&["B"]);
+    let a = db.create_node(&["A"]).unwrap();
+    let b = db.create_node(&["B"]).unwrap();
     db.create_edge(a, b, "PRE");
     db.compact().expect("compact");
 
     // New nodes + edge entirely in the overlay.
-    let c = db.create_node(&["A"]);
-    let d = db.create_node(&["B"]);
+    let c = db.create_node(&["A"]).unwrap();
+    let d = db.create_node(&["B"]).unwrap();
     db.create_edge(c, d, "POST");
 
     assert_eq!(int_scalar(&db, "MATCH ()-[r]->() RETURN count(r)"), 2);
@@ -81,9 +81,9 @@ fn post_compact_edge_visible() {
 #[test]
 fn post_compact_edge_between_base_and_overlay_nodes() {
     let mut db = GrafeoDB::new_in_memory();
-    let base_a = db.create_node(&["A"]);
+    let base_a = db.create_node(&["A"]).unwrap();
     db.compact().expect("compact");
-    let overlay_b = db.create_node(&["B"]);
+    let overlay_b = db.create_node(&["B"]).unwrap();
     db.create_edge(base_a, overlay_b, "CROSS");
 
     // The edge connects a base node to an overlay node — visibility has
@@ -98,10 +98,11 @@ fn post_compact_edge_between_base_and_overlay_nodes() {
 #[test]
 fn post_compact_node_property_survives_reread() {
     let mut db = GrafeoDB::new_in_memory();
-    db.create_node(&["X"]);
+    db.create_node(&["X"]).unwrap();
     db.compact().expect("compact");
-    let n = db.create_node(&["Y"]);
-    db.set_node_property(n, "label", Value::String("hello".into()));
+    let n = db.create_node(&["Y"]).unwrap();
+    db.set_node_property(n, "label", Value::String("hello".into()))
+        .unwrap();
 
     let s = db.session();
     let r = s.execute("MATCH (n:Y) RETURN n.label").unwrap();

--- a/crates/grafeo-engine/tests/scalar_similarity_functions.rs
+++ b/crates/grafeo-engine/tests/scalar_similarity_functions.rs
@@ -12,15 +12,18 @@ use grafeo_engine::database::QueryResult;
 
 fn setup() -> GrafeoDB {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["Doc"]);
-    db.set_node_property(a, "name", Value::from("A"));
-    db.set_node_property(a, "emb", Value::Vector(vec![1.0f32, 0.0, 0.0].into()));
-    let b = db.create_node(&["Doc"]);
-    db.set_node_property(b, "name", Value::from("B"));
-    db.set_node_property(b, "emb", Value::Vector(vec![0.0f32, 1.0, 0.0].into()));
-    let c = db.create_node(&["Doc"]);
-    db.set_node_property(c, "name", Value::from("C"));
-    db.set_node_property(c, "emb", Value::Vector(vec![1.0f32, 0.0, 0.0].into())); // identical to A
+    let a = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(a, "name", Value::from("A")).unwrap();
+    db.set_node_property(a, "emb", Value::Vector(vec![1.0f32, 0.0, 0.0].into()))
+        .unwrap();
+    let b = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(b, "name", Value::from("B")).unwrap();
+    db.set_node_property(b, "emb", Value::Vector(vec![0.0f32, 1.0, 0.0].into()))
+        .unwrap();
+    let c = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(c, "name", Value::from("C")).unwrap();
+    db.set_node_property(c, "emb", Value::Vector(vec![1.0f32, 0.0, 0.0].into()))
+        .unwrap(); // identical to A
     db
 }
 

--- a/crates/grafeo-engine/tests/search_operations.rs
+++ b/crates/grafeo-engine/tests/search_operations.rs
@@ -27,21 +27,29 @@ mod vector {
     fn setup_vector_db() -> GrafeoDB {
         let db = GrafeoDB::new_in_memory();
 
-        let n1 = db.create_node(&["Doc"]);
-        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
-        db.set_node_property(n1, "category", Value::String("science".into()));
+        let n1 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
+        db.set_node_property(n1, "category", Value::String("science".into()))
+            .unwrap();
 
-        let n2 = db.create_node(&["Doc"]);
-        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0));
-        db.set_node_property(n2, "category", Value::String("science".into()));
+        let n2 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0))
+            .unwrap();
+        db.set_node_property(n2, "category", Value::String("science".into()))
+            .unwrap();
 
-        let n3 = db.create_node(&["Doc"]);
-        db.set_node_property(n3, "emb", vec3(0.0, 0.0, 1.0));
-        db.set_node_property(n3, "category", Value::String("art".into()));
+        let n3 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n3, "emb", vec3(0.0, 0.0, 1.0))
+            .unwrap();
+        db.set_node_property(n3, "category", Value::String("art".into()))
+            .unwrap();
 
-        let n4 = db.create_node(&["Doc"]);
-        db.set_node_property(n4, "emb", vec3(0.9, 0.1, 0.0));
-        db.set_node_property(n4, "category", Value::String("science".into()));
+        let n4 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n4, "emb", vec3(0.9, 0.1, 0.0))
+            .unwrap();
+        db.set_node_property(n4, "category", Value::String("science".into()))
+            .unwrap();
 
         db.create_property_index("category");
         db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
@@ -53,8 +61,8 @@ mod vector {
     #[test]
     fn test_vector_search_no_index_error() {
         let db = GrafeoDB::new_in_memory();
-        let n = db.create_node(&["Doc"]);
-        db.set_node_property(n, "emb", vec3(1.0, 0.0, 0.0));
+        let n = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n, "emb", vec3(1.0, 0.0, 0.0)).unwrap();
 
         // No vector index created: search should fail
         let result = db.vector_search("Doc", "emb", &[1.0, 0.0, 0.0], 5, None, None);
@@ -182,11 +190,13 @@ mod vector {
             .expect("create empty index");
 
         // Add nodes AFTER index exists (no rebuild)
-        let n1 = db.create_node(&["Doc"]);
-        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
+        let n1 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
 
-        let n2 = db.create_node(&["Doc"]);
-        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0));
+        let n2 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0))
+            .unwrap();
 
         // Search should find both nodes WITHOUT calling rebuild_vector_index
         let results = db
@@ -247,12 +257,15 @@ mod vector {
     #[test]
     fn test_scalar_quantized_vector_index() {
         let db = GrafeoDB::new_in_memory();
-        let n1 = db.create_node(&["Doc"]);
-        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
-        let n2 = db.create_node(&["Doc"]);
-        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0));
-        let n3 = db.create_node(&["Doc"]);
-        db.set_node_property(n3, "emb", vec3(0.0, 0.0, 1.0));
+        let n1 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
+        let n2 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0))
+            .unwrap();
+        let n3 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n3, "emb", vec3(0.0, 0.0, 1.0))
+            .unwrap();
 
         db.create_vector_index(
             "Doc",
@@ -275,10 +288,12 @@ mod vector {
     #[test]
     fn test_binary_quantized_vector_index() {
         let db = GrafeoDB::new_in_memory();
-        let n1 = db.create_node(&["Doc"]);
-        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
-        let n2 = db.create_node(&["Doc"]);
-        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0));
+        let n1 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
+        let n2 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0))
+            .unwrap();
 
         db.create_vector_index(
             "Doc",
@@ -303,9 +318,10 @@ mod vector {
         // so use 8-dim vectors.
         let db = GrafeoDB::new_in_memory();
         for i in 0..10 {
-            let n = db.create_node(&["Doc"]);
+            let n = db.create_node(&["Doc"]).unwrap();
             let vec: Vec<f32> = (0..8).map(|j| ((i * 8 + j) as f32) / 80.0).collect();
-            db.set_node_property(n, "emb", Value::Vector(vec.into()));
+            db.set_node_property(n, "emb", Value::Vector(vec.into()))
+                .unwrap();
         }
 
         db.create_vector_index(
@@ -342,10 +358,12 @@ mod vector {
         .expect("create empty scalar index");
 
         // Add nodes after index creation
-        let n1 = db.create_node(&["Doc"]);
-        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
-        let n2 = db.create_node(&["Doc"]);
-        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0));
+        let n1 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
+        let n2 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0))
+            .unwrap();
 
         let results = db
             .vector_search("Doc", "emb", &[1.0, 0.0, 0.0], 2, None, None)
@@ -356,10 +374,12 @@ mod vector {
     #[test]
     fn test_rebuild_preserves_quantization_type() {
         let db = GrafeoDB::new_in_memory();
-        let n1 = db.create_node(&["Doc"]);
-        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
-        let n2 = db.create_node(&["Doc"]);
-        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0));
+        let n1 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
+        let n2 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0))
+            .unwrap();
 
         db.create_vector_index(
             "Doc",
@@ -394,18 +414,21 @@ mod text {
     fn setup_text_db() -> GrafeoDB {
         let db = GrafeoDB::new_in_memory();
 
-        let n1 = db.create_node(&["Article"]);
-        db.set_node_property(n1, "title", Value::String("Rust graph database".into()));
+        let n1 = db.create_node(&["Article"]).unwrap();
+        db.set_node_property(n1, "title", Value::String("Rust graph database".into()))
+            .unwrap();
 
-        let n2 = db.create_node(&["Article"]);
-        db.set_node_property(n2, "title", Value::String("Python machine learning".into()));
+        let n2 = db.create_node(&["Article"]).unwrap();
+        db.set_node_property(n2, "title", Value::String("Python machine learning".into()))
+            .unwrap();
 
-        let n3 = db.create_node(&["Article"]);
+        let n3 = db.create_node(&["Article"]).unwrap();
         db.set_node_property(
             n3,
             "title",
             Value::String("Rust systems programming".into()),
-        );
+        )
+        .unwrap();
 
         db.create_text_index("Article", "title")
             .expect("create text index");
@@ -426,8 +449,9 @@ mod text {
     #[test]
     fn test_text_search_no_index_error() {
         let db = GrafeoDB::new_in_memory();
-        let n = db.create_node(&["Article"]);
-        db.set_node_property(n, "title", Value::String("test".into()));
+        let n = db.create_node(&["Article"]).unwrap();
+        db.set_node_property(n, "title", Value::String("test".into()))
+            .unwrap();
 
         // No text index: should error
         let result = db.text_search("Article", "title", "test", 10);
@@ -450,8 +474,9 @@ mod text {
         let db = setup_text_db();
 
         // Add a new article
-        let n = db.create_node(&["Article"]);
-        db.set_node_property(n, "title", Value::String("Rust web framework".into()));
+        let n = db.create_node(&["Article"]).unwrap();
+        db.set_node_property(n, "title", Value::String("Rust web framework".into()))
+            .unwrap();
 
         let results = db.text_search("Article", "title", "Rust", 10).unwrap();
 
@@ -502,37 +527,45 @@ mod hybrid {
     fn setup_hybrid_db() -> GrafeoDB {
         let db = GrafeoDB::new_in_memory();
 
-        let n1 = db.create_node(&["Doc"]);
+        let n1 = db.create_node(&["Doc"]).unwrap();
         db.set_node_property(
             n1,
             "content",
             Value::String("Rust graph database engine".into()),
-        );
-        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
+        )
+        .unwrap();
+        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
 
-        let n2 = db.create_node(&["Doc"]);
+        let n2 = db.create_node(&["Doc"]).unwrap();
         db.set_node_property(
             n2,
             "content",
             Value::String("Python machine learning framework".into()),
-        );
-        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0));
+        )
+        .unwrap();
+        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0))
+            .unwrap();
 
-        let n3 = db.create_node(&["Doc"]);
+        let n3 = db.create_node(&["Doc"]).unwrap();
         db.set_node_property(
             n3,
             "content",
             Value::String("Rust systems programming language".into()),
-        );
-        db.set_node_property(n3, "emb", vec3(0.9, 0.1, 0.0));
+        )
+        .unwrap();
+        db.set_node_property(n3, "emb", vec3(0.9, 0.1, 0.0))
+            .unwrap();
 
-        let n4 = db.create_node(&["Doc"]);
+        let n4 = db.create_node(&["Doc"]).unwrap();
         db.set_node_property(
             n4,
             "content",
             Value::String("Graph neural network research".into()),
-        );
-        db.set_node_property(n4, "emb", vec3(0.5, 0.5, 0.0));
+        )
+        .unwrap();
+        db.set_node_property(n4, "emb", vec3(0.5, 0.5, 0.0))
+            .unwrap();
 
         // Create both indexes
         db.create_text_index("Doc", "content")
@@ -657,13 +690,17 @@ mod hybrid {
     fn test_hybrid_search_without_text_index() {
         let db = GrafeoDB::new_in_memory();
 
-        let n1 = db.create_node(&["Doc"]);
-        db.set_node_property(n1, "content", Value::String("Rust graph database".into()));
-        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
+        let n1 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n1, "content", Value::String("Rust graph database".into()))
+            .unwrap();
+        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
 
-        let n2 = db.create_node(&["Doc"]);
-        db.set_node_property(n2, "content", Value::String("Python ML".into()));
-        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0));
+        let n2 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n2, "content", Value::String("Python ML".into()))
+            .unwrap();
+        db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0))
+            .unwrap();
 
         // Create ONLY vector index, no text index
         db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
@@ -692,9 +729,11 @@ mod hybrid {
     fn test_hybrid_search_without_vector_index() {
         let db = GrafeoDB::new_in_memory();
 
-        let n1 = db.create_node(&["Doc"]);
-        db.set_node_property(n1, "content", Value::String("Rust graph database".into()));
-        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
+        let n1 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n1, "content", Value::String("Rust graph database".into()))
+            .unwrap();
+        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
 
         // Create ONLY text index, no vector index
         db.create_text_index("Doc", "content")
@@ -723,9 +762,11 @@ mod hybrid {
     fn test_hybrid_search_without_any_index() {
         let db = GrafeoDB::new_in_memory();
 
-        let n1 = db.create_node(&["Doc"]);
-        db.set_node_property(n1, "content", Value::String("Rust graph database".into()));
-        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
+        let n1 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n1, "content", Value::String("Rust graph database".into()))
+            .unwrap();
+        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
 
         // No indexes at all
         let results = db
@@ -807,8 +848,9 @@ mod concurrent_vector {
         let db = std::sync::Arc::new(GrafeoDB::new_in_memory());
 
         // Seed initial data
-        let n1 = db.create_node(&["Doc"]);
-        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
+        let n1 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
         db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
             .unwrap();
 
@@ -818,9 +860,11 @@ mod concurrent_vector {
         // Writer thread: add more nodes
         let writer = std::thread::spawn(move || {
             for i in 0..10 {
-                let n = db_write.create_node(&["Doc"]);
+                let n = db_write.create_node(&["Doc"]).unwrap();
                 let x = (i as f32) / 10.0;
-                db_write.set_node_property(n, "emb", vec3(x, 1.0 - x, 0.0));
+                db_write
+                    .set_node_property(n, "emb", vec3(x, 1.0 - x, 0.0))
+                    .unwrap();
             }
         });
 
@@ -847,12 +891,13 @@ mod concurrent_text {
     fn test_concurrent_text_read_during_write() {
         let db = std::sync::Arc::new(GrafeoDB::new_in_memory());
 
-        let n1 = db.create_node(&["Doc"]);
+        let n1 = db.create_node(&["Doc"]).unwrap();
         db.set_node_property(
             n1,
             "content",
             Value::String("initial document about graphs".into()),
-        );
+        )
+        .unwrap();
         db.create_text_index("Doc", "content").unwrap();
 
         let db_read = std::sync::Arc::clone(&db);
@@ -860,12 +905,14 @@ mod concurrent_text {
 
         let writer = std::thread::spawn(move || {
             for i in 0..10 {
-                let n = db_write.create_node(&["Doc"]);
-                db_write.set_node_property(
-                    n,
-                    "content",
-                    Value::String(format!("document number {i} about databases").into()),
-                );
+                let n = db_write.create_node(&["Doc"]).unwrap();
+                db_write
+                    .set_node_property(
+                        n,
+                        "content",
+                        Value::String(format!("document number {i} about databases").into()),
+                    )
+                    .unwrap();
             }
         });
 
@@ -898,17 +945,23 @@ mod quantized_vector {
     fn test_scalar_quantized_index_create_insert_search() {
         let db = GrafeoDB::new_in_memory();
 
-        let alix = db.create_node(&["Doc"]);
-        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0));
-        db.set_node_property(alix, "name", Value::from("Alix"));
+        let alix = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
+        db.set_node_property(alix, "name", Value::from("Alix"))
+            .unwrap();
 
-        let gus = db.create_node(&["Doc"]);
-        db.set_node_property(gus, "emb", vec3(0.0, 1.0, 0.0));
-        db.set_node_property(gus, "name", Value::from("Gus"));
+        let gus = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(gus, "emb", vec3(0.0, 1.0, 0.0))
+            .unwrap();
+        db.set_node_property(gus, "name", Value::from("Gus"))
+            .unwrap();
 
-        let vincent = db.create_node(&["Doc"]);
-        db.set_node_property(vincent, "emb", vec3(0.9, 0.1, 0.0));
-        db.set_node_property(vincent, "name", Value::from("Vincent"));
+        let vincent = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(vincent, "emb", vec3(0.9, 0.1, 0.0))
+            .unwrap();
+        db.set_node_property(vincent, "name", Value::from("Vincent"))
+            .unwrap();
 
         db.create_vector_index(
             "Doc",
@@ -934,14 +987,17 @@ mod quantized_vector {
     fn test_binary_quantized_index_create_insert_search() {
         let db = GrafeoDB::new_in_memory();
 
-        let alix = db.create_node(&["Doc"]);
-        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0));
+        let alix = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
 
-        let gus = db.create_node(&["Doc"]);
-        db.set_node_property(gus, "emb", vec3(0.0, 1.0, 0.0));
+        let gus = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(gus, "emb", vec3(0.0, 1.0, 0.0))
+            .unwrap();
 
-        let vincent = db.create_node(&["Doc"]);
-        db.set_node_property(vincent, "emb", vec3(0.0, 0.0, 1.0));
+        let vincent = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(vincent, "emb", vec3(0.0, 0.0, 1.0))
+            .unwrap();
 
         db.create_vector_index(
             "Doc",
@@ -967,11 +1023,13 @@ mod quantized_vector {
         // Regression test: quantization=None (default) should behave identically
         let db = GrafeoDB::new_in_memory();
 
-        let alix = db.create_node(&["Doc"]);
-        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0));
+        let alix = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
 
-        let gus = db.create_node(&["Doc"]);
-        db.set_node_property(gus, "emb", vec3(0.0, 1.0, 0.0));
+        let gus = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(gus, "emb", vec3(0.0, 1.0, 0.0))
+            .unwrap();
 
         // Explicit None quantization
         db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
@@ -989,8 +1047,9 @@ mod quantized_vector {
     fn test_quantization_none_string_equivalent_to_default() {
         let db = GrafeoDB::new_in_memory();
 
-        let alix = db.create_node(&["Doc"]);
-        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0));
+        let alix = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
 
         // "none" string should be equivalent to None
         db.create_vector_index(
@@ -1014,8 +1073,9 @@ mod quantized_vector {
     fn test_invalid_quantization_type_errors() {
         let db = GrafeoDB::new_in_memory();
 
-        let alix = db.create_node(&["Doc"]);
-        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0));
+        let alix = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
 
         let result = db.create_vector_index(
             "Doc",
@@ -1051,11 +1111,13 @@ mod quantized_vector {
         .expect("create empty scalar-quantized index");
 
         // Insert after index creation
-        let alix = db.create_node(&["Doc"]);
-        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0));
+        let alix = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
 
-        let gus = db.create_node(&["Doc"]);
-        db.set_node_property(gus, "emb", vec3(0.0, 1.0, 0.0));
+        let gus = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(gus, "emb", vec3(0.0, 1.0, 0.0))
+            .unwrap();
 
         let results = db
             .vector_search("Doc", "emb", &[1.0, 0.0, 0.0], 1, None, None)
@@ -1073,11 +1135,13 @@ mod quantized_vector {
     fn test_rebuild_preserves_quantization() {
         let db = GrafeoDB::new_in_memory();
 
-        let alix = db.create_node(&["Doc"]);
-        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0));
+        let alix = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(alix, "emb", vec3(1.0, 0.0, 0.0))
+            .unwrap();
 
-        let gus = db.create_node(&["Doc"]);
-        db.set_node_property(gus, "emb", vec3(0.0, 1.0, 0.0));
+        let gus = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(gus, "emb", vec3(0.0, 1.0, 0.0))
+            .unwrap();
 
         db.create_vector_index(
             "Doc",

--- a/crates/grafeo-engine/tests/session_transaction_vector_index.rs
+++ b/crates/grafeo-engine/tests/session_transaction_vector_index.rs
@@ -1,0 +1,167 @@
+//! Regression tests for transaction-buffered session vector index updates.
+
+#![cfg(feature = "vector-index")]
+
+use grafeo_common::types::Value;
+use grafeo_engine::GrafeoDB;
+
+fn vec3(x: f32, y: f32, z: f32) -> Value {
+    Value::Vector(vec![x, y, z].into())
+}
+
+fn create_empty_doc_index(db: &GrafeoDB) {
+    db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
+        .expect("create empty vector index");
+}
+
+fn result_ids(db: &GrafeoDB, query: &[f32], k: usize) -> Vec<u64> {
+    db.vector_search("Doc", "emb", query, k, None, None)
+        .expect("vector search")
+        .into_iter()
+        .map(|(id, _)| id.as_u64())
+        .collect()
+}
+
+#[test]
+fn rolled_back_create_node_with_vector_props_is_not_searchable() {
+    let db = GrafeoDB::new_in_memory();
+    create_empty_doc_index(&db);
+
+    let mut session = db.session();
+    session.begin_transaction().expect("begin");
+    let rolled_back = session
+        .create_node_with_props(&["Doc"], [("emb", vec3(1.0, 0.0, 0.0))])
+        .expect("create vector node");
+    session.rollback().expect("rollback");
+
+    let ids = result_ids(&db, &[1.0, 0.0, 0.0], 10);
+    assert!(
+        !ids.contains(&rolled_back.as_u64()),
+        "rolled-back vector node must not be indexed"
+    );
+    assert!(
+        ids.is_empty(),
+        "empty index should remain empty after rollback"
+    );
+}
+
+#[test]
+fn commit_applies_create_update_and_delete_vector_intents() {
+    let db = GrafeoDB::new_in_memory();
+    create_empty_doc_index(&db);
+
+    let mut session = db.session();
+    session.begin_transaction().expect("begin create");
+    let node = session
+        .create_node_with_props(&["Doc"], [("emb", vec3(1.0, 0.0, 0.0))])
+        .expect("create vector node");
+    session.commit().expect("commit create");
+    assert!(result_ids(&db, &[1.0, 0.0, 0.0], 10).contains(&node.as_u64()));
+
+    session.begin_transaction().expect("begin update");
+    session
+        .set_node_property(node, "emb", vec3(0.0, 1.0, 0.0))
+        .expect("update vector property");
+    session.commit().expect("commit update");
+    let updated = db
+        .vector_search("Doc", "emb", &[0.0, 1.0, 0.0], 1, None, None)
+        .expect("search updated vector");
+    assert_eq!(updated.first().map(|(id, _)| *id), Some(node));
+    assert!(
+        updated
+            .first()
+            .is_some_and(|(_, distance)| *distance < 0.001),
+        "updated vector should be indexed at the committed value"
+    );
+
+    session.begin_transaction().expect("begin delete");
+    assert!(
+        session.delete_node(node),
+        "delete should see committed node"
+    );
+    session.commit().expect("commit delete");
+    assert!(
+        result_ids(&db, &[0.0, 1.0, 0.0], 10).is_empty(),
+        "committed delete should remove the node from the vector index"
+    );
+}
+
+#[test]
+fn rollback_to_savepoint_truncates_later_vector_intents() {
+    let db = GrafeoDB::new_in_memory();
+    create_empty_doc_index(&db);
+
+    let mut session = db.session();
+    session.begin_transaction().expect("begin");
+    let kept = session
+        .create_node_with_props(&["Doc"], [("emb", vec3(1.0, 0.0, 0.0))])
+        .expect("create kept node");
+    session.savepoint("after_kept").expect("savepoint");
+    let discarded = session
+        .create_node_with_props(&["Doc"], [("emb", vec3(0.0, 1.0, 0.0))])
+        .expect("create discarded node");
+    session
+        .rollback_to_savepoint("after_kept")
+        .expect("rollback to savepoint");
+    session.commit().expect("commit");
+
+    let ids = result_ids(&db, &[0.5, 0.5, 0.0], 10);
+    assert!(
+        ids.contains(&kept.as_u64()),
+        "pre-savepoint node should be indexed"
+    );
+    assert!(
+        !ids.contains(&discarded.as_u64()),
+        "post-savepoint node intent should be discarded"
+    );
+    assert_eq!(ids.len(), 1);
+}
+
+#[test]
+fn commit_conflict_loser_discards_vector_intents() {
+    let db = GrafeoDB::new_in_memory();
+    create_empty_doc_index(&db);
+
+    let mut seed = db.session();
+    seed.begin_transaction().expect("begin seed");
+    let node = seed
+        .create_node_with_props(&["Doc"], [("emb", vec3(1.0, 0.0, 0.0))])
+        .expect("seed node");
+    seed.commit().expect("commit seed");
+
+    let mut winner = db.session();
+    let mut loser = db.session();
+    winner.begin_transaction().expect("begin winner");
+    loser.begin_transaction().expect("begin loser");
+
+    winner
+        .set_node_property(node, "emb", vec3(0.0, 1.0, 0.0))
+        .expect("winner update");
+    winner.commit().expect("winner commit");
+
+    loser
+        .set_node_property(node, "emb", vec3(0.0, 0.0, 1.0))
+        .expect("loser update before commit conflict");
+    assert!(
+        loser.commit().is_err(),
+        "loser should fail at commit due to write-write conflict"
+    );
+
+    let current = db.get_node(node).expect("node remains visible");
+    assert_eq!(
+        current.properties.get(&"emb".into()),
+        Some(&vec3(0.0, 1.0, 0.0)),
+        "conflict rollback should restore the winner's graph value"
+    );
+
+    let results = db
+        .vector_search("Doc", "emb", &[0.0, 1.0, 0.0], 1, None, None)
+        .expect("search winner vector");
+    assert_eq!(results.first().map(|(id, _)| *id), Some(node));
+    assert!(
+        results
+            .first()
+            .is_some_and(|(_, distance)| *distance < 0.001),
+        "conflict loser vector intent should not replace the committed index value"
+    );
+}

--- a/crates/grafeo-engine/tests/session_transactional_batch/commit_visibility.rs
+++ b/crates/grafeo-engine/tests/session_transactional_batch/commit_visibility.rs
@@ -1,0 +1,199 @@
+//! Commit / visibility / preflight / WAL / vector coverage.
+
+use super::common::person;
+use grafeo_common::types::Value;
+use grafeo_engine::session::{TransactionalEdgeCreate, TransactionalNodeCreate};
+use grafeo_engine::{Config, GrafeoDB};
+
+#[test]
+fn session_transactional_batch_requires_explicit_transaction() {
+    let db = GrafeoDB::new_in_memory();
+    let session = db.session();
+
+    let err = session
+        .create_nodes_with_props_transactional(&[person("A", 1)])
+        .expect_err("batch without a transaction must fail");
+    let msg = format!("{err}");
+    assert!(
+        msg.to_lowercase().contains("transaction"),
+        "error should mention the missing transaction: {msg}"
+    );
+
+    let err = session
+        .create_edges_with_props_transactional(&[])
+        .expect_err("edge batch without a transaction must fail");
+    assert!(format!("{err}").to_lowercase().contains("transaction"));
+}
+
+#[test]
+fn session_transactional_batch_commit_makes_rows_visible() {
+    let db = GrafeoDB::new_in_memory();
+    let mut session = db.session();
+
+    session.begin_transaction().expect("begin");
+    let ids = session
+        .create_nodes_with_props_transactional(&[person("A", 1), person("B", 2), person("C", 3)])
+        .expect("batch create");
+    assert_eq!(ids.len(), 3);
+    session.commit().expect("commit");
+
+    for (id, (name, age)) in ids.iter().zip([("A", 1), ("B", 2), ("C", 3)]) {
+        let node = db.get_node(*id).expect("committed node visible");
+        assert!(node.has_label("Person"));
+        assert_eq!(
+            node.get_property("name").and_then(|v| v.as_str()),
+            Some(name)
+        );
+        assert_eq!(
+            node.get_property("age").and_then(|v| v.as_int64()),
+            Some(age)
+        );
+    }
+}
+
+#[test]
+fn session_transactional_batch_concurrent_visibility() {
+    let db = GrafeoDB::new_in_memory();
+
+    let mut session_a = db.session();
+    session_a.begin_transaction().expect("begin A");
+    let ids = session_a
+        .create_nodes_with_props_transactional(&[person("A", 1), person("B", 2)])
+        .expect("batch create");
+
+    {
+        let session_b = db.session();
+        for id in &ids {
+            assert!(
+                session_b.get_node(*id).is_none(),
+                "uncommitted batch row must be invisible to other sessions"
+            );
+        }
+    }
+
+    session_a.commit().expect("commit A");
+
+    {
+        let session_c = db.session();
+        for id in &ids {
+            assert!(
+                session_c.get_node(*id).is_some(),
+                "committed batch row must be visible after commit"
+            );
+        }
+    }
+}
+
+#[test]
+fn session_transactional_batch_preflight_is_atomic() {
+    let config = Config::in_memory().with_max_property_size(8);
+    let db = GrafeoDB::with_config(config).expect("open");
+    let mut session = db.session();
+
+    session.begin_transaction().expect("begin");
+    let oversized = TransactionalNodeCreate::new(["Person"]).with_property(
+        "blob",
+        Value::from("this value is far larger than eight bytes"),
+    );
+    let result = session.create_nodes_with_props_transactional(&[person("ok", 1), oversized]);
+
+    assert!(result.is_err(), "oversized property must fail preflight");
+    assert_eq!(db.node_count(), 0, "preflight failure must create nothing");
+    session.rollback().ok();
+}
+
+#[test]
+fn session_transactional_batch_edges_commit_and_order() {
+    let db = GrafeoDB::new_in_memory();
+    let mut session = db.session();
+
+    session.begin_transaction().expect("begin");
+    let nodes = session
+        .create_nodes_with_props_transactional(&[person("A", 1), person("B", 2), person("C", 3)])
+        .expect("nodes");
+    let edges = session
+        .create_edges_with_props_transactional(&[
+            TransactionalEdgeCreate::new(nodes[0], nodes[1], "KNOWS")
+                .with_property("w", Value::from(1i64)),
+            TransactionalEdgeCreate::new(nodes[1], nodes[2], "LIKES"),
+        ])
+        .expect("edges");
+    session.commit().expect("commit");
+
+    assert_eq!(edges.len(), 2);
+    assert_eq!(edges[1].0, edges[0].0 + 1, "edge IDs preserve input order");
+    let e0 = db.get_edge(edges[0]).expect("edge visible");
+    assert_eq!(e0.src, nodes[0]);
+    assert_eq!(e0.dst, nodes[1]);
+    assert_eq!(e0.get_property("w").and_then(|v| v.as_int64()), Some(1));
+}
+
+#[cfg(feature = "wal")]
+#[test]
+fn session_transactional_batch_wal_durable_across_reopen() {
+    use grafeo_engine::config::StorageFormat;
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("batchdb");
+
+    let committed_ids = {
+        let config = Config::persistent(&path).with_storage_format(StorageFormat::WalDirectory);
+        let db = GrafeoDB::with_config(config).expect("open");
+        let mut session = db.session();
+        session.begin_transaction().expect("begin");
+        let ids = session
+            .create_nodes_with_props_transactional(&[person("A", 1), person("B", 2)])
+            .expect("batch create");
+        session.commit().expect("commit");
+        drop(session);
+        db.close().expect("close");
+        ids
+    };
+
+    let config = Config::persistent(&path).with_storage_format(StorageFormat::WalDirectory);
+    let db = GrafeoDB::with_config(config).expect("reopen");
+    assert_eq!(
+        db.node_count(),
+        committed_ids.len(),
+        "WAL replay restores batch"
+    );
+    for id in committed_ids {
+        assert!(db.get_node(id).is_some(), "replayed batch row present");
+    }
+}
+
+#[cfg(feature = "vector-index")]
+#[test]
+fn session_transactional_batch_vector_intents_deferred_to_commit() {
+    let db = GrafeoDB::new_in_memory();
+    db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
+        .expect("create vector index");
+
+    fn doc(x: f32) -> TransactionalNodeCreate {
+        TransactionalNodeCreate::new(["Doc"])
+            .with_property("emb", Value::Vector(vec![x, 0.0, 0.0].into()))
+    }
+
+    let mut session = db.session();
+    session.begin_transaction().expect("begin");
+    let ids = session
+        .create_nodes_with_props_transactional(&[doc(1.0), doc(0.0)])
+        .expect("batch create with vectors");
+
+    let pre = db.vector_search("Doc", "emb", &[1.0, 0.0, 0.0], 5, None, None);
+    assert!(
+        pre.as_ref().map_or(true, |r| r.is_empty()),
+        "vector index must not see uncommitted batch rows"
+    );
+
+    session.commit().expect("commit");
+
+    let results = db
+        .vector_search("Doc", "emb", &[1.0, 0.0, 0.0], 5, None, None)
+        .expect("search after commit");
+    assert_eq!(results.len(), 2, "both committed vectors become searchable");
+    let found: Vec<u64> = results.iter().map(|(id, _)| id.as_u64()).collect();
+    for id in &ids {
+        assert!(found.contains(&id.as_u64()), "committed vector row indexed");
+    }
+}

--- a/crates/grafeo-engine/tests/session_transactional_batch/common.rs
+++ b/crates/grafeo-engine/tests/session_transactional_batch/common.rs
@@ -1,0 +1,12 @@
+//! Shared fixtures for session transactional batch tests.
+
+#![allow(dead_code)]
+
+use grafeo_common::types::Value;
+use grafeo_engine::session::TransactionalNodeCreate;
+
+pub fn person(name: &str, age: i64) -> TransactionalNodeCreate {
+    TransactionalNodeCreate::new(["Person"])
+        .with_property("name", Value::from(name))
+        .with_property("age", Value::from(age))
+}

--- a/crates/grafeo-engine/tests/session_transactional_batch/main.rs
+++ b/crates/grafeo-engine/tests/session_transactional_batch/main.rs
@@ -1,0 +1,11 @@
+//! Session-level transactional batch mutation tests (W1-GRAFEO-BATCH).
+//!
+//! ```bash
+//! cargo test -p grafeo-engine --test session_transactional_batch --features 'lpg,wal,vector-index,cdc'
+//! ```
+
+#![allow(missing_docs)]
+
+mod commit_visibility;
+mod common;
+mod rollback;

--- a/crates/grafeo-engine/tests/session_transactional_batch/rollback.rs
+++ b/crates/grafeo-engine/tests/session_transactional_batch/rollback.rs
@@ -1,0 +1,193 @@
+//! Full / savepoint / reopen rollback coverage for session batch APIs.
+
+use super::common::person;
+use grafeo_common::types::Value;
+use grafeo_engine::session::TransactionalEdgeCreate;
+use grafeo_engine::{Config, GrafeoDB};
+
+#[test]
+fn session_transactional_batch_rollback_discards_every_row() {
+    let db = GrafeoDB::new_in_memory();
+    let mut session = db.session();
+
+    session.begin_transaction().expect("begin");
+    let ids = session
+        .create_nodes_with_props_transactional(&[person("A", 1), person("B", 2)])
+        .expect("batch create");
+    session.rollback().expect("rollback");
+
+    for id in ids {
+        assert!(db.get_node(id).is_none(), "rolled-back row must be gone");
+    }
+    assert_eq!(db.node_count(), 0, "no nodes survive a full rollback");
+}
+
+#[test]
+fn session_transactional_batch_rollback_cleans_secondaries_and_intents() {
+    let db = GrafeoDB::new_in_memory();
+    db.create_property_index("name");
+
+    {
+        let mut s = db.session();
+        s.begin_transaction().expect("begin baseline");
+        s.create_nodes_with_props_transactional(&[person("keep", 9)])
+            .expect("baseline");
+        s.commit().expect("commit baseline");
+    }
+
+    let mut session = db.session();
+    session.begin_transaction().expect("begin");
+    let nodes = session
+        .create_nodes_with_props_transactional(&[person("gone", 1), person("gone2", 2)])
+        .expect("nodes");
+    let edges = session
+        .create_edges_with_props_transactional(&[TransactionalEdgeCreate::new(
+            nodes[0], nodes[1], "KNOWS",
+        )
+        .with_property("w", Value::from(1i64))])
+        .expect("edges");
+    session.rollback().expect("rollback");
+
+    for id in &nodes {
+        assert!(db.get_node(*id).is_none());
+    }
+    for id in &edges {
+        assert!(db.get_edge(*id).is_none());
+    }
+
+    assert_eq!(
+        db.find_nodes_by_property("name", &Value::from("keep"))
+            .len(),
+        1,
+        "baseline property-index entry must survive"
+    );
+    assert!(
+        db.find_nodes_by_property("name", &Value::from("gone"))
+            .is_empty(),
+        "property index must drop staged values"
+    );
+    assert!(
+        db.find_nodes_by_property("name", &Value::from("gone2"))
+            .is_empty()
+    );
+    assert_eq!(db.node_count(), 1);
+    assert_eq!(db.edge_count(), 0);
+
+    session.begin_transaction().expect("begin again");
+    let fresh = session
+        .create_nodes_with_props_transactional(&[person("fresh", 3)])
+        .expect("fresh");
+    assert_ne!(fresh[0], nodes[0]);
+    assert_ne!(fresh[0], nodes[1]);
+    session.rollback().expect("rollback fresh");
+}
+
+#[cfg(feature = "vector-index")]
+#[test]
+fn session_transactional_batch_rollback_discards_vector_intents() {
+    let db = GrafeoDB::new_in_memory();
+    db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
+        .expect("create vector index");
+
+    let mut session = db.session();
+    session.begin_transaction().expect("begin");
+    let _ids = session
+        .create_nodes_with_props_transactional(&[
+            grafeo_engine::session::TransactionalNodeCreate::new(["Doc"])
+                .with_property("emb", Value::Vector(vec![1.0, 0.0, 0.0].into())),
+            grafeo_engine::session::TransactionalNodeCreate::new(["Doc"])
+                .with_property("emb", Value::Vector(vec![0.0, 1.0, 0.0].into())),
+        ])
+        .expect("batch");
+    session.rollback().expect("rollback");
+
+    let results = db
+        .vector_search("Doc", "emb", &[1.0, 0.0, 0.0], 5, None, None)
+        .expect("search after rollback");
+    assert!(
+        results.is_empty(),
+        "rolled-back vector intents must not be applied"
+    );
+    assert_eq!(db.node_count(), 0);
+}
+
+#[cfg(feature = "wal")]
+#[test]
+fn session_transactional_batch_rollback_absent_after_reopen() {
+    use grafeo_engine::config::StorageFormat;
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("batchdb_rollback");
+
+    {
+        let config = Config::persistent(&path).with_storage_format(StorageFormat::WalDirectory);
+        let db = GrafeoDB::with_config(config).expect("open");
+        let mut session = db.session();
+        session.begin_transaction().expect("begin");
+        session
+            .create_nodes_with_props_transactional(&[person("A", 1), person("B", 2)])
+            .expect("batch");
+        session.rollback().expect("rollback");
+        drop(session);
+        db.close().expect("close");
+    }
+
+    let config = Config::persistent(&path).with_storage_format(StorageFormat::WalDirectory);
+    let db = GrafeoDB::with_config(config).expect("reopen");
+    assert_eq!(
+        db.node_count(),
+        0,
+        "rolled-back batch must not resurrect after reopen"
+    );
+}
+
+#[test]
+fn session_transactional_batch_savepoint_cleans_secondaries() {
+    let db = GrafeoDB::new_in_memory();
+    db.create_property_index("name");
+    let mut session = db.session();
+
+    session.begin_transaction().expect("begin");
+    let kept = session
+        .create_nodes_with_props_transactional(&[person("keep", 1)])
+        .expect("pre-savepoint");
+    session.savepoint("sp1").expect("savepoint");
+
+    let staged = session
+        .create_nodes_with_props_transactional(&[person("gone", 2), person("gone2", 3)])
+        .expect("post-savepoint nodes");
+    let edges = session
+        .create_edges_with_props_transactional(&[TransactionalEdgeCreate::new(
+            staged[0], staged[1], "TEMP",
+        )])
+        .expect("post-savepoint edges");
+
+    session.rollback_to_savepoint("sp1").expect("rollback sp");
+
+    assert!(db.get_node(kept[0]).is_none(), "still uncommitted");
+    assert!(session.get_node(kept[0]).is_some(), "owner sees keep");
+    for id in &staged {
+        assert!(session.get_node(*id).is_none());
+        assert!(db.get_node(*id).is_none());
+    }
+    for id in &edges {
+        assert!(session.get_edge(*id).is_none());
+        assert!(db.get_edge(*id).is_none());
+    }
+    assert!(
+        db.find_nodes_by_property("name", &Value::from("gone"))
+            .is_empty()
+    );
+    assert!(
+        db.find_nodes_by_property("name", &Value::from("gone2"))
+            .is_empty()
+    );
+
+    session.commit().expect("commit kept");
+    assert_eq!(db.node_count(), 1);
+    assert_eq!(db.edge_count(), 0);
+    assert_eq!(
+        db.find_nodes_by_property("name", &Value::from("keep")),
+        vec![kept[0]]
+    );
+}

--- a/crates/grafeo-engine/tests/session_wal_durability.rs
+++ b/crates/grafeo-engine/tests/session_wal_durability.rs
@@ -74,8 +74,8 @@ mod session_wal_durability {
 
             // Anchor nodes via the WAL-correct DB-direct path so we know the
             // nodes themselves survive; the test isolates the edge bug.
-            let alix = db.create_node(&["Person"]);
-            let gus = db.create_node(&["Person"]);
+            let alix = db.create_node(&["Person"]).unwrap();
+            let gus = db.create_node(&["Person"]).unwrap();
 
             let mut session = db.session();
             session.begin_transaction().expect("begin");
@@ -113,7 +113,7 @@ mod session_wal_durability {
 
             // Create node via DB-direct path so the node itself is durable;
             // the test isolates the property bug.
-            alix = db.create_node(&["Person"]);
+            alix = db.create_node(&["Person"]).expect("create anchor node");
 
             let mut session = db.session();
             session.begin_transaction().expect("begin");
@@ -147,8 +147,8 @@ mod session_wal_durability {
             let db = GrafeoDB::with_config(config).expect("open for write");
 
             // Anchor edge via DB-direct path; isolate the property bug.
-            let alix = db.create_node(&["Person"]);
-            let gus = db.create_node(&["Person"]);
+            let alix = db.create_node(&["Person"]).unwrap();
+            let gus = db.create_node(&["Person"]).unwrap();
             edge_id = db.create_edge(alix, gus, "KNOWS");
 
             let mut session = db.session();
@@ -230,8 +230,8 @@ mod session_wal_durability {
         {
             let config = Config::persistent(&path).with_storage_format(StorageFormat::WalDirectory);
             let db = GrafeoDB::with_config(config).expect("open for write");
-            let alix = db.create_node(&["Person"]);
-            let gus = db.create_node(&["Person"]);
+            let alix = db.create_node(&["Person"]).unwrap();
+            let gus = db.create_node(&["Person"]).unwrap();
 
             let mut session = db.session();
             session.begin_transaction().expect("begin");
@@ -258,8 +258,8 @@ mod session_wal_durability {
         {
             let config = Config::persistent(&path).with_storage_format(StorageFormat::WalDirectory);
             let db = GrafeoDB::with_config(config).expect("open for write");
-            let alix = db.create_node(&["Person"]);
-            let _gus = db.create_node(&["Person"]);
+            let alix = db.create_node(&["Person"]).unwrap();
+            let _gus = db.create_node(&["Person"]).unwrap();
 
             let mut session = db.session();
             session.begin_transaction().expect("begin");
@@ -287,8 +287,8 @@ mod session_wal_durability {
         {
             let config = Config::persistent(&path).with_storage_format(StorageFormat::WalDirectory);
             let db = GrafeoDB::with_config(config).expect("open for write");
-            let alix = db.create_node(&["Person"]);
-            let gus = db.create_node(&["Person"]);
+            let alix = db.create_node(&["Person"]).unwrap();
+            let gus = db.create_node(&["Person"]).unwrap();
             let _kept = db.create_edge(alix, gus, "KNOWS");
             let to_delete = db.create_edge(alix, gus, "ALSO_KNOWS");
 

--- a/crates/grafeo-engine/tests/snapshot.rs
+++ b/crates/grafeo-engine/tests/snapshot.rs
@@ -105,10 +105,10 @@ fn export_import_preserves_nodes() {
 #[test]
 fn export_import_preserves_edges() {
     let db = GrafeoDB::new_in_memory();
-    let alix = db.create_node(&["Person"]);
-    db.set_node_property(alix, "name", "Alix".into());
-    let gus = db.create_node(&["Person"]);
-    db.set_node_property(gus, "name", "Gus".into());
+    let alix = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(alix, "name", "Alix".into()).unwrap();
+    let gus = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(gus, "name", "Gus".into()).unwrap();
     db.create_edge(alix, gus, "KNOWS");
 
     let bytes = db.export_snapshot().unwrap();
@@ -151,10 +151,10 @@ fn import_rejects_invalid_data() {
 #[test]
 fn snapshot_round_trip_schema() {
     let db = GrafeoDB::new_in_memory();
-    let alix = db.create_node(&["Person"]);
-    db.set_node_property(alix, "name", "Alix".into());
-    let gus = db.create_node(&["Person"]);
-    db.set_node_property(gus, "name", "Gus".into());
+    let alix = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(alix, "name", "Alix".into()).unwrap();
+    let gus = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(gus, "name", "Gus".into()).unwrap();
     db.create_edge(alix, gus, "KNOWS");
 
     let schema_before = db.schema();
@@ -173,8 +173,8 @@ fn snapshot_round_trip_schema() {
 #[test]
 fn export_import_preserves_edge_properties() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["Person"]);
-    let b = db.create_node(&["Person"]);
+    let a = db.create_node(&["Person"]).unwrap();
+    let b = db.create_node(&["Person"]).unwrap();
     let edge = db.create_edge(a, b, "KNOWS");
     db.set_edge_property(edge, "since", Value::Int64(2020));
     db.set_edge_property(edge, "strength", Value::Float64(0.95));
@@ -196,9 +196,9 @@ fn export_import_preserves_edge_properties() {
 #[test]
 fn export_import_preserves_multiple_labels() {
     let db = GrafeoDB::new_in_memory();
-    db.create_node(&["Person", "Employee"]);
-    db.create_node(&["Person", "Manager"]);
-    db.create_node(&["Animal"]);
+    db.create_node(&["Person", "Employee"]).unwrap();
+    db.create_node(&["Person", "Manager"]).unwrap();
+    db.create_node(&["Animal"]).unwrap();
 
     let bytes = db.export_snapshot().unwrap();
     let restored = GrafeoDB::import_snapshot(&bytes).unwrap();
@@ -226,7 +226,7 @@ fn export_import_preserves_temporal_values() {
     use grafeo_common::types::{Date, Duration, Time, Timestamp, ZonedDatetime};
 
     let db = GrafeoDB::new_in_memory();
-    let id = db.create_node(&["Temporal"]);
+    let id = db.create_node(&["Temporal"]).unwrap();
 
     let date = Date::from_ymd(2025, 6, 15).unwrap();
     let time = Time::from_hms(14, 30, 0).unwrap();
@@ -234,11 +234,16 @@ fn export_import_preserves_temporal_values() {
     let duration = Duration::new(1, 15, 3_600_000_000_000); // 1 month, 15 days, 1 hour
     let zoned = ZonedDatetime::from_timestamp_offset(Timestamp::from_secs(1_700_000_000), 3600);
 
-    db.set_node_property(id, "date_val", Value::Date(date));
-    db.set_node_property(id, "time_val", Value::Time(time));
-    db.set_node_property(id, "ts_val", Value::Timestamp(timestamp));
-    db.set_node_property(id, "dur_val", Value::Duration(duration));
-    db.set_node_property(id, "zdt_val", Value::ZonedDatetime(zoned));
+    db.set_node_property(id, "date_val", Value::Date(date))
+        .unwrap();
+    db.set_node_property(id, "time_val", Value::Time(time))
+        .unwrap();
+    db.set_node_property(id, "ts_val", Value::Timestamp(timestamp))
+        .unwrap();
+    db.set_node_property(id, "dur_val", Value::Duration(duration))
+        .unwrap();
+    db.set_node_property(id, "zdt_val", Value::ZonedDatetime(zoned))
+        .unwrap();
 
     let bytes = db.export_snapshot().unwrap();
     let restored = GrafeoDB::import_snapshot(&bytes).unwrap();
@@ -260,17 +265,22 @@ fn export_import_preserves_temporal_values() {
 #[test]
 fn export_import_preserves_all_value_types() {
     let db = GrafeoDB::new_in_memory();
-    let id = db.create_node(&["Test"]);
-    db.set_node_property(id, "str_val", Value::String("hello".into()));
-    db.set_node_property(id, "int_val", Value::Int64(42));
-    db.set_node_property(id, "float_val", Value::Float64(9.81));
-    db.set_node_property(id, "bool_val", Value::Bool(true));
-    db.set_node_property(id, "null_val", Value::Null);
+    let id = db.create_node(&["Test"]).unwrap();
+    db.set_node_property(id, "str_val", Value::String("hello".into()))
+        .unwrap();
+    db.set_node_property(id, "int_val", Value::Int64(42))
+        .unwrap();
+    db.set_node_property(id, "float_val", Value::Float64(9.81))
+        .unwrap();
+    db.set_node_property(id, "bool_val", Value::Bool(true))
+        .unwrap();
+    db.set_node_property(id, "null_val", Value::Null).unwrap();
     db.set_node_property(
         id,
         "bytes_val",
         Value::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF].into()),
-    );
+    )
+    .unwrap();
 
     let bytes = db.export_snapshot().unwrap();
     let restored = GrafeoDB::import_snapshot(&bytes).unwrap();
@@ -296,12 +306,13 @@ fn export_import_preserves_all_value_types() {
 #[test]
 fn export_import_preserves_collection_values() {
     let db = GrafeoDB::new_in_memory();
-    let id = db.create_node(&["Test"]);
+    let id = db.create_node(&["Test"]).unwrap();
     db.set_node_property(
         id,
         "tags",
         Value::List(vec![Value::String("a".into()), Value::String("b".into())].into()),
-    );
+    )
+    .unwrap();
 
     let bytes = db.export_snapshot().unwrap();
     let restored = GrafeoDB::import_snapshot(&bytes).unwrap();
@@ -320,9 +331,9 @@ fn export_import_preserves_collection_values() {
 #[test]
 fn export_import_preserves_multiple_edge_types() {
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["Person"]);
-    let b = db.create_node(&["Person"]);
-    let c = db.create_node(&["Company"]);
+    let a = db.create_node(&["Person"]).unwrap();
+    let b = db.create_node(&["Person"]).unwrap();
+    let c = db.create_node(&["Company"]).unwrap();
 
     db.create_edge(a, b, "KNOWS");
     db.create_edge(a, c, "WORKS_AT");
@@ -349,8 +360,8 @@ fn export_import_preserves_multiple_edge_types() {
 #[test]
 fn export_import_preserves_empty_property_nodes() {
     let db = GrafeoDB::new_in_memory();
-    db.create_node(&["Empty"]);
-    db.create_node(&["Empty"]);
+    db.create_node(&["Empty"]).unwrap();
+    db.create_node(&["Empty"]).unwrap();
 
     let bytes = db.export_snapshot().unwrap();
     let restored = GrafeoDB::import_snapshot(&bytes).unwrap();
@@ -371,9 +382,10 @@ fn export_import_moderate_dataset() {
     // Create 100 nodes with properties
     let mut ids = Vec::new();
     for i in 0..100 {
-        let id = db.create_node(&["Item"]);
-        db.set_node_property(id, "index", Value::Int64(i));
-        db.set_node_property(id, "name", Value::String(format!("item_{i}").into()));
+        let id = db.create_node(&["Item"]).unwrap();
+        db.set_node_property(id, "index", Value::Int64(i)).unwrap();
+        db.set_node_property(id, "name", Value::String(format!("item_{i}").into()))
+            .unwrap();
         ids.push(id);
     }
 
@@ -457,8 +469,8 @@ fn import_rejects_dangling_edge_source() {
     // Create a valid snapshot, then re-export after deleting the source node
     // to create a snapshot with a dangling edge reference.
     let db = GrafeoDB::new_in_memory();
-    let a = db.create_node(&["Person"]);
-    let b = db.create_node(&["Person"]);
+    let a = db.create_node(&["Person"]).unwrap();
+    let b = db.create_node(&["Person"]).unwrap();
     db.create_edge(a, b, "KNOWS");
 
     // Export valid snapshot
@@ -473,7 +485,7 @@ fn import_rejects_dangling_edge_source() {
     // Actually, let's tamper with binary data at a higher level:
     // Build a snapshot where edge references node ID 999 which doesn't exist.
     let db2 = GrafeoDB::new_in_memory();
-    let n = db2.create_node(&["Person"]);
+    let n = db2.create_node(&["Person"]).unwrap();
     // Create an edge referencing a non-existent source node
     // We need to use the direct store API since create_edge validates at a higher level
     db2.store()
@@ -502,7 +514,7 @@ fn import_rejects_dangling_edge_source() {
 #[test]
 fn import_rejects_dangling_edge_destination() {
     let db = GrafeoDB::new_in_memory();
-    let n = db.create_node(&["Person"]);
+    let n = db.create_node(&["Person"]).unwrap();
     db.store()
         .create_edge_with_id(
             grafeo_common::types::EdgeId::new(0),
@@ -975,7 +987,7 @@ fn import_unknown_snapshot_version_returns_clear_error() {
 #[test]
 fn import_truncated_snapshot_returns_error() {
     let db = GrafeoDB::new_in_memory();
-    db.create_node(&["Test"]);
+    db.create_node(&["Test"]).unwrap();
     let bytes = db.export_snapshot().unwrap();
 
     // Truncate to half

--- a/crates/grafeo-engine/tests/storage_tier_overrides.rs
+++ b/crates/grafeo-engine/tests/storage_tier_overrides.rs
@@ -41,13 +41,15 @@ fn alix_force_disk_on_vector_only_does_not_spill_lpg() {
     // ONLY the VectorStore consumer, not the LpgStore consumer.
     let dim = 8;
     for i in 1..=5 {
-        let id = db.create_node(&["Item"]);
-        db.set_node_property(id, "name", Value::from(format!("item_{i}")));
+        let id = db.create_node(&["Item"]).unwrap();
+        db.set_node_property(id, "name", Value::from(format!("item_{i}")))
+            .unwrap();
         db.set_node_property(
             id,
             "embedding",
             Value::Vector(make_embedding(i, dim).into()),
-        );
+        )
+        .unwrap();
     }
     db.create_vector_index("Item", "embedding", Some(dim), None, None, None, None)
         .unwrap();
@@ -95,12 +97,13 @@ fn gus_no_force_disk_overrides_means_no_auto_spill() {
     // Build LPG content + a vector index, all with the default Auto tier.
     let dim = 8;
     for i in 1..=5 {
-        let id = db.create_node(&["Item"]);
+        let id = db.create_node(&["Item"]).unwrap();
         db.set_node_property(
             id,
             "embedding",
             Value::Vector(make_embedding(i, dim).into()),
-        );
+        )
+        .unwrap();
     }
     db.create_vector_index("Item", "embedding", Some(dim), None, None, None, None)
         .unwrap();
@@ -170,12 +173,13 @@ fn hans_force_ram_skips_explicit_spill_request() {
 
     let dim = 8;
     for i in 1..=5 {
-        let id = db.create_node(&["Item"]);
+        let id = db.create_node(&["Item"]).unwrap();
         db.set_node_property(
             id,
             "embedding",
             Value::Vector(make_embedding(i, dim).into()),
-        );
+        )
+        .unwrap();
     }
     db.create_vector_index("Item", "embedding", Some(dim), None, None, None, None)
         .unwrap();
@@ -218,12 +222,13 @@ fn django_force_ram_survives_spill_all() {
 
     let dim = 8;
     for i in 1..=5 {
-        let id = db.create_node(&["Item"]);
+        let id = db.create_node(&["Item"]).unwrap();
         db.set_node_property(
             id,
             "embedding",
             Value::Vector(make_embedding(i, dim).into()),
-        );
+        )
+        .unwrap();
     }
     db.create_vector_index("Item", "embedding", Some(dim), None, None, None, None)
         .unwrap();
@@ -263,12 +268,13 @@ fn shosanna_reload_eligible_brings_spilled_vectors_back_to_ram() {
 
     let dim = 8;
     for i in 1..=5 {
-        let id = db.create_node(&["Item"]);
+        let id = db.create_node(&["Item"]).unwrap();
         db.set_node_property(
             id,
             "embedding",
             Value::Vector(make_embedding(i, dim).into()),
-        );
+        )
+        .unwrap();
     }
     db.create_vector_index("Item", "embedding", Some(dim), None, None, None, None)
         .unwrap();
@@ -315,7 +321,7 @@ fn mia_storage_tiers_lists_only_section_consumers() {
     let db = GrafeoDB::with_config(config).unwrap();
 
     // Add some content so LpgStore has nonzero memory.
-    let _id = db.create_node(&["X"]);
+    let _id = db.create_node(&["X"]).unwrap();
 
     let tiers = db.storage_tiers();
 

--- a/crates/grafeo-engine/tests/streaming_results.rs
+++ b/crates/grafeo-engine/tests/streaming_results.rs
@@ -12,22 +12,29 @@ use grafeo_engine::GrafeoDB;
 /// Seeds a small Person/KNOWS graph. Test data names follow the repo
 /// convention (Alix, Gus, Tarantino characters) from CODE_STYLE.md.
 fn seed_people(db: &GrafeoDB) {
-    let alix = db.create_node(&["Person"]);
-    let gus = db.create_node(&["Person"]);
-    let vincent = db.create_node(&["Person"]);
-    let jules = db.create_node(&["Person"]);
-    let mia = db.create_node(&["Person"]);
+    let alix = db.create_node(&["Person"]).unwrap();
+    let gus = db.create_node(&["Person"]).unwrap();
+    let vincent = db.create_node(&["Person"]).unwrap();
+    let jules = db.create_node(&["Person"]).unwrap();
+    let mia = db.create_node(&["Person"]).unwrap();
 
-    db.set_node_property(alix, "name", Value::String("Alix".into()));
-    db.set_node_property(alix, "age", Value::Int64(32));
-    db.set_node_property(gus, "name", Value::String("Gus".into()));
-    db.set_node_property(gus, "age", Value::Int64(28));
-    db.set_node_property(vincent, "name", Value::String("Vincent".into()));
-    db.set_node_property(vincent, "age", Value::Int64(45));
-    db.set_node_property(jules, "name", Value::String("Jules".into()));
-    db.set_node_property(jules, "age", Value::Int64(40));
-    db.set_node_property(mia, "name", Value::String("Mia".into()));
-    db.set_node_property(mia, "age", Value::Int64(24));
+    db.set_node_property(alix, "name", Value::String("Alix".into()))
+        .unwrap();
+    db.set_node_property(alix, "age", Value::Int64(32)).unwrap();
+    db.set_node_property(gus, "name", Value::String("Gus".into()))
+        .unwrap();
+    db.set_node_property(gus, "age", Value::Int64(28)).unwrap();
+    db.set_node_property(vincent, "name", Value::String("Vincent".into()))
+        .unwrap();
+    db.set_node_property(vincent, "age", Value::Int64(45))
+        .unwrap();
+    db.set_node_property(jules, "name", Value::String("Jules".into()))
+        .unwrap();
+    db.set_node_property(jules, "age", Value::Int64(40))
+        .unwrap();
+    db.set_node_property(mia, "name", Value::String("Mia".into()))
+        .unwrap();
+    db.set_node_property(mia, "age", Value::Int64(24)).unwrap();
 
     db.create_edge(alix, gus, "KNOWS");
     db.create_edge(vincent, jules, "KNOWS");

--- a/crates/grafeo-engine/tests/text_index_mutations.rs
+++ b/crates/grafeo-engine/tests/text_index_mutations.rs
@@ -20,13 +20,15 @@ fn test_text_index_auto_insert_via_create_node() {
     let db = setup_db_with_text_index();
 
     // Create a node AFTER the text index exists
-    let id = db.create_node_with_props(
-        &["Doc"],
-        [(
-            "content",
-            Value::String("The quick brown fox jumps over the lazy dog".into()),
-        )],
-    );
+    let id = db
+        .create_node_with_props(
+            &["Doc"],
+            [(
+                "content",
+                Value::String("The quick brown fox jumps over the lazy dog".into()),
+            )],
+        )
+        .unwrap();
 
     // Should be searchable immediately
     let results = db
@@ -40,13 +42,15 @@ fn test_text_index_auto_insert_via_create_node() {
 fn test_text_index_auto_update_via_set_property() {
     let db = setup_db_with_text_index();
 
-    let id = db.create_node_with_props(
-        &["Doc"],
-        [(
-            "content",
-            Value::String("original text about databases".into()),
-        )],
-    );
+    let id = db
+        .create_node_with_props(
+            &["Doc"],
+            [(
+                "content",
+                Value::String("original text about databases".into()),
+            )],
+        )
+        .unwrap();
 
     // Verify initial text is searchable
     let results = db.text_search("Doc", "content", "databases", 10).unwrap();
@@ -57,7 +61,8 @@ fn test_text_index_auto_update_via_set_property() {
         id,
         "content",
         Value::String("updated text about graph theory".into()),
-    );
+    )
+    .unwrap();
 
     // Old text should no longer match
     let results = db.text_search("Doc", "content", "databases", 10).unwrap();
@@ -78,20 +83,22 @@ fn test_text_index_auto_update_via_set_property() {
 fn test_text_index_auto_delete() {
     let db = setup_db_with_text_index();
 
-    let id = db.create_node_with_props(
-        &["Doc"],
-        [(
-            "content",
-            Value::String("searchable document content".into()),
-        )],
-    );
+    let id = db
+        .create_node_with_props(
+            &["Doc"],
+            [(
+                "content",
+                Value::String("searchable document content".into()),
+            )],
+        )
+        .unwrap();
 
     // Verify it's searchable
     let results = db.text_search("Doc", "content", "searchable", 10).unwrap();
     assert_eq!(results.len(), 1);
 
     // Delete the node
-    let deleted = db.delete_node(id);
+    let deleted = db.delete_node(id).unwrap();
     assert!(deleted);
 
     // Should no longer appear in search
@@ -108,13 +115,15 @@ fn test_text_index_add_label() {
     db.create_text_index("Article", "content").unwrap();
 
     // Create a node WITHOUT the Article label
-    let id = db.create_node_with_props(
-        &["Doc"],
-        [(
-            "content",
-            Value::String("important article about Rust programming".into()),
-        )],
-    );
+    let id = db
+        .create_node_with_props(
+            &["Doc"],
+            [(
+                "content",
+                Value::String("important article about Rust programming".into()),
+            )],
+        )
+        .unwrap();
 
     // Not searchable under Article index
     let results = db.text_search("Article", "content", "Rust", 10).unwrap();
@@ -137,7 +146,9 @@ fn test_text_index_non_string_property_ignored() {
     let db = setup_db_with_text_index();
 
     // Set a non-String property: should not crash or pollute the index
-    let id = db.create_node_with_props(&["Doc"], [("content", Value::Int64(42))]);
+    let id = db
+        .create_node_with_props(&["Doc"], [("content", Value::Int64(42))])
+        .unwrap();
 
     let results = db.text_search("Doc", "content", "42", 10).unwrap();
     assert!(
@@ -150,7 +161,8 @@ fn test_text_index_non_string_property_ignored() {
         id,
         "content",
         Value::String("now it is a string value".into()),
-    );
+    )
+    .unwrap();
     let results = db
         .text_search("Doc", "content", "string value", 10)
         .unwrap();
@@ -161,27 +173,33 @@ fn test_text_index_non_string_property_ignored() {
 fn test_text_index_multiple_nodes() {
     let db = setup_db_with_text_index();
 
-    let _id1 = db.create_node_with_props(
-        &["Doc"],
-        [(
-            "content",
-            Value::String("machine learning with neural networks".into()),
-        )],
-    );
-    let _id2 = db.create_node_with_props(
-        &["Doc"],
-        [(
-            "content",
-            Value::String("graph databases and knowledge graphs".into()),
-        )],
-    );
-    let id3 = db.create_node_with_props(
-        &["Doc"],
-        [(
-            "content",
-            Value::String("machine learning on graphs".into()),
-        )],
-    );
+    let _id1 = db
+        .create_node_with_props(
+            &["Doc"],
+            [(
+                "content",
+                Value::String("machine learning with neural networks".into()),
+            )],
+        )
+        .unwrap();
+    let _id2 = db
+        .create_node_with_props(
+            &["Doc"],
+            [(
+                "content",
+                Value::String("graph databases and knowledge graphs".into()),
+            )],
+        )
+        .unwrap();
+    let id3 = db
+        .create_node_with_props(
+            &["Doc"],
+            [(
+                "content",
+                Value::String("machine learning on graphs".into()),
+            )],
+        )
+        .unwrap();
 
     // "machine learning" should match 2 docs
     let results = db
@@ -190,7 +208,7 @@ fn test_text_index_multiple_nodes() {
     assert_eq!(results.len(), 2);
 
     // Delete one
-    db.delete_node(id3);
+    db.delete_node(id3).unwrap();
     let results = db
         .text_search("Doc", "content", "machine learning", 10)
         .unwrap();

--- a/crates/grafeo-engine/tests/time_travel.rs
+++ b/crates/grafeo-engine/tests/time_travel.rs
@@ -140,13 +140,13 @@ fn test_get_node_at_epoch_deleted_node() {
     // Bump epoch so the node is created at epoch > 0
     bump_epoch(&mut session);
 
-    let id = db.create_node(&["Person"]);
+    let id = db.create_node(&["Person"]).unwrap();
     let epoch_after_insert = db.current_epoch();
 
     // Bump epoch before delete
     bump_epoch(&mut session);
 
-    db.delete_node(id);
+    db.delete_node(id).unwrap();
 
     // Node should be visible at the epoch after insert (before deletion)
     let node = db.get_node_at_epoch(id, epoch_after_insert);
@@ -273,8 +273,9 @@ fn test_get_node_at_epoch() {
     // Advance epoch first so nodes are created at epoch > 0
     bump_epoch(&mut session);
 
-    let id = db.create_node(&["Person"]);
-    db.set_node_property(id, "name", Value::String("Alix".into()));
+    let id = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(id, "name", Value::String("Alix".into()))
+        .unwrap();
     let epoch_after = db.current_epoch();
 
     // Node should exist at this epoch
@@ -294,8 +295,8 @@ fn test_get_edge_at_epoch() {
     // Advance epoch first
     bump_epoch(&mut session);
 
-    let src = db.create_node(&["Person"]);
-    let dst = db.create_node(&["Person"]);
+    let src = db.create_node(&["Person"]).unwrap();
+    let dst = db.create_node(&["Person"]).unwrap();
     let edge_id = db.create_edge(src, dst, "KNOWS");
     let epoch_after = db.current_epoch();
 
@@ -314,8 +315,9 @@ fn test_get_edge_at_epoch() {
 fn test_node_history_single_version() {
     let db = setup_db();
 
-    let id = db.create_node(&["Person"]);
-    db.set_node_property(id, "name", Value::String("Alix".into()));
+    let id = db.create_node(&["Person"]).unwrap();
+    db.set_node_property(id, "name", Value::String("Alix".into()))
+        .unwrap();
 
     let history = db.get_node_history(id);
     assert_eq!(history.len(), 1);
@@ -330,8 +332,8 @@ fn test_node_history_single_version() {
 fn test_node_history_deleted() {
     let db = setup_db();
 
-    let id = db.create_node(&["Person"]);
-    db.delete_node(id);
+    let id = db.create_node(&["Person"]).unwrap();
+    db.delete_node(id).unwrap();
 
     let history = db.get_node_history(id);
     // Version chain should still exist with a deleted marker
@@ -353,8 +355,8 @@ fn test_node_history_nonexistent() {
 fn test_edge_history_single_version() {
     let db = setup_db();
 
-    let src = db.create_node(&["Person"]);
-    let dst = db.create_node(&["Person"]);
+    let src = db.create_node(&["Person"]).unwrap();
+    let dst = db.create_node(&["Person"]).unwrap();
     let edge_id = db.create_edge(src, dst, "KNOWS");
 
     let history = db.get_edge_history(edge_id);

--- a/crates/grafeo-engine/tests/vector_filtered.rs
+++ b/crates/grafeo-engine/tests/vector_filtered.rs
@@ -20,31 +20,42 @@ fn setup_db() -> GrafeoDB {
     let db = GrafeoDB::new_in_memory();
 
     // user_id=1: nodes near [1, 0, 0]
-    let n1 = db.create_node(&["Doc"]);
-    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
-    db.set_node_property(n1, "user_id", Value::Int64(1));
+    let n1 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+        .unwrap();
+    db.set_node_property(n1, "user_id", Value::Int64(1))
+        .unwrap();
 
-    let n2 = db.create_node(&["Doc"]);
-    db.set_node_property(n2, "emb", vec3(0.95, 0.05, 0.0));
-    db.set_node_property(n2, "user_id", Value::Int64(1));
+    let n2 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n2, "emb", vec3(0.95, 0.05, 0.0))
+        .unwrap();
+    db.set_node_property(n2, "user_id", Value::Int64(1))
+        .unwrap();
 
     // user_id=2: nodes near [0, 1, 0]
-    let n3 = db.create_node(&["Doc"]);
-    db.set_node_property(n3, "emb", vec3(0.0, 1.0, 0.0));
-    db.set_node_property(n3, "user_id", Value::Int64(2));
+    let n3 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n3, "emb", vec3(0.0, 1.0, 0.0))
+        .unwrap();
+    db.set_node_property(n3, "user_id", Value::Int64(2))
+        .unwrap();
 
-    let n4 = db.create_node(&["Doc"]);
-    db.set_node_property(n4, "emb", vec3(0.05, 0.95, 0.0));
-    db.set_node_property(n4, "user_id", Value::Int64(2));
+    let n4 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n4, "emb", vec3(0.05, 0.95, 0.0))
+        .unwrap();
+    db.set_node_property(n4, "user_id", Value::Int64(2))
+        .unwrap();
 
     // user_id=3: node near [0, 0, 1]
-    let n5 = db.create_node(&["Doc"]);
-    db.set_node_property(n5, "emb", vec3(0.0, 0.0, 1.0));
-    db.set_node_property(n5, "user_id", Value::Int64(3));
+    let n5 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n5, "emb", vec3(0.0, 0.0, 1.0))
+        .unwrap();
+    db.set_node_property(n5, "user_id", Value::Int64(3))
+        .unwrap();
 
     // No user_id property
-    let n6 = db.create_node(&["Doc"]);
-    db.set_node_property(n6, "emb", vec3(0.5, 0.5, 0.0));
+    let n6 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n6, "emb", vec3(0.5, 0.5, 0.0))
+        .unwrap();
 
     // Create property index for fast lookups
     db.create_property_index("user_id");
@@ -202,7 +213,8 @@ fn test_filtered_search_non_indexed_property() {
 
     // Set "category" on first 2 nodes only
     for (id, _) in results_all.iter().take(2) {
-        db.set_node_property(*id, "category", Value::String("science".into()));
+        db.set_node_property(*id, "category", Value::String("science".into()))
+            .unwrap();
     }
 
     // No property index for "category": should still work (scan fallback)
@@ -234,8 +246,9 @@ fn test_create_vector_index_with_dims_no_data_succeeds() {
         .expect("should create empty index with explicit dimensions");
 
     // Insert a node with vector after index creation, auto-insert should work
-    let id = db.create_node(&["Doc"]);
-    db.set_node_property(id, "emb", Value::Vector(vec![1.0, 0.0, 0.0, 0.0].into()));
+    let id = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(id, "emb", Value::Vector(vec![1.0, 0.0, 0.0, 0.0].into()))
+        .unwrap();
 
     let results = db
         .vector_search("Doc", "emb", &[1.0, 0.0, 0.0, 0.0], 5, None, None)
@@ -264,23 +277,26 @@ fn test_grafeo_memory_pattern() {
     // Create nodes with properties at creation time (grafeo-memory pattern)
     for i in 0..10 {
         let user = if i < 5 { "alix" } else { "gus" };
-        let id = db.create_node_with_props(
-            &["Memory"],
-            vec![
-                (
-                    grafeo_common::types::PropertyKey::new("text"),
-                    Value::String(format!("memory {i}").into()),
-                ),
-                (
-                    grafeo_common::types::PropertyKey::new("user_id"),
-                    Value::String(user.into()),
-                ),
-            ],
-        );
+        let id = db
+            .create_node_with_props(
+                &["Memory"],
+                vec![
+                    (
+                        grafeo_common::types::PropertyKey::new("text"),
+                        Value::String(format!("memory {i}").into()),
+                    ),
+                    (
+                        grafeo_common::types::PropertyKey::new("user_id"),
+                        Value::String(user.into()),
+                    ),
+                ],
+            )
+            .unwrap();
 
         // Set embedding separately (grafeo-memory calls set_node_property for vectors)
         let emb = vec![(i as f32) / 10.0, 1.0 - (i as f32) / 10.0, 0.1, 0.1];
-        db.set_node_property(id, "embedding", Value::Vector(emb.into()));
+        db.set_node_property(id, "embedding", Value::Vector(emb.into()))
+            .unwrap();
     }
 
     // Search WITHOUT filters first: should work
@@ -333,20 +349,23 @@ fn setup_operator_db() -> GrafeoDB {
             1 => "fact",
             _ => "event",
         };
-        let id = db.create_node_with_props(
-            &["Item"],
-            vec![
-                (PropertyKey::new("score"), Value::Float64((i as f64) * 0.1)),
-                (PropertyKey::new("rank"), Value::Int64(i)),
-                (PropertyKey::new("category"), Value::String(category.into())),
-                (
-                    PropertyKey::new("text"),
-                    Value::String(format!("item number {i} is great").into()),
-                ),
-            ],
-        );
+        let id = db
+            .create_node_with_props(
+                &["Item"],
+                vec![
+                    (PropertyKey::new("score"), Value::Float64((i as f64) * 0.1)),
+                    (PropertyKey::new("rank"), Value::Int64(i)),
+                    (PropertyKey::new("category"), Value::String(category.into())),
+                    (
+                        PropertyKey::new("text"),
+                        Value::String(format!("item number {i} is great").into()),
+                    ),
+                ],
+            )
+            .unwrap();
         let emb = vec![(i as f32) / 10.0, 1.0 - (i as f32) / 10.0, 0.5];
-        db.set_node_property(id, "emb", Value::Vector(emb.into()));
+        db.set_node_property(id, "emb", Value::Vector(emb.into()))
+            .unwrap();
     }
     db
 }
@@ -603,18 +622,23 @@ fn test_filter_ne_excludes_nodes_missing_property() {
     let db = GrafeoDB::new_in_memory();
 
     // 3 nodes: two with color, one without
-    let n1 = db.create_node(&["Item"]);
-    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
-    db.set_node_property(n1, "color", Value::String("red".into()));
+    let n1 = db.create_node(&["Item"]).unwrap();
+    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+        .unwrap();
+    db.set_node_property(n1, "color", Value::String("red".into()))
+        .unwrap();
     db.create_vector_index("Item", "emb", Some(3), None, None, None, None)
         .unwrap();
 
-    let n2 = db.create_node(&["Item"]);
-    db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0));
-    db.set_node_property(n2, "color", Value::String("blue".into()));
+    let n2 = db.create_node(&["Item"]).unwrap();
+    db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0))
+        .unwrap();
+    db.set_node_property(n2, "color", Value::String("blue".into()))
+        .unwrap();
 
-    let n3 = db.create_node(&["Item"]);
-    db.set_node_property(n3, "emb", vec3(0.0, 0.0, 1.0));
+    let n3 = db.create_node(&["Item"]).unwrap();
+    db.set_node_property(n3, "emb", vec3(0.0, 0.0, 1.0))
+        .unwrap();
     // n3 has no "color" property
 
     // $ne: "red" should match n2 (blue) but NOT n3 (no color)

--- a/crates/grafeo-engine/tests/vector_incremental.rs
+++ b/crates/grafeo-engine/tests/vector_incremental.rs
@@ -18,17 +18,20 @@ fn test_incremental_insert_via_set_property() {
     let db = GrafeoDB::new_in_memory();
 
     // Create initial nodes and build index
-    let n1 = db.create_node(&["Doc"]);
-    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
-    let n2 = db.create_node(&["Doc"]);
-    db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0));
+    let n1 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+        .unwrap();
+    let n2 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0))
+        .unwrap();
 
     db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
         .expect("create index");
 
     // Add a new node AFTER index creation
-    let n3 = db.create_node(&["Doc"]);
-    db.set_node_property(n3, "emb", vec3(0.9, 0.1, 0.0));
+    let n3 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n3, "emb", vec3(0.9, 0.1, 0.0))
+        .unwrap();
 
     // Search should find the new node (closest to [1, 0, 0])
     let results = db
@@ -51,8 +54,9 @@ fn test_repeated_vector_update_preserves_hnsw_reachability() {
         let mut nodes = Vec::with_capacity(NODE_COUNT);
 
         for offset in 0..NODE_COUNT {
-            let node = db.create_node(&["Doc"]);
-            db.set_node_property(node, "emb", vec3(0.5 + offset as f32 * 0.01, 0.0, 0.0));
+            let node = db.create_node(&["Doc"]).unwrap();
+            db.set_node_property(node, "emb", vec3(0.5 + offset as f32 * 0.01, 0.0, 0.0))
+                .unwrap();
             nodes.push(node);
         }
 
@@ -61,7 +65,8 @@ fn test_repeated_vector_update_preserves_hnsw_reachability() {
 
         let target = nodes[NODE_COUNT / 2];
         for _ in 0..5 {
-            db.set_node_property(target, "emb", vec3(0.53, 0.0, 0.0));
+            db.set_node_property(target, "emb", vec3(0.53, 0.0, 0.0))
+                .unwrap();
         }
 
         let results = db
@@ -80,17 +85,21 @@ fn test_repeated_vector_update_preserves_hnsw_reachability() {
 fn test_vector_replacement_moves_node_without_losing_neighbors() {
     let db = GrafeoDB::new_in_memory();
 
-    let left = db.create_node(&["Doc"]);
-    db.set_node_property(left, "emb", vec3(1.0, 0.0, 0.0));
-    let moving = db.create_node(&["Doc"]);
-    db.set_node_property(moving, "emb", vec3(0.9, 0.1, 0.0));
-    let right = db.create_node(&["Doc"]);
-    db.set_node_property(right, "emb", vec3(0.0, 1.0, 0.0));
+    let left = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(left, "emb", vec3(1.0, 0.0, 0.0))
+        .unwrap();
+    let moving = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(moving, "emb", vec3(0.9, 0.1, 0.0))
+        .unwrap();
+    let right = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(right, "emb", vec3(0.0, 1.0, 0.0))
+        .unwrap();
 
     db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
         .expect("create index");
 
-    db.set_node_property(moving, "emb", vec3(0.0, 0.99, 0.01));
+    db.set_node_property(moving, "emb", vec3(0.0, 0.99, 0.01))
+        .unwrap();
 
     let results = db
         .vector_search("Doc", "emb", &[0.0, 1.0, 0.0], 3, None, None)
@@ -122,8 +131,9 @@ fn test_incremental_batch_create_after_index() {
     let db = GrafeoDB::new_in_memory();
 
     // Create initial node and build index
-    let n1 = db.create_node(&["Doc"]);
-    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
+    let n1 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+        .unwrap();
 
     db.create_vector_index("Doc", "emb", Some(3), Some("euclidean"), None, None, None)
         .expect("create index");
@@ -146,18 +156,21 @@ fn test_incremental_batch_create_after_index() {
 fn test_delete_removes_from_index() {
     let db = GrafeoDB::new_in_memory();
 
-    let n1 = db.create_node(&["Doc"]);
-    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
-    let n2 = db.create_node(&["Doc"]);
-    db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0));
-    let n3 = db.create_node(&["Doc"]);
-    db.set_node_property(n3, "emb", vec3(0.0, 0.0, 1.0));
+    let n1 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+        .unwrap();
+    let n2 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0))
+        .unwrap();
+    let n3 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n3, "emb", vec3(0.0, 0.0, 1.0))
+        .unwrap();
 
     db.create_vector_index("Doc", "emb", Some(3), Some("euclidean"), None, None, None)
         .expect("create index");
 
     // Delete n2
-    assert!(db.delete_node(n2));
+    assert!(db.delete_node(n2).unwrap());
 
     // Search should NOT return n2
     let results = db
@@ -177,15 +190,17 @@ fn test_label_after_vector_triggers_index() {
     let db = GrafeoDB::new_in_memory();
 
     // Build index on "Doc:emb" with an initial node
-    let n1 = db.create_node(&["Doc"]);
-    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
+    let n1 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+        .unwrap();
 
     db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
         .expect("create index");
 
     // Create a node WITHOUT the "Doc" label, set vector, THEN add label
-    let n2 = db.create_node(&["Other"]);
-    db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0));
+    let n2 = db.create_node(&["Other"]).unwrap();
+    db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0))
+        .unwrap();
     // At this point n2 has label "Other", not "Doc": no index match
     db.add_node_label(n2, "Doc");
     // Now n2 has "Doc" label, should trigger auto-insert
@@ -205,8 +220,9 @@ fn test_label_after_vector_triggers_index() {
 fn test_drop_vector_index() {
     let db = GrafeoDB::new_in_memory();
 
-    let n1 = db.create_node(&["Doc"]);
-    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
+    let n1 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+        .unwrap();
 
     db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
         .expect("create index");
@@ -232,17 +248,20 @@ fn test_drop_vector_index() {
 fn test_rebuild_vector_index() {
     let db = GrafeoDB::new_in_memory();
 
-    let n1 = db.create_node(&["Doc"]);
-    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
+    let n1 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+        .unwrap();
 
     db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
         .expect("create index");
 
     // Add more nodes
-    let n2 = db.create_node(&["Doc"]);
-    db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0));
-    let n3 = db.create_node(&["Doc"]);
-    db.set_node_property(n3, "emb", vec3(0.0, 0.0, 1.0));
+    let n2 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n2, "emb", vec3(0.0, 1.0, 0.0))
+        .unwrap();
+    let n3 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n3, "emb", vec3(0.0, 0.0, 1.0))
+        .unwrap();
 
     // Rebuild rescans all nodes
     db.rebuild_vector_index("Doc", "emb").expect("rebuild");
@@ -265,8 +284,9 @@ fn test_set_vector_without_index_is_noop() {
     let db = GrafeoDB::new_in_memory();
 
     // No vector index exists: setting a vector property should not crash
-    let n1 = db.create_node(&["Doc"]);
-    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
+    let n1 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+        .unwrap();
 
     // Node should exist with the property
     let node = db.get_node(n1);

--- a/crates/grafeo-engine/tests/vector_incremental.rs
+++ b/crates/grafeo-engine/tests/vector_incremental.rs
@@ -42,6 +42,82 @@ fn test_incremental_insert_via_set_property() {
 }
 
 #[test]
+fn test_repeated_vector_update_preserves_hnsw_reachability() {
+    const ITERATIONS: usize = 60;
+    const NODE_COUNT: usize = 6;
+
+    for iteration in 0..ITERATIONS {
+        let db = GrafeoDB::new_in_memory();
+        let mut nodes = Vec::with_capacity(NODE_COUNT);
+
+        for offset in 0..NODE_COUNT {
+            let node = db.create_node(&["Doc"]);
+            db.set_node_property(node, "emb", vec3(0.5 + offset as f32 * 0.01, 0.0, 0.0));
+            nodes.push(node);
+        }
+
+        db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
+            .expect("create index");
+
+        let target = nodes[NODE_COUNT / 2];
+        for _ in 0..5 {
+            db.set_node_property(target, "emb", vec3(0.53, 0.0, 0.0));
+        }
+
+        let results = db
+            .vector_search("Doc", "emb", &[0.5, 0.0, 0.0], NODE_COUNT, None, None)
+            .expect("search");
+
+        assert_eq!(
+            results.len(),
+            NODE_COUNT,
+            "same-ID vector replay must not disconnect HNSW nodes (iteration {iteration})"
+        );
+    }
+}
+
+#[test]
+fn test_vector_replacement_moves_node_without_losing_neighbors() {
+    let db = GrafeoDB::new_in_memory();
+
+    let left = db.create_node(&["Doc"]);
+    db.set_node_property(left, "emb", vec3(1.0, 0.0, 0.0));
+    let moving = db.create_node(&["Doc"]);
+    db.set_node_property(moving, "emb", vec3(0.9, 0.1, 0.0));
+    let right = db.create_node(&["Doc"]);
+    db.set_node_property(right, "emb", vec3(0.0, 1.0, 0.0));
+
+    db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
+        .expect("create index");
+
+    db.set_node_property(moving, "emb", vec3(0.0, 0.99, 0.01));
+
+    let results = db
+        .vector_search("Doc", "emb", &[0.0, 1.0, 0.0], 3, None, None)
+        .expect("search");
+    let ids: Vec<u64> = results.iter().map(|(id, _)| id.as_u64()).collect();
+
+    assert_eq!(
+        results.len(),
+        3,
+        "replacement must keep all nodes reachable"
+    );
+    assert_eq!(
+        ids.first(),
+        Some(&right.as_u64()),
+        "the unchanged nearest node should remain first"
+    );
+    assert!(
+        ids.contains(&moving.as_u64()),
+        "the replaced vector must remain indexed"
+    );
+    assert!(
+        ids.contains(&left.as_u64()),
+        "unrelated nodes must remain indexed"
+    );
+}
+
+#[test]
 fn test_incremental_batch_create_after_index() {
     let db = GrafeoDB::new_in_memory();
 

--- a/crates/grafeo-engine/tests/vector_pushdown_boundary.rs
+++ b/crates/grafeo-engine/tests/vector_pushdown_boundary.rs
@@ -40,9 +40,11 @@ fn setup_euclidean_fixture() -> GrafeoDB {
         ("d07", 0.7),
         ("d09", 0.9),
     ] {
-        let n = db.create_node(&["Item"]);
-        db.set_node_property(n, "label", Value::String(label.into()));
-        db.set_node_property(n, "vec", Value::Vector(vec![d, 0.0, 0.0].into()));
+        let n = db.create_node(&["Item"]).unwrap();
+        db.set_node_property(n, "label", Value::String(label.into()))
+            .unwrap();
+        db.set_node_property(n, "vec", Value::Vector(vec![d, 0.0, 0.0].into()))
+            .unwrap();
     }
     db.create_vector_index("Item", "vec", Some(3), Some("euclidean"), None, None, None)
         .expect("create vector index");
@@ -95,9 +97,11 @@ fn setup_manhattan_fixture() -> GrafeoDB {
         ("d07", 0.7),
         ("d09", 0.9),
     ] {
-        let n = db.create_node(&["Item"]);
-        db.set_node_property(n, "label", Value::String(label.into()));
-        db.set_node_property(n, "vec", Value::Vector(vec![d, 0.0, 0.0].into()));
+        let n = db.create_node(&["Item"]).unwrap();
+        db.set_node_property(n, "label", Value::String(label.into()))
+            .unwrap();
+        db.set_node_property(n, "vec", Value::Vector(vec![d, 0.0, 0.0].into()))
+            .unwrap();
     }
     db.create_vector_index("Item", "vec", Some(3), Some("manhattan"), None, None, None)
         .expect("create vector index");

--- a/crates/grafeo-engine/tests/vector_quant_reopen.rs
+++ b/crates/grafeo-engine/tests/vector_quant_reopen.rs
@@ -1,0 +1,150 @@
+//! Disk reopen tests for durable vector index quantization (V2-QUANT).
+//!
+//! Layer 2 acceptance:
+//! create(mode) → insert vectors → checkpoint → close → reopen →
+//! inspect mode matches + search returns the seeded top-1 neighbor.
+//!
+//! Product quant is schema-supported; reopen oracle deferred for cost
+//! (schema field still round-trips via Catalog unit tests).
+
+#![cfg(all(feature = "vector-index", feature = "grafeo-file", feature = "lpg"))]
+
+use grafeo_common::types::Value;
+use grafeo_core::index::vector::QuantizationType;
+use grafeo_engine::{Config, GrafeoDB};
+
+fn seeded_vector(seed: u64, dim: usize) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+    let mut raw: Vec<f32> = (0..dim)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1);
+            ((state >> 33) as f32) / (u32::MAX as f32) * 2.0 - 1.0
+        })
+        .collect();
+    let norm: f32 = raw.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in &mut raw {
+            *x /= norm;
+        }
+    }
+    raw
+}
+
+fn reopen_mode_and_search(mode: Option<&str>, expected: QuantizationType) {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    // Prefer /data/tmp when TMPDIR is set by the host; tempfile honors TMPDIR.
+    let path = dir
+        .path()
+        .join(format!("v2_quant_{}.grafeo", expected.name()));
+    let dim = 16;
+    let n = 40;
+    let query = seeded_vector(0, dim);
+
+    let (top1_before, heap_before) = {
+        let db = GrafeoDB::with_config(Config::persistent(&path)).expect("create db");
+        let mut first_id = None;
+        for i in 0..n {
+            let node = db.create_node(&["Doc"]).expect("node");
+            if i == 0 {
+                first_id = Some(node);
+            }
+            db.set_node_property(
+                node,
+                "emb",
+                Value::Vector(seeded_vector(i as u64, dim).into()),
+            )
+            .expect("emb");
+        }
+        db.create_vector_index("Doc", "emb", Some(dim), Some("cosine"), None, None, mode)
+            .expect("create vector index");
+
+        assert!(db.has_vector_index("Doc", "emb"));
+        assert_eq!(
+            db.vector_index_quantization("Doc", "emb"),
+            Some(expected),
+            "inspect after create"
+        );
+
+        let results = db
+            .vector_search("Doc", "emb", &query, 3, None, None)
+            .expect("search before");
+        assert!(!results.is_empty(), "search ready before close");
+        let top1 = results[0].0;
+        assert_eq!(top1, first_id.expect("first"), "query0 should prefer seed0");
+        let heap = db
+            .vector_index_heap_memory_bytes("Doc", "emb")
+            .expect("heap");
+
+        db.wal_checkpoint().expect("checkpoint");
+        db.close().expect("close");
+        (top1, heap)
+    };
+
+    let db = GrafeoDB::open(&path).expect("reopen");
+    assert!(
+        db.has_vector_index("Doc", "emb"),
+        "index registered after reopen"
+    );
+    assert_eq!(
+        db.vector_index_quantization("Doc", "emb"),
+        Some(expected),
+        "mode sticky after reopen (Catalog authority)"
+    );
+
+    let results = db
+        .vector_search("Doc", "emb", &query, 3, None, None)
+        .expect("search after reopen");
+    assert!(!results.is_empty(), "search ready after reopen");
+    assert_eq!(
+        results[0].0, top1_before,
+        "top-1 neighbor identity preserved for synthetic fixture"
+    );
+
+    let heap_after = db
+        .vector_index_heap_memory_bytes("Doc", "emb")
+        .expect("heap after");
+    // Not a pass/fail RSS gate — record order-of-magnitude sanity only.
+    assert!(
+        heap_after > 0 && heap_before > 0,
+        "heap helpers must report non-zero after rehydrate/create (before={heap_before} after={heap_after})"
+    );
+
+    db.close().ok();
+}
+
+#[test]
+fn quant_reopen_none_mode() {
+    reopen_mode_and_search(None, QuantizationType::None);
+    reopen_mode_and_search(Some("none"), QuantizationType::None);
+}
+
+#[test]
+fn quant_reopen_scalar_mode() {
+    reopen_mode_and_search(Some("scalar"), QuantizationType::Scalar);
+}
+
+#[test]
+fn quant_reopen_binary_mode() {
+    reopen_mode_and_search(Some("binary"), QuantizationType::Binary);
+}
+
+#[test]
+fn inspect_api_missing_vs_plain() {
+    let db = GrafeoDB::new_in_memory();
+    assert!(!db.has_vector_index("Doc", "emb"));
+    assert_eq!(db.vector_index_quantization("Doc", "emb"), None);
+    assert_eq!(db.vector_index_heap_memory_bytes("Doc", "emb"), None);
+
+    let node = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(node, "emb", Value::Vector(seeded_vector(1, 4).into()))
+        .unwrap();
+    db.create_vector_index("Doc", "emb", Some(4), Some("cosine"), None, None, None)
+        .unwrap();
+    assert!(db.has_vector_index("Doc", "emb"));
+    assert_eq!(
+        db.vector_index_quantization("Doc", "emb"),
+        Some(QuantizationType::None)
+    );
+}

--- a/crates/grafeo-engine/tests/vector_search_procedures.rs
+++ b/crates/grafeo-engine/tests/vector_search_procedures.rs
@@ -16,15 +16,18 @@ fn vec3(x: f32, y: f32, z: f32) -> Value {
 
 fn setup_vector_graph() -> GrafeoDB {
     let db = GrafeoDB::new_in_memory();
-    let n1 = db.create_node(&["Doc"]);
-    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0));
-    db.set_node_property(n1, "title", Value::from("A"));
-    let n2 = db.create_node(&["Doc"]);
-    db.set_node_property(n2, "emb", vec3(0.9, 0.1, 0.0));
-    db.set_node_property(n2, "title", Value::from("B"));
-    let n3 = db.create_node(&["Doc"]);
-    db.set_node_property(n3, "emb", vec3(0.0, 1.0, 0.0));
-    db.set_node_property(n3, "title", Value::from("C"));
+    let n1 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n1, "emb", vec3(1.0, 0.0, 0.0))
+        .unwrap();
+    db.set_node_property(n1, "title", Value::from("A")).unwrap();
+    let n2 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n2, "emb", vec3(0.9, 0.1, 0.0))
+        .unwrap();
+    db.set_node_property(n2, "title", Value::from("B")).unwrap();
+    let n3 = db.create_node(&["Doc"]).unwrap();
+    db.set_node_property(n3, "emb", vec3(0.0, 1.0, 0.0))
+        .unwrap();
+    db.set_node_property(n3, "title", Value::from("C")).unwrap();
 
     db.create_vector_index("Doc", "emb", Some(3), Some("cosine"), None, None, None)
         .expect("create vector index");
@@ -171,12 +174,15 @@ mod text {
 
     fn setup_text_graph() -> GrafeoDB {
         let db = GrafeoDB::new_in_memory();
-        let n1 = db.create_node(&["Doc"]);
-        db.set_node_property(n1, "body", Value::from("graph databases are great"));
-        let n2 = db.create_node(&["Doc"]);
-        db.set_node_property(n2, "body", Value::from("vector search for retrieval"));
-        let n3 = db.create_node(&["Doc"]);
-        db.set_node_property(n3, "body", Value::from("graph neural networks for nlp"));
+        let n1 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n1, "body", Value::from("graph databases are great"))
+            .unwrap();
+        let n2 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n2, "body", Value::from("vector search for retrieval"))
+            .unwrap();
+        let n3 = db.create_node(&["Doc"]).unwrap();
+        db.set_node_property(n3, "body", Value::from("graph neural networks for nlp"))
+            .unwrap();
 
         db.create_text_index("Doc", "body")
             .expect("create text index");

--- a/crates/grafeo-engine/tests/vector_spill.rs
+++ b/crates/grafeo-engine/tests/vector_spill.rs
@@ -12,6 +12,24 @@ use grafeo_common::storage::{SectionMemoryConfig, SectionType, TierOverride};
 use grafeo_common::types::Value;
 use grafeo_engine::{Config, GrafeoDB};
 
+fn force_disk_config(db_path: &std::path::Path, spill_path: &std::path::Path) -> Config {
+    Config::persistent(db_path)
+        .with_spill_path(spill_path)
+        .with_section_tier(SectionType::VectorStore, TierOverride::ForceDisk)
+}
+
+fn assert_exact_hit(db: &GrafeoDB, expected: grafeo_common::types::NodeId, query: &[f32]) {
+    let results = db
+        .vector_search("Item", "embedding", query, 2, None, None)
+        .unwrap();
+    assert_eq!(results.first().map(|hit| hit.0), Some(expected));
+    assert!(
+        results[0].1 < 1.0e-6,
+        "expected exact vector distance, got {}",
+        results[0].1
+    );
+}
+
 fn make_embedding(seed: u64, dim: usize) -> Vec<f32> {
     (0..dim)
         .map(|i| ((seed * 7 + i as u64) % 100) as f32 / 100.0)
@@ -147,5 +165,106 @@ fn checkpoint_after_spill_preserves_non_vector_data() {
             "should find the node after reopen"
         );
         assert_eq!(result.rows()[0][0], Value::from("test"));
+    }
+}
+
+#[test]
+#[cfg(all(
+    feature = "vector-index",
+    feature = "mmap",
+    feature = "grafeo-file",
+    not(feature = "temporal")
+))]
+fn force_disk_fresh_mutate_checkpoint_close_reopen_search() {
+    use grafeo_common::memory::StorageTier;
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("fresh_lifecycle.grafeo");
+    let spill_path = dir.path().join("fresh_lifecycle.spill");
+    let first = vec![1.0, 0.0, 0.0, 0.0];
+    let updated = vec![0.0, 1.0, 0.0, 0.0];
+    let node;
+
+    {
+        let db = GrafeoDB::with_config(force_disk_config(&db_path, &spill_path)).unwrap();
+        node = db.create_node(&["Item"]).unwrap();
+        db.set_node_property(node, "embedding", Value::Vector(first.clone().into()))
+            .unwrap();
+        db.create_vector_index("Item", "embedding", Some(4), None, None, None, None)
+            .unwrap();
+
+        db.wal_checkpoint().unwrap();
+        assert_eq!(
+            db.storage_tiers().get(&SectionType::VectorStore),
+            Some(&StorageTier::OnDisk),
+            "checkpoint must enforce ForceDisk for indexes created after open"
+        );
+        assert_exact_hit(&db, node, &first);
+
+        db.set_node_property(node, "embedding", Value::Vector(updated.clone().into()))
+            .unwrap();
+        assert_exact_hit(&db, node, &updated);
+        db.wal_checkpoint().unwrap();
+        assert_eq!(
+            db.storage_tiers().get(&SectionType::VectorStore),
+            Some(&StorageTier::OnDisk)
+        );
+        db.close().unwrap();
+    }
+
+    {
+        let db = GrafeoDB::with_config(force_disk_config(&db_path, &spill_path)).unwrap();
+        assert_eq!(
+            db.storage_tiers().get(&SectionType::VectorStore),
+            Some(&StorageTier::OnDisk)
+        );
+        assert_exact_hit(&db, node, &updated);
+        db.close().unwrap();
+    }
+
+    // The container remains authoritative: switching ForceDisk off must not
+    // depend on a spill sidecar to recover the latest vector.
+    {
+        let db = GrafeoDB::with_config(Config::persistent(&db_path)).unwrap();
+        assert_exact_hit(&db, node, &updated);
+        db.close().unwrap();
+    }
+}
+
+#[test]
+#[cfg(all(
+    feature = "vector-index",
+    feature = "mmap",
+    feature = "grafeo-file",
+    not(feature = "temporal")
+))]
+fn existing_auto_graph_reopens_and_searches_under_force_disk() {
+    use grafeo_common::memory::StorageTier;
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("existing_lifecycle.grafeo");
+    let spill_path = dir.path().join("existing_lifecycle.spill");
+    let embedding = vec![0.0, 0.0, 1.0, 0.0];
+    let node;
+
+    {
+        let db = GrafeoDB::with_config(Config::persistent(&db_path)).unwrap();
+        node = db.create_node(&["Item"]).unwrap();
+        db.set_node_property(node, "embedding", Value::Vector(embedding.clone().into()))
+            .unwrap();
+        db.create_vector_index("Item", "embedding", Some(4), None, None, None, None)
+            .unwrap();
+        db.wal_checkpoint().unwrap();
+        db.close().unwrap();
+    }
+
+    {
+        let db = GrafeoDB::with_config(force_disk_config(&db_path, &spill_path)).unwrap();
+        assert_eq!(
+            db.storage_tiers().get(&SectionType::VectorStore),
+            Some(&StorageTier::OnDisk)
+        );
+        assert_exact_hit(&db, node, &embedding);
+        db.close().unwrap();
     }
 }

--- a/crates/grafeo-engine/tests/vector_spill.rs
+++ b/crates/grafeo-engine/tests/vector_spill.rs
@@ -38,10 +38,12 @@ fn force_disk_spills_and_search_works() {
     let dim = 8;
     let mut node_ids = Vec::new();
     for i in 1..=10 {
-        let id = db.create_node(&["Item"]);
+        let id = db.create_node(&["Item"]).unwrap();
         let embedding = make_embedding(i, dim);
-        db.set_node_property(id, "name", Value::from(format!("item_{i}")));
-        db.set_node_property(id, "embedding", Value::Vector(embedding.into()));
+        db.set_node_property(id, "name", Value::from(format!("item_{i}")))
+            .unwrap();
+        db.set_node_property(id, "embedding", Value::Vector(embedding.into()))
+            .unwrap();
         node_ids.push(id);
     }
 
@@ -115,13 +117,15 @@ fn checkpoint_after_spill_preserves_non_vector_data() {
         let config = Config::persistent(&db_path);
         let db = GrafeoDB::with_config(config).unwrap();
 
-        let id = db.create_node(&["Item"]);
-        db.set_node_property(id, "name", Value::from("test"));
+        let id = db.create_node(&["Item"]).unwrap();
+        db.set_node_property(id, "name", Value::from("test"))
+            .unwrap();
         db.set_node_property(
             id,
             "embedding",
             Value::Vector(vec![1.0, 2.0, 3.0, 4.0].into()),
-        );
+        )
+        .unwrap();
         db.create_vector_index("Item", "embedding", Some(4), None, None, None, None)
             .unwrap();
 

--- a/crates/grafeo-engine/tests/wal_directory.rs
+++ b/crates/grafeo-engine/tests/wal_directory.rs
@@ -22,10 +22,12 @@ mod wal_directory {
         {
             let config = Config::persistent(&path).with_storage_format(StorageFormat::WalDirectory);
             let db = GrafeoDB::with_config(config).expect("open for write");
-            let a = db.create_node(&["Person"]);
-            db.set_node_property(a, "name", Value::String("Alix".into()));
-            let b = db.create_node(&["Person"]);
-            db.set_node_property(b, "name", Value::String("Gus".into()));
+            let a = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(a, "name", Value::String("Alix".into()))
+                .unwrap();
+            let b = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(b, "name", Value::String("Gus".into()))
+                .unwrap();
             db.create_edge(a, b, "KNOWS");
             db.close().expect("close");
         }
@@ -52,10 +54,12 @@ mod wal_directory {
             let db = GrafeoDB::with_config(config).expect("open for write");
 
             // Write nodes BEFORE rotation (these go into wal_0.log)
-            let a = db.create_node(&["Person"]);
-            db.set_node_property(a, "name", Value::String("Alix".into()));
-            let b = db.create_node(&["Person"]);
-            db.set_node_property(b, "name", Value::String("Gus".into()));
+            let a = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(a, "name", Value::String("Alix".into()))
+                .unwrap();
+            let b = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(b, "name", Value::String("Gus".into()))
+                .unwrap();
             db.create_edge(a, b, "KNOWS");
 
             // Force WAL rotation so current_sequence advances
@@ -63,8 +67,9 @@ mod wal_directory {
             wal.rotate().expect("rotate WAL");
 
             // Write more nodes AFTER rotation (these go into wal_1.log)
-            let c = db.create_node(&["Person"]);
-            db.set_node_property(c, "name", Value::String("Vincent".into()));
+            let c = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(c, "name", Value::String("Vincent".into()))
+                .unwrap();
 
             db.close().expect("close");
         }
@@ -118,7 +123,8 @@ mod wal_directory {
                 db.create_node_with_props(
                     &["Batch"],
                     [("cycle", Value::Int64(1)), ("idx", Value::Int64(i))],
-                );
+                )
+                .unwrap();
             }
             db.close().expect("close");
         }
@@ -131,14 +137,16 @@ mod wal_directory {
                 db.create_node_with_props(
                     &["Batch"],
                     [("cycle", Value::Int64(2)), ("idx", Value::Int64(i))],
-                );
+                )
+                .unwrap();
             }
             db.wal().expect("wal").rotate().expect("rotate");
             for i in 0..3 {
                 db.create_node_with_props(
                     &["Batch"],
                     [("cycle", Value::Int64(2)), ("idx", Value::Int64(10 + i))],
-                );
+                )
+                .unwrap();
             }
             db.close().expect("close");
         }
@@ -176,8 +184,9 @@ mod wal_directory {
         {
             let config = Config::persistent(&path).with_storage_format(StorageFormat::WalDirectory);
             let db = GrafeoDB::with_config(config).expect("open");
-            let n = db.create_node(&["Person"]);
-            db.set_node_property(n, "name", Value::String("Alix".into()));
+            let n = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(n, "name", Value::String("Alix".into()))
+                .unwrap();
             // intentionally no db.close(), Drop handles it
         }
 
@@ -212,9 +221,10 @@ mod wal_directory {
 
         // First batch: create nodes with properties
         for i in 0..10 {
-            let id = db.create_node(&["Person"]);
-            db.set_node_property(id, "name", Value::from(format!("Node{i}")));
-            db.set_node_property(id, "index", Value::Int64(i));
+            let id = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(id, "name", Value::from(format!("Node{i}")))
+                .unwrap();
+            db.set_node_property(id, "index", Value::Int64(i)).unwrap();
         }
 
         // Sleep long enough to trigger Batch mode sync threshold (default 100ms)
@@ -223,9 +233,10 @@ mod wal_directory {
         // Second batch: this would deadlock before the fix because the first
         // write_frame triggers sync_all() while holding active_log.
         for i in 10..20 {
-            let id = db.create_node(&["Person"]);
-            db.set_node_property(id, "name", Value::from(format!("Node{i}")));
-            db.set_node_property(id, "index", Value::Int64(i));
+            let id = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(id, "name", Value::from(format!("Node{i}")))
+                .unwrap();
+            db.set_node_property(id, "index", Value::Int64(i)).unwrap();
         }
 
         assert_eq!(db.node_count(), 20);
@@ -248,7 +259,7 @@ mod wal_directory {
         {
             let config = Config::persistent(&path).with_storage_format(StorageFormat::WalDirectory);
             let db = GrafeoDB::with_config(config).expect("open");
-            db.create_node(&["Test"]);
+            db.create_node(&["Test"]).unwrap();
             db.close().expect("close");
         }
 
@@ -332,16 +343,20 @@ mod wal_directory {
             let config = Config::persistent(&path).with_storage_format(StorageFormat::WalDirectory);
             let db = GrafeoDB::with_config(config).expect("open");
 
-            let a = db.create_node(&["Person"]);
-            db.set_node_property(a, "name", Value::String("Alix".into()));
-            db.set_node_property(a, "temp", Value::String("remove_me".into()));
+            let a = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(a, "name", Value::String("Alix".into()))
+                .unwrap();
+            db.set_node_property(a, "temp", Value::String("remove_me".into()))
+                .unwrap();
             db.remove_node_property(a, "temp");
 
-            let b = db.create_node(&["Person"]);
-            db.set_node_property(b, "name", Value::String("Gus".into()));
+            let b = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(b, "name", Value::String("Gus".into()))
+                .unwrap();
 
-            let c = db.create_node(&["Person"]);
-            db.set_node_property(c, "name", Value::String("Vincent".into()));
+            let c = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(c, "name", Value::String("Vincent".into()))
+                .unwrap();
 
             let e1 = db.create_edge(a, b, "KNOWS");
             db.set_edge_property(e1, "weight", Value::Float64(0.8));
@@ -350,7 +365,7 @@ mod wal_directory {
 
             // Delete the edge first, then the node (CRUD API does not detach)
             db.delete_edge(e2);
-            db.delete_node(c);
+            db.delete_node(c).unwrap();
 
             db.close().expect("close");
         }

--- a/crates/grafeo-engine/tests/wal_recovery.rs
+++ b/crates/grafeo-engine/tests/wal_recovery.rs
@@ -20,11 +20,13 @@ mod wal {
         // Create and populate
         {
             let db = GrafeoDB::open(&path).expect("open for write");
-            let a = db.create_node(&["Person"]);
-            db.set_node_property(a, "name", Value::String("Alix".into()));
-            db.set_node_property(a, "age", Value::Int64(30));
-            let b = db.create_node(&["Person"]);
-            db.set_node_property(b, "name", Value::String("Gus".into()));
+            let a = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(a, "name", Value::String("Alix".into()))
+                .unwrap();
+            db.set_node_property(a, "age", Value::Int64(30)).unwrap();
+            let b = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(b, "name", Value::String("Gus".into()))
+                .unwrap();
             db.create_edge(a, b, "KNOWS");
             db.close().expect("close");
         }
@@ -53,7 +55,7 @@ mod wal {
 
         {
             let db = GrafeoDB::open(&path).expect("open");
-            let n = db.create_node(&["Person"]);
+            let n = db.create_node(&["Person"]).unwrap();
             db.add_node_label(n, "Employee");
             db.close().expect("close");
         }
@@ -74,16 +76,19 @@ mod wal {
 
         {
             let db = GrafeoDB::open(&path).expect("open");
-            let a = db.create_node(&["Person"]);
-            db.set_node_property(a, "name", Value::String("Alix".into()));
-            let b = db.create_node(&["Person"]);
-            db.set_node_property(b, "name", Value::String("Gus".into()));
-            let c = db.create_node(&["Person"]);
-            db.set_node_property(c, "name", Value::String("Harm".into()));
+            let a = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(a, "name", Value::String("Alix".into()))
+                .unwrap();
+            let b = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(b, "name", Value::String("Gus".into()))
+                .unwrap();
+            let c = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(c, "name", Value::String("Harm".into()))
+                .unwrap();
             db.create_edge(a, b, "KNOWS");
 
             // Delete Harm (no edges)
-            db.delete_node(c);
+            db.delete_node(c).unwrap();
             db.close().expect("close");
         }
 
@@ -105,10 +110,12 @@ mod wal {
         let save_path = dir.path().join("saved.grafeo");
 
         let db = GrafeoDB::new_in_memory();
-        let a = db.create_node(&["Person"]);
-        db.set_node_property(a, "name", Value::String("Alix".into()));
-        let b = db.create_node(&["Person"]);
-        db.set_node_property(b, "name", Value::String("Gus".into()));
+        let a = db.create_node(&["Person"]).unwrap();
+        db.set_node_property(a, "name", Value::String("Alix".into()))
+            .unwrap();
+        let b = db.create_node(&["Person"]).unwrap();
+        db.set_node_property(b, "name", Value::String("Gus".into()))
+            .unwrap();
         db.create_edge(a, b, "KNOWS");
 
         // Save in-memory database to disk
@@ -129,8 +136,9 @@ mod wal {
         // Create persistent database
         {
             let db = GrafeoDB::open(&path).expect("open");
-            let n = db.create_node(&["Person"]);
-            db.set_node_property(n, "name", Value::String("Alix".into()));
+            let n = db.create_node(&["Person"]).unwrap();
+            db.set_node_property(n, "name", Value::String("Alix".into()))
+                .unwrap();
             db.close().expect("close");
         }
 
@@ -143,7 +151,7 @@ mod wal {
         );
 
         // Modifications to the in-memory copy don't affect the file
-        mem_db.create_node(&["Extra"]);
+        mem_db.create_node(&["Extra"]).expect("create extra node");
         assert_eq!(mem_db.node_count(), 2);
 
         // Reopening the file should still show 1 node
@@ -158,7 +166,7 @@ mod wal {
         let path = dir.path().join("status.grafeo");
 
         let db = GrafeoDB::open(&path).expect("open");
-        db.create_node(&["N"]);
+        db.create_node(&["N"]).unwrap();
 
         let status = db.wal_status();
         assert!(status.enabled, "persistent db should have WAL enabled");
@@ -285,8 +293,9 @@ mod wal {
         let path = dir.path().join("checkpoint.grafeo");
 
         let db = GrafeoDB::open(&path).expect("open");
-        let n = db.create_node(&["Person"]);
-        db.set_node_property(n, "name", Value::String("Alix".into()));
+        let n = db.create_node(&["Person"]).unwrap();
+        db.set_node_property(n, "name", Value::String("Alix".into()))
+            .unwrap();
 
         // Explicit checkpoint should not error
         db.wal_checkpoint().expect("checkpoint should succeed");
@@ -477,8 +486,9 @@ mod wal {
 
         {
             let db = GrafeoDB::open(&path).expect("open");
-            let n = db.create_node(&["Config"]);
-            db.set_node_property(n, "name", Value::String("settings".into()));
+            let n = db.create_node(&["Config"]).unwrap();
+            db.set_node_property(n, "name", Value::String("settings".into()))
+                .unwrap();
             let mut map = std::collections::BTreeMap::new();
             map.insert(
                 grafeo_common::types::PropertyKey::from("theme"),
@@ -488,7 +498,8 @@ mod wal {
                 grafeo_common::types::PropertyKey::from("font_size"),
                 Value::Int64(14),
             );
-            db.set_node_property(n, "prefs", Value::Map(std::sync::Arc::new(map)));
+            db.set_node_property(n, "prefs", Value::Map(std::sync::Arc::new(map)))
+                .unwrap();
             db.close().expect("close");
         }
 
@@ -520,11 +531,13 @@ mod wal {
 
         {
             let db = GrafeoDB::open(&path).expect("open");
-            let n = db.create_node(&["Document"]);
-            db.set_node_property(n, "name", Value::String("doc1".into()));
+            let n = db.create_node(&["Document"]).unwrap();
+            db.set_node_property(n, "name", Value::String("doc1".into()))
+                .unwrap();
             let embedding: std::sync::Arc<[f32]> =
                 std::sync::Arc::from(vec![0.1_f32, 0.2, 0.3, 0.4]);
-            db.set_node_property(n, "embedding", Value::Vector(embedding));
+            db.set_node_property(n, "embedding", Value::Vector(embedding))
+                .unwrap();
             db.close().expect("close");
         }
 
@@ -553,10 +566,12 @@ mod wal {
 
         {
             let db = GrafeoDB::open(&path).expect("open");
-            let n = db.create_node(&["Event"]);
-            db.set_node_property(n, "name", Value::String("launch".into()));
+            let n = db.create_node(&["Event"]).unwrap();
+            db.set_node_property(n, "name", Value::String("launch".into()))
+                .unwrap();
             let ts = grafeo_common::types::Timestamp::from_secs(1_700_000_000);
-            db.set_node_property(n, "occurred_at", Value::Timestamp(ts));
+            db.set_node_property(n, "occurred_at", Value::Timestamp(ts))
+                .unwrap();
             db.close().expect("close");
         }
 
@@ -584,11 +599,13 @@ mod wal {
 
         {
             let db = GrafeoDB::open(&path).expect("open");
-            let n = db.create_node(&["Meeting"]);
-            db.set_node_property(n, "name", Value::String("standup".into()));
+            let n = db.create_node(&["Meeting"]).unwrap();
+            db.set_node_property(n, "name", Value::String("standup".into()))
+                .unwrap();
             let ts = grafeo_common::types::Timestamp::from_secs(1_700_000_000);
             let zdt = grafeo_common::types::ZonedDatetime::from_timestamp_offset(ts, 3600);
-            db.set_node_property(n, "scheduled_at", Value::ZonedDatetime(zdt));
+            db.set_node_property(n, "scheduled_at", Value::ZonedDatetime(zdt))
+                .unwrap();
             db.close().expect("close");
         }
 
@@ -617,10 +634,12 @@ mod wal {
 
         {
             let db = GrafeoDB::open(&path).expect("open");
-            let n = db.create_node(&["Task"]);
-            db.set_node_property(n, "name", Value::String("sprint".into()));
+            let n = db.create_node(&["Task"]).unwrap();
+            db.set_node_property(n, "name", Value::String("sprint".into()))
+                .unwrap();
             let dur = grafeo_common::types::Duration::new(0, 14, 0); // 14 days
-            db.set_node_property(n, "duration", Value::Duration(dur));
+            db.set_node_property(n, "duration", Value::Duration(dur))
+                .unwrap();
             db.close().expect("close");
         }
 

--- a/crates/grafeo/src/lib.rs
+++ b/crates/grafeo/src/lib.rs
@@ -65,6 +65,8 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 // Re-export the main database API
+#[cfg(feature = "vector-index")]
+pub use grafeo_engine::IndexedVectorRead;
 pub use grafeo_engine::{
     AccessMode, Catalog, CatalogError, Config, ConfigError, DurabilityMode, GrafeoDB, Grant,
     GraphModel, GraphStore, GraphStoreMut, Identity, IndexDefinition, IndexType, Role, Session,

--- a/docs/TRACK_E_LPG_RESIDENCY.md
+++ b/docs/TRACK_E_LPG_RESIDENCY.md
@@ -1,0 +1,33 @@
+# Track E — LPG residency accounting + compact/lazy experiments
+
+**Branch:** `diagnostics/lpg-memory-accounting`  
+**Base:** `9781320f` (`agent/txn-session-batch-20260726`)  
+**Separate from** diagnostics PR #2.
+
+## Attribution API
+
+Expanded `memory_usage` / property-column detail:
+- map slot bytes + capacity waste
+- decoded payload bytes
+- string payload bytes
+- compressed backing bytes
+- adjacency capacity accounting
+
+## Synthetic experiments (`lpg_residency_experiments`)
+
+Workload: 200k string properties, 256 unique 60-ish-char tokens.
+
+| Experiment | Estimated total | RSS anon | Point-get ns | Correctness |
+|------------|----------------:|---------:|-------------:|-------------|
+| Baseline | 24,640,531 B (~23.5 MiB) | 13,136 KiB | 208.7 | pass |
+| A `shrink_capacities` | same (waste Δ=0 on this fill) | 13,136 (Δ0) | 499.0 | pass |
+| B `force_compress_all` + lazy get | 4,018,259 B (−20.6 MiB est.) | 7,584 (Δ −5,552 KiB) | 171.0 | pass |
+
+## Relation to ~4 GiB production residual
+
+Phase3 heaptrack: open-stack attributed ~59% to PropertyColumn/deserialize/arcstr; residual ~4 GiB unattributed. Dictionary-compact strings show **large estimated payload reduction** on high-duplication string columns; production gain depends on unique-string cardinality of account/code graphs. Capacity shrink alone was a no-op on this synthetic fill.
+
+## Track F inputs
+
+- Live open residual still dominated by LPG property/string residency after jemalloc (~2.4 GiB help).
+- Compact dictionary representation is a promising in-process lever before process isolation.

--- a/docs/diagnostics/TRACK_E_LPG_MEMORY_ACCOUNTING.md
+++ b/docs/diagnostics/TRACK_E_LPG_MEMORY_ACCOUNTING.md
@@ -1,0 +1,85 @@
+# Track E — LPG memory accounting & compact/lazy residency
+
+**Branch:** `diagnostics/lpg-memory-accounting` (off product pin `9781320f` / `agent/txn-session-batch-20260726`)  
+**Worktree:** `/data/worktrees/grafeo-lpg-accounting`  
+**Staging policy:** `/data/tmp` only — never `/data/grafeo`  
+**Separate from:** AM diagnostics PR #2 / Grafeo `diagnostics/close-forensics`
+
+## Problem
+
+Phase 3/4 forensics (AM docs): live sidecar open ~9–12 GiB RssAnon; jemalloc recovers ~2.4 GiB; residual ~4 GiB consistent with LPG properties/strings/adjacency + allocator blind spots. Prior `memory_usage()` counted property **map slots** (`capacity × sizeof(Value)`) but **omitted decoded Value heap** (especially ArcStr), so Grafeo tracked only ~2.93 GiB (~32% of sidecar Δ) while heaptrack open stacks attributed ~59%.
+
+## Delivered APIs
+
+| API | Where | What |
+|-----|-------|------|
+| `PropertyStorage::memory_detail()` | `grafeo-core` | Per-column map slots, decoded payloads, string payloads, compressed bytes, capacity waste |
+| `PropertyColumn::memory_detail()` / updated `heap_memory_bytes()` | `grafeo-core` | Includes `Value::estimated_size_bytes` + compressed backing |
+| `PropertyStorage::shrink_capacities()` | `grafeo-core` | `shrink_to_fit` hot maps |
+| Compressed lazy `PropertyColumn::get` | `grafeo-core` | Binary-search `index_to_id` + on-demand decode (strings/bools/ints) |
+| `AdjacencyIndex::capacity_memory()` / `shrink_capacities()` | `grafeo-core` | Hot used vs capacity, cold, aux, waste |
+| `LpgStore::lpg_residency_detail()` / `shrink_lpg_capacities()` / `force_compress_properties()` | `grafeo-core` | Aggregated residency + experiment knobs |
+| `GrafeoDB::lpg_residency_detail()` (+ shrink/compress) | `grafeo-engine` | Operator-facing surface |
+| Types | `grafeo-common::memory` | `PropertyColumnMemory`, `PropertyStorageMemory`, `AdjacencyCapacityMemory`, `LpgResidencyMemory`; extended `StoreMemory` / `IndexMemory` fields |
+
+## Measured results (2026-07-29, synthetic N=200k, 256 unique ~60 B strings)
+
+Harness log: `/data/tmp/grafeo-lpg-accounting-track-e/grafeo-lpg-accounting-track-e-run.log`
+
+| Metric | Baseline | A shrink | B force_compress + lazy get |
+|--------|---------:|---------:|----------------------------:|
+| Estimated total (bytes) | 24,640,531 | 24,640,531 | **4,018,259** (−20.6 MiB / −84%) |
+| Map slots | 11,239,424 | same | (hot cleared into dict) |
+| String payload (hot) | 13,400,000 | same | **≪** (moved to compressed) |
+| Capacity waste | 1,439,424 | 1,439,424 (Δ0) | — |
+| Compressed bytes | 0 | 0 | **4,017,152** |
+| RssAnon (KiB) | 13,136 | 13,136 (Δ0) | **7,584 (Δ −5,552)** |
+| Point-get ns/op | 883.5 | 618.3 | **405.9** |
+| Correctness (200k gets) | PASS | PASS | **PASS** |
+
+### Interpretation
+
+- **A:** Post-fill `hashbrown` already sits at its load-factor capacity; `shrink_to_fit` does not reclaim meaningful RSS on this pattern. Still a safe operator knob after over-reserve / partial deletes.
+- **B:** Dictionary-compact + lazy decode is the clear win: estimated residency −84%, process RssAnon −5.4 MiB on a 200k toy, **and** point-get correctness holds (fixes the prior compressed-`get` → `None` hole). Production scale (Phase 3 ~1.44 GiB arcstr open stacks) is the extrapolation target — sidecar remeasure when MemAvailable allows.
+- Point-get latency **improved** after compress on this workload (dict + binary search beat hot HashMap+ArcStr clone path under the bench); treat as workload-specific, not a universal guarantee.
+
+## How to re-run
+
+```bash
+export TMPDIR=/data/tmp
+export CARGO_TARGET_DIR=/data/cargo-targets/jfrie-grafeo-lpg-accounting/target
+export RUSTC_WRAPPER=sccache SCCACHE_DIR=/data/sccache
+cargo test -p grafeo-core --test lpg_residency_experiments -- --nocapture
+```
+
+## Operational risk
+
+- **Accounting change:** `heap_memory_bytes` / `StoreMemory.node_properties_bytes` now include decoded payloads → reported totals rise toward reality (not a live RSS change by itself).
+- **Lazy get after compress:** integer/bool compressed point-get may decompress a whole column per miss (strings are O(log n) + dict lookup). Prefer scan/block paths for analytics; fine for sparse correctness.
+- **force_compress:** still gated by internal ratio thresholds; no-op when compression does not help.
+- **Do not** run full sidecar open on this host while `am-server-rs` holds ~18 GiB RSS without reclaiming MemAvailable first.
+
+## Notes for Track F (process isolation) — do not implement here
+
+Numbers F needs (from Phase 3/4, glibc unless noted):
+
+| Quantity | Value | Source |
+|----------|------:|--------|
+| Sidecar open Δ RssAnon (glibc) | ~9.39 GiB (9,845,496 KiB) | PHASE3 |
+| Live open total with account (glibc) | ~11.62 GiB | PHASE4 |
+| jemalloc live open total | ~9.14 GiB (−2.36 GiB) | PHASE4D |
+| Grafeo tracked pre-Track-E | ~2.93 GiB (~32%) | PHASE3 |
+| heaptrack open-stack sum | ~5.58 GiB (~59% of Δ) | PHASE3 |
+| Unattributed residual | ~4 GiB (~41% of Δ) | PHASE3 |
+| Close wall | ~143–152 s | MITIGATION |
+| Account healthy during sidecar close | yes (149/149) | MITIGATION |
+| Combined same-file | **worse** (+~0.7 GiB) | PHASE4E |
+
+Isolation estimate (unchanged): moving sidecar RSS into another process protects account latency during close and allows kill-to-reclaim; it does **not** shrink the sidecar working set itself. Track E attribution + compact/lazy wins are the in-process residual levers; F owns process boundary.
+
+## Remaining work
+
+- [ ] Re-measure account/sidecar open with new `lpg_residency_detail()` when MemAvailable ≥ ~14 GiB (copy staging under `/data/tmp`)
+- [ ] Optional: ID→index hash for O(1) compressed get (avoid binary search / int full decompress)
+- [ ] Optional: unique-ArcStr accounting via pointer set (reduce shared-string overcount)
+- [ ] Wire CLI `memory` pretty-print for new StoreMemory / LpgResidency fields


### PR DESCRIPTION
## Summary
- Expand LPG memory accounting: per-column map slots, decoded Value/string payloads, compressed backings, adjacency capacity waste (`LpgResidencyMemory` / `memory_detail` / `GrafeoDB::lpg_residency_detail`).
- Fix compressed property point-get via lazy decode (closes prior compress → `get` returns `None` hole); add `shrink_capacities` + `force_compress` experiment knobs.
- Measured synthetic experiments (200k / 256 unique strings): **A** shrink no-op on post-fill hashbrown; **B** dictionary-compact **−84% estimated** / **−5.5 MiB RssAnon**, correctness PASS.

Branch is off product pin `9781320f` — **not** `diagnostics/close-forensics` (AM diagnostics PR #2).

## Test plan
- [x] `cargo test -p grafeo-core --test lpg_residency_experiments -- --nocapture`
- [x] `cargo test -p grafeo-engine --lib memory_usage`
- [ ] Remeasure staging sidecar with `lpg_residency_detail()` when MemAvailable ≥ ~14 GiB

## Artifacts / docs
- `docs/diagnostics/TRACK_E_LPG_MEMORY_ACCOUNTING.md`
- `docs/TRACK_E_LPG_RESIDENCY.md`
- `/data/tmp/grafeo-lpg-accounting-track-e/`

## Track F notes
Process isolation not implemented. Residual inputs: sidecar Δ ~9.39 GiB glibc; jemalloc live ~9.14 GiB; prior tracked ~2.93 GiB; heaptrack open ~59%; unattributed ~4 GiB.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds detailed LPG memory residency attribution and lazy decode for compressed properties, plus transaction-aware batch node/edge creation and an exact spill-aware vector read. Improves memory visibility, write throughput, rollback correctness, and ForceDisk vector durability.

- **New Features**
  - LPG memory detail in `grafeo-core` and `grafeo-engine`: `LpgResidencyMemory`, `GrafeoDB::lpg_residency_detail`, `shrink_lpg_capacities`, `force_compress_properties`. Tracks map slots, decoded/string payloads, compressed backings, and adjacency capacity. Synthetic run shows −84% estimated property bytes and −5.5 MiB RSS with dictionary compression.
  - Transactional batch writes: storage-level batch in `grafeo-core` (`BatchNodeCreate`, `BatchEdgeCreate`), session APIs in `grafeo-engine` (`create_nodes_with_props_transactional`, `create_edges_with_props_transactional`). Hoists locks once per batch, versions rows under PENDING, logs WAL, buffers vector intents, and fully cleans secondary state on rollback. Adds offline bulk loaders for fresh stores.
  - Vector indexing: spill-aware accessor reads property deltas first, mmap second; new `GrafeoDB::read_indexed_node_vector` for exact by-NodeId reads. Catalog v2 persists `QuantizationType`; quantized HNSW uses the accessor (no dual full-f32 store). Safe replacement of existing HNSW entries.

- **Bug Fixes**
  - Compressed property point-get now lazily decodes (fixes prior `get` returning `None` holes).
  - Uncommitted deletes marked with `EpochId::PENDING` and rolled back safely; delete WAL logging checks existence before write.
  - Restore vector index shells (including quantized) from catalog on open; durable ForceDisk spill lifecycle and exact reads after checkpoint/reopen.
  - `grafeo-cli` `create_node` returns `Result` and propagates errors.

<sup>Written for commit 195678c36b335022c9a2add4f755bb675955feb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/GrafeoDB/grafeo/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

